### PR TITLE
Add llm-d stack via Flux: kgateway + CRDs, llm-d-infra, and CPU-only …

### DIFF
--- a/kubernetes/apps/cortex/kustomization.yaml
+++ b/kubernetes/apps/cortex/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./litellm/ks.yaml
-  # - ./llm-d/ks.yaml
+  - ./llm-d/ks.yaml
   - ./open-webui/ks.yaml
   - ./qdrant/ks.yaml
   # - ./sillytavern/ks.yaml

--- a/kubernetes/apps/cortex/llm-d/app/helmrelease-llmd-infra.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/helmrelease-llmd-infra.yaml
@@ -27,10 +27,14 @@ spec:
         enabled: false
     gateway:
       gatewayClassName: kgateway
-      serviceType: NodePort
+      serviceType: LoadBalancer
+      annotations:
+        io.cilium/lb-ipam-ips: "10.90.3.214"
     ingress:
       enabled: true
       ingressClassName: internal
       host: "llmd.${SECRET_DOMAIN}"
+      annotations:
+        external-dns.alpha.kubernetes.io/hostname: "llmd.${SECRET_DOMAIN}"
       tls:
         enabled: false

--- a/kubernetes/apps/cortex/llm-d/app/helmrelease-llmd-infra.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/helmrelease-llmd-infra.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llmd-infra
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: llm-d-infra
+      sourceRef:
+        kind: HelmRepository
+        name: llm-d-infra
+        namespace: flux-system
+      version: "~1.2.0"
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    auth:
+      hf_token:
+        enabled: false
+    gateway:
+      gatewayClassName: kgateway
+      serviceType: NodePort
+    ingress:
+      enabled: true
+      ingressClassName: internal
+      host: "llmd.${SECRET_DOMAIN}"
+      tls:
+        enabled: false

--- a/kubernetes/apps/cortex/llm-d/app/helmrelease-modelservice.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/helmrelease-modelservice.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llmd-modelservice
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: llm-d-modelservice
+      sourceRef:
+        kind: HelmRepository
+        name: llm-d-modelservice
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    multinode: false
+    modelArtifacts:
+      name: random/model
+      uri: "hf://{{ .Values.modelArtifacts.name }}"
+      size: 5Mi
+    routing:
+      servicePort: 8000
+      epp:
+        create: true
+        debugLevel: 6
+        disableReadinessProbe: true
+        disableLivenessProbe: true
+      httpRoute:
+        create: true
+        matches:
+          - headers:
+            - name: x-model-name
+              type: Exact
+              value: "{{ .Values.modelArtifacts.name }}"
+    decode:
+      replicas: 1
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.3.0
+          modelCommand: imageDefault
+          ports:
+            - containerPort: 8200
+              protocol: TCP
+          mountModelVolume: true
+    prefill:
+      replicas: 1
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.3.0
+          modelCommand: imageDefault
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          mountModelVolume: true

--- a/kubernetes/apps/cortex/llm-d/app/kustomization.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../namespace.yaml
+  - ./helmrelease-llmd-infra.yaml
+  - ./helmrelease-modelservice.yaml

--- a/kubernetes/apps/cortex/llm-d/ks.yaml
+++ b/kubernetes/apps/cortex/llm-d/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app llm-d
+  namespace: flux-system
+spec:
+  targetNamespace: llm-d
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cluster-apps-kgateway
+  path: ./kubernetes/apps/cortex/llm-d/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/apps/cortex/llm-d/namespace.yaml
+++ b/kubernetes/apps/cortex/llm-d/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llm-d

--- a/kubernetes/apps/games/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/games/romm/app/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rommapp/romm
-              tag: 4.0.1@sha256:2f31f792885cd0fc839a590b9645ada846106d4893e5de0be68dc6580b11b5f9
+              tag: 4.1.3@sha256:fe68b32b2765c61a696012709e7ad638faba9c4776d936bf23a35fb576a66eea
             env:
               ROMM_DB_DRIVER: postgresql
               ROMM_BASE_PATH: /romm

--- a/kubernetes/apps/games/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/games/romm/app/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rommapp/romm
-              tag: 4.1.3@sha256:fe68b32b2765c61a696012709e7ad638faba9c4776d936bf23a35fb576a66eea
+              tag: 4.0.1@sha256:2f31f792885cd0fc839a590b9645ada846106d4893e5de0be68dc6580b11b5f9
             env:
               ROMM_DB_DRIVER: postgresql
               ROMM_BASE_PATH: /romm

--- a/kubernetes/apps/network/kgateway/app/helmrelease-kgateway-crds.yaml
+++ b/kubernetes/apps/network/kgateway/app/helmrelease-kgateway-crds.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kgateway-crds
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: kgateway-crds
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3

--- a/kubernetes/apps/network/kgateway/app/helmrelease-kgateway.yaml
+++ b/kubernetes/apps/network/kgateway/app/helmrelease-kgateway.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kgateway
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: kgateway
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    inferenceExtension:
+      enabled: true
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    podSecurityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      runAsNonRoot: true

--- a/kubernetes/apps/network/kgateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/kgateway/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../namespace.yaml
+  - ./helmrelease-kgateway-crds.yaml
+  - ./helmrelease-kgateway.yaml

--- a/kubernetes/apps/network/kgateway/ks.yaml
+++ b/kubernetes/apps/network/kgateway/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-kgateway
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: llmd-crds-gateway-api
+    - name: llmd-crds-gie
+  targetNamespace: kgateway-system
+  path: ./kubernetes/apps/network/kgateway/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  interval: 30m
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/network/kgateway/namespace.yaml
+++ b/kubernetes/apps/network/kgateway/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kgateway-system

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
   - ./external-services/ks.yaml
   - ./ingress-nginx/ks.yaml
   - ./k8s-gateway/ks.yaml
+  - ./kgateway/ks.yaml
+  - ./llmd-gateway-crds/ks.yaml
   - ./multus/ks.yaml
   # - ./netboot/ks.yaml
   - ./oauth2-proxy/ks.yaml

--- a/kubernetes/apps/network/llmd-gateway-crds/ks.yaml
+++ b/kubernetes/apps/network/llmd-gateway-crds/ks.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: llmd-crds-gateway-api
+  namespace: flux-system
+spec:
+  prune: false
+  interval: 30m
+  sourceRef:
+    kind: GitRepository
+    name: llmd-inference-scheduler
+  path: ./deploy/components/crds-gateway-api
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: llmd-crds-gie
+  namespace: flux-system
+spec:
+  prune: false
+  interval: 30m
+  sourceRef:
+    kind: GitRepository
+    name: llmd-inference-scheduler
+  path: ./deploy/components/crds-gie

--- a/kubernetes/flux/repositories/git/kustomization.yaml
+++ b/kubernetes/flux/repositories/git/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+  - ./llmd-inference-scheduler.yaml

--- a/kubernetes/flux/repositories/git/llmd-inference-scheduler.yaml
+++ b/kubernetes/flux/repositories/git/llmd-inference-scheduler.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: llmd-inference-scheduler
+  namespace: flux-system
+spec:
+  interval: 1h
+  ref:
+    branch: main
+  url: https://github.com/llm-d/llm-d-inference-scheduler

--- a/kubernetes/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/repositories/helm/kustomization.yaml
@@ -28,6 +28,8 @@ resources:
   - ./qdrant.yaml
   - ./redash.yaml
   - ./rook-ceph-charts.yaml
+  - ./llm-d-infra.yaml
+  - ./llm-d-modelservice.yaml
   - ./stevehipwell.yaml
   - ./spegel.yaml
   - ./stakater.yaml

--- a/kubernetes/flux/repositories/helm/llm-d-infra.yaml
+++ b/kubernetes/flux/repositories/helm/llm-d-infra.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: llm-d-infra
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://llm-d-incubation.github.io/llm-d-infra/

--- a/kubernetes/flux/repositories/helm/llm-d-modelservice.yaml
+++ b/kubernetes/flux/repositories/helm/llm-d-modelservice.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: llm-d-modelservice
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://llm-d-incubation.github.io/llm-d-modelservice/

--- a/kubernetes/flux/repositories/oci/kgateway-crds.yaml
+++ b/kubernetes/flux/repositories/oci/kgateway-crds.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: kgateway-crds
+  namespace: flux-system
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v2.0.4
+  url: oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds

--- a/kubernetes/flux/repositories/oci/kgateway.yaml
+++ b/kubernetes/flux/repositories/oci/kgateway.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: kgateway
+  namespace: flux-system
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v2.0.4
+  url: oci://cr.kgateway.dev/kgateway-dev/charts/kgateway

--- a/kubernetes/flux/repositories/oci/kustomization.yaml
+++ b/kubernetes/flux/repositories/oci/kustomization.yaml
@@ -4,4 +4,6 @@ kind: Kustomization
 resources:
   - ./app-template.yaml
   - ./mariadb.yaml
+  - ./kgateway.yaml
+  - ./kgateway-crds.yaml
 


### PR DESCRIPTION
…modelservice

- Add kgateway CRDs/controller as OCI Helm sources and HelmReleases
- Add Gateway API and GIE CRDs via upstream Git kustomize components
- Add llm-d-infra HelmRelease with ingress behind existing internal class
- Add llm-d-modelservice HelmRelease with vLLM simulator (CPU) demo
- Wire Flux Kustomizations with explicit dependsOn; non-invasive defaults