### PR TITLE
feat(llm-d): Add llm-d integration with distributed inference and Windows workers

### DIFF
--- a/kubernetes/apps/cortex/kustomization.yaml
+++ b/kubernetes/apps/cortex/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./litellm/ks.yaml
+    - ./llm-d/ks.yaml
   # - ./llm-d/ks.yaml
   - ./open-webui/ks.yaml
   - ./qdrant/ks.yaml

--- a/kubernetes/apps/cortex/llm-d/app/externalsecret.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# ExternalSecret to pull HuggingFace and worker tokens from 1Password.
+# Adjust the secret names and keys in your secret store accordingly.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: llm-d
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: llm-d-secret
+    template:
+      engineVersion: v2
+      data:
+        # Hugging Face access token used for model downloads
+        HF_TOKEN: "{{ .LLM_D_HF_TOKEN }}"
+        # Token used by Windows/WSL2 workers to authenticate with the llm‑d gateway.
+        WORKER_TOKEN: "{{ .LLM_D_WORKER_TOKEN }}"
+  # Pull all fields from the `llm-d` item in 1Password so they are available
+  # via the {{ . ... }} expressions above
+  dataFrom:
+    - extract:
+        key: llm-d

--- a/kubernetes/apps/cortex/llm-d/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/helmrelease.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app llm-d
+  namespace: cortex
+spec:
+  # Check for chart updates every 30 minutes
+  interval: 30m
+  # Use an explicit release name for predictable resource names
+  releaseName: llm-d
+  chart:
+    spec:
+      # Use the llm-d-infra chart from our GitRepository source
+      chart: charts/llm-d-infra
+      sourceRef:
+        kind: GitRepository
+        name: llm-d-infra
+        namespace: flux-system
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  dependsOn:
+    # Wait for Ceph and VolSync to be ready before deploying llm-d
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  values:
+    # Override namespace for all resources to cortex
+    global:
+      namespaceOverride: cortex
+    # Configure the gateway service; disable built-in ingress
+    gateway:
+      serviceType: ClusterIP
+      ingress:
+        enabled: false
+    # Enable Redis/Dragonfly cache
+    cache:
+      enabled: true
+    # Expose Prometheus metrics
+    metrics:
+      enabled: true
+    # Reference the ExternalSecret for HuggingFace token
+    secrets:
+      hf:
+        existingSecret: llm-d-secret
+        key: HF_TOKEN

--- a/kubernetes/apps/cortex/llm-d/app/ingress-api.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/ingress-api.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: llm-d-api
+  namespace: cortex
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  tls:
+    - hosts:
+        - "llm-d-api.${SECRET_DOMAIN}"
+      secretName: llm-d-api-tls
+  rules:
+    - host: "llm-d-api.${SECRET_DOMAIN}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: llm-d-gateway
+                port:
+                  number: 80

--- a/kubernetes/apps/cortex/llm-d/app/ingress-workers.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/ingress-workers.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: llm-d-workers
+  namespace: cortex
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  tls:
+    - hosts:
+        - "llm-d-workers.${SECRET_DOMAIN}"
+      secretName: llm-d-workers-tls
+  rules:
+    - host: "llm-d-workers.${SECRET_DOMAIN}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: llm-d-gateway
+                port:
+                  number: 80

--- a/kubernetes/apps/cortex/llm-d/app/kustomization.yaml
+++ b/kubernetes/apps/cortex/llm-d/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./ingress-api.yaml
+  - ./ingress-workers.yaml
+  # Include shared templates for volsync and gatus health checks
+  - ../../../../templates/volsync
+  - ../../../../templates/gatus/guarded

--- a/kubernetes/apps/cortex/llm-d/ks.yaml
+++ b/kubernetes/apps/cortex/llm-d/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app llm-d
+  namespace: flux-system
+spec:
+  # Deploy all llm-d resources into the cortex namespace
+  targetNamespace: cortex
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    # llm-d depends on database, cache and secret stores running first
+    - name: cloudnative-pg-cluster17
+    - name: dragonfly-cluster
+    - name: external-secrets-stores
+  # Path within this repo where the llm-d application manifests live
+  path: ./kubernetes/apps/cortex/llm-d/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CLAIM: llm-d-models
+      VOLSYNC_CAPACITY: 100Gi
+      VOLSYNC_CACHE_CLAIM: llm-d-cache
+      VOLSYNC_CACHE_CAPACITY: 50Gi
+      GATUS_SUBDOMAIN: llm-d

--- a/kubernetes/flux/repositories/git/kustomization.yaml
+++ b/kubernetes/flux/repositories/git/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+  - ./llm-d-infra.yaml

--- a/kubernetes/flux/repositories/git/llm-d-infra.yaml
+++ b/kubernetes/flux/repositories/git/llm-d-infra.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: llm-d-infra
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://github.com/llm-d-incubation/llm-d-infra
+  ref:
+    tag: v1.1.1

--- a/workers/windows/.env.example
+++ b/workers/windows/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and set your variables
+SERVER_URL=https://llm-d-workers.${SECRET_DOMAIN}
+WORKER_TOKEN=
+WORKER_NAME=win-gpu-01

--- a/workers/windows/config.yaml
+++ b/workers/windows/config.yaml
@@ -1,0 +1,18 @@
+worker:
+  name: ${WORKER_NAME}
+  server_url: ${SERVER_URL}
+  auth:
+    token: ${WORKER_TOKEN}
+runtime:
+  gpu:
+    memory_fraction: 0.90
+  model_cache_dir: /models
+  kv_cache_dir: /cache
+models:
+  preload:
+    # Example to preload a model
+    # - repo: openai/gpt-oss-120b
+    #   quantization: mxfp4
+    #   parallelism:
+    #     expert_parallel: true
+    #     tensor_parallel: 1

--- a/workers/windows/docker-compose.yaml
+++ b/workers/windows/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  llmd-worker:
+    image: ghcr.io/llm-d-ai/llm-d-worker:latest
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./config.yaml:/app/config.yaml:ro
+      - ./models:/models
+      - ./cache:/cache
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]


### PR DESCRIPTION
This PR adds the llm-d distributed inference stack to the `cortex` namespace via the official helm chart `llm-d-infra` and connects Windows worker nodes.

Key changes include:
- Adds a `llm-d-infra` GitRepository in `kubernetes/flux/repositories` and updates the git kustomization.
- Adds a new `llm-d` application under `kubernetes/apps/cortex` with its own kustomization.
- Defines a HelmRelease using the official `llm-d-infra` chart, enabling gateway (OpenAI-compatible), cache, and metrics.
- Adds an ExternalSecret to fetch `LLM_D_HF_TOKEN` and `LLM_D_WORKER_TOKEN` from 1Password, storing them in `llm-d-secret` for the Helm chart.
- Creates custom Ingresses for API (`llm-d-api.<domain>`) and worker registration (`llm-d-workers.<domain>`).
- Provides Windows worker deployment files (`docker-compose.yaml`, `.env.example`, and `config.yaml`) under `workers/windows` for running GPU workers via WSL2.

This will deploy llm-d on the home cluster, enabling distributed inference across Windows GPU nodes and exposing an OpenAI-compatible endpoint for n8n and other tools.
