### PR TITLE
fix(cortex): correct mempalace ExternalSecret 1Password reference

### DIFF
--- a/kubernetes/apps/cortex/mempalace/app/externalsecret.yaml
+++ b/kubernetes/apps/cortex/mempalace/app/externalsecret.yaml
@@ -10,8 +10,6 @@ spec:
     name: onepassword-connect
   target:
     name: mempalace-secret
-  data:
-    - secretKey: MEMPALACE_TOKEN
-      remoteRef:
-        key: MEMPALACE_TOKEN
-        property: password
+  dataFrom:
+    - extract:
+        key: mempalace


### PR DESCRIPTION
## Summary
Follow-up to #1825. The ExternalSecret had the 1Password reference inverted.

## Details
Convention: 1Password item title is `mempalace` (lowercase app name), field inside is `MEMPALACE_TOKEN`. Previous manifest looked for an item literally titled `MEMPALACE_TOKEN` with a `password` field — doesn't exist, ExternalSecret was stuck in SecretSyncedError.

Switched to `dataFrom extract` pattern (same as mem0) which imports all fields of the `mempalace` item into the materialised k8s Secret with their original names, producing env var `MEMPALACE_TOKEN` for the pod.

## Test plan
- [x] kubeconform valid
- [ ] ExternalSecret reaches SecretSynced after merge
- [ ] Pod transitions Ready (was stuck in ContainerCreating waiting on the Secret)
- [ ] Subagent B completes Plan 2 MCP validation