### PR TITLE
feat(home-assistant): add Contact Energy smart-meter integration via init container

### DIFF
--- a/docs/infrastructure-roadmap/README.md
+++ b/docs/infrastructure-roadmap/README.md
@@ -1,0 +1,200 @@
+# Infrastructure Roadmap
+
+12-month plan for home infrastructure redundancy, monitoring, and upgrades.
+Triggered May 2026 by a fibre cut taking the house offline — exposed how
+brittle the single-point-of-failure dependencies are across power and internet.
+
+**Status**: Planning phase. No procurement decisions finalised.
+
+---
+
+## Scope
+
+Five workstreams. Power and the electrification questions are tightly coupled
+because they jointly determine the solar payback model.
+
+1. **Power redundancy** — Battery backup (Powerwall, BYD, or portable system),
+   possibly solar. Eliminate per-device UPSes.
+2. **Energy electrification** — Replace gas califont with heat pump water
+   heater (HPWH), replace gas cooktop with induction. Goal: disconnect gas
+   reticulation entirely once the last gas appliance is gone.
+3. **Internet redundancy** — 5G failover via UniFi U5G Max Outdoor + One NZ
+   SIM, terminated into UDM Pro WAN2.
+4. **Networking upgrades** — TBD scope. Likely candidates: more deliberate
+   VLAN segmentation, additional PoE budget, possible 10GbE between rack
+   and key APs.
+5. **Compute upgrades** — TBD scope. Likely candidates: cluster node
+   additions, NAS/storage expansion, dedicated game server hardware.
+
+---
+
+## Constraints
+
+- **Move horizon**: 3–4 years. Anything installed needs to either pay back
+  within that window, or add to sale price, or be transportable.
+- **Single-phase** electrical supply (TBC at switchboard inspection).
+- **No current desire to install solar unless payback proves out** — driven
+  by the move horizon.
+- **Gas currently in use** for water heating (califont) and cooking.
+
+---
+
+## Current state (May 2026)
+
+| Layer | Today |
+|---|---|
+| ISP | Bigpipe fibre (IPv4 only, no IPv6 since 2018) |
+| Edge | UDM Pro, all-UniFi switches/APs (US-24-250W, US-48, U6 Lite ×3) |
+| Cluster | 3-node MS-01 Talos (stanton-01/02/03), Thunderbolt ring, Cilium + BGP |
+| Storage | Rook-Ceph on cluster + Dell R730 TrueNAS for NFS/backup |
+| Power | Grid only, 2× Eaton 5S 850 UPSes |
+| Gas | Reticulated — califont + cooktop |
+| Smart meter | Installed ~Nov 2025, retailer = Contact Energy |
+| Monitoring | Prometheus, Grafana, Home Assistant, TeslaMate, NUT |
+
+---
+
+## Phase plan (rough)
+
+### Phase 1 — Internet failover
+
+Get 5G failover online so the next fibre cut doesn't take the house offline.
+
+- [ ] Confirm U5G-Max-Outdoor availability with GoWifi NZ (preferred) or PB Tech
+- [ ] Order U5G-Max-Outdoor (~NZD $934 from PB Tech, equivalent from GoWifi)
+- [ ] Acquire One NZ business/M2M SIM (data-only plan)
+- [ ] Mount U5G-Max-Outdoor on roof, run Cat6 to rack
+- [ ] Adopt into UniFi controller, configure WAN2 failover priority
+- [ ] Tune WAN failover ping interval (default is sluggish)
+- [ ] Set WAN2 traffic policy: failover-only, block bulk traffic (Plex,
+      Jellyfin, qBittorrent) from cellular path
+- [ ] Test failover: pull WAN1, validate cutover and service continuity
+
+**Risk**: U5G Max Outdoor isn't formally certified for NZ carriers (US only).
+Hardware supports all NZ-relevant bands (B1/B3/B7/B28, n78). Validate during
+install; fallback is Peplink BR1 Pro 5G + Poynting antenna if it doesn't
+attach cleanly.
+
+### Phase 2 — Power monitoring foundation (parallel with Phase 1)
+
+Start collecting data we'll need for battery sizing and solar feasibility.
+
+- [ ] Add `ha-contact-energy` HACS integration to home-ops repo via init
+      container → Contact API into HA
+      (see [`contact-energy.md`](./contact-energy.md))
+- [ ] Verify Contact data flowing into HA Energy Dashboard
+- [ ] Pipe HA energy data through to Prometheus → Grafana
+- [ ] Switchboard inspection: confirm phase config (single vs 3-phase),
+      main breaker rating
+- [ ] Roof feasibility: orientation, available m², shading
+- [ ] Pull NUT historical data: current UPS load profile, what's protected
+      today, typical draw
+- [ ] TeslaMate query: home-charging schedule and kWh per session
+- [ ] Outage history: NUT events, Northpower outage notifications
+- [ ] Gather last 12 months of gas bills
+
+### Phase 3 — Solar + battery feasibility model
+
+The decision gate. Build a model with real data and quotes, then decide
+go/no-go on solar + which battery architecture.
+
+- [ ] Site visits + quotes from 2–3 NZ solar installers
+- [ ] Quote from HPWH installer for califont replacement
+- [ ] Quote for induction cooktop install
+- [ ] TOU tariff comparison: Octopus NZ vs Contact Hour Power vs Electric
+      Kiwi vs Flick — does switching retailer change the maths meaningfully?
+- [ ] Build payback model in spreadsheet:
+  - Solar generation forecast (installer-provided)
+  - Battery sized for self-consumption maximisation
+  - Pre + post-electrification consumption forecast
+  - 5–10 year payback projection across scenarios
+- [ ] **Decision gate**:
+  - Payback ≤ 5 years → Phase 4a (full package: solar + battery +
+    electrification, fixed install)
+  - Payback 5–7 years → judgment call (partial breakeven + sale-price uplift)
+  - Payback > 7 years → Phase 4b (portable battery for resilience only,
+    electrify only what makes standalone sense)
+
+### Phase 4a — Full package install (if Phase 3 goes "yes solar")
+
+- [ ] Installer selected, contract signed
+- [ ] Solar PV install (panels + inverter)
+- [ ] Powerwall 3 or BYD HVS install (likely whole-house given solar
+      changes self-consumption maths)
+- [ ] Califont → HPWH swap
+- [ ] Gas cooktop → induction swap
+- [ ] Gas reticulation disconnect (kills standing charge)
+- [ ] **Bundle CT-clamp monitoring** (Shelly Pro 3EM or similar) into install
+- [ ] Commission + grid-tie
+- [ ] Retire per-device UPSes incrementally
+- [ ] Monitoring integration: Powerwall/inverter data → HA → Prometheus → Grafana
+
+### Phase 4b — Portable backup only (if Phase 3 goes "no solar")
+
+- [ ] Select portable system (EcoFlow Delta Pro Ultra + Smart Home Panel
+      most likely)
+- [ ] Critical-loads sub-panel install (electrician)
+- [ ] System install + commissioning
+- [ ] **CT-clamp added at same time** (sparky's already in the board)
+- [ ] Retire per-device UPSes incrementally
+- [ ] Monitoring integration into HA + Prometheus
+
+### Phase 5 — Networking & compute (months 7–12)
+
+To be scoped. Initial candidates:
+
+- Networking: rack-to-AP backhaul upgrades, additional PoE switch capacity,
+  dedicated management VLAN cleanup
+- Compute: cluster node additions, NAS/storage tier expansion, possible
+  dedicated game server hardware
+
+---
+
+## Open decisions
+
+| # | Decision | Status | Notes |
+|---|---|---|---|
+| 1 | Solar yes/no | Gated on Phase 3 model | Depends on payback maths after electrification + TOU tariff selected |
+| 2 | Battery architecture: whole-house vs critical-loads | Gated on #1 | If solar yes → whole-house likely; if no → critical-loads |
+| 3 | Battery product: Powerwall vs BYD vs Sonnen vs EcoFlow Delta Pro Ultra | Gated on #1, #2 | Fixed install if solar; portable if not |
+| 4 | Electrify gas appliances | Open, likely yes | HPWH almost certainly worth it standalone; cooktop is preference-driven |
+| 5 | 5G modem: U5G Max Outdoor vs Peplink BR1 Pro 5G | Leaning U5G | NZ carrier cert risk; pragmatic plan is buy U5G, fallback to Peplink if it doesn't attach |
+| 6 | Stay on Contact Energy or switch retailer | Open | Octopus NZ may give better TOU + buy-back if solar happens |
+| 7 | Stay on Bigpipe or switch ISP | Open | Bigpipe = no IPv6, but otherwise fine. 2degrees / Voyager would give IPv6 if that matters |
+
+---
+
+## Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-11 | Track project in `home-ops` repo as markdown | GitOps fits existing workflow; version controlled |
+| 2026-05-11 | Project covers 5 workstreams over ~12 months | Triggered by fibre cut + general infrastructure resilience goals |
+| 2026-05-11 | Use `ha-contact-energy` HACS integration for smart meter data | Native HA → Prometheus path; avoids manual CSV workflow. Upstream archived Oct 2024 — pin to commit `16826d2b82efb294e33f48f70647d21f551b6bf1`; underlying Python library still maintained, fallback documented in PR |
+| 2026-05-11 | Defer CT-clamp install until battery install | Free incremental scope when sparky is already in switchboard |
+| 2026-05-11 | Add electrification (HPWH + induction) as in-scope workstream | Required to make solar payback maths viable; standalone payback also reasonable |
+| 2026-05-11 | Solar decision deferred to Phase 3 model | Need real consumption + quote data before committing |
+
+---
+
+## Data to gather
+
+- [ ] Contact Energy: ~6 months of hourly consumption data (via integration in Phase 2)
+- [ ] Gas: last 12 months of bills (kWh equivalent + standing charges)
+- [ ] Switchboard: phase config, main breaker rating
+- [ ] Roof: orientation, dimensions, shading
+- [ ] NUT: current protected loads + draw
+- [ ] TeslaMate: home charging patterns + monthly kWh
+- [ ] One NZ: M2M / business SIM plan options and pricing
+- [ ] Lines company: outage history for the area
+
+---
+
+## References
+
+- HA Contact Energy integration: https://github.com/codyc1515/ha-contact-energy
+- Contact Energy Python lib: https://pypi.org/project/contact-energy-nz/
+- UniFi U5G Max Outdoor (PB Tech NZ): https://www.pbtech.co.nz/product/NETUBI260206/Ubiquiti-UniFi-U5G-Max-Outdoor-5G-Outdoor-Gateway
+- UniFi 5G/LTE backup best practices: https://help.ui.com/hc/en-us/articles/29887153953559-UniFi-5G-and-LTE-Backup-Best-Practices
+- Peplink BR1 Pro 5G (Powertec NZ, fallback): https://powertec.co.nz/peplink-br1-pro-5g-includes-1-year-primecare/
+- Reclaim Energy CO2 HPWH: https://reclaimenergy.com.au/

--- a/docs/infrastructure-roadmap/contact-energy.md
+++ b/docs/infrastructure-roadmap/contact-energy.md
@@ -1,0 +1,157 @@
+# Home Assistant — Contact Energy smart meter integration
+
+Adds the [`ha-contact-energy`](https://github.com/codyc1515/ha-contact-energy)
+HACS integration to Home Assistant via an init container, so smart meter data
+from Contact Energy flows into HA → Prometheus → Grafana without manual HACS
+clicks or CSV exports.
+
+Part of the [infrastructure roadmap](./README.md) **Phase 2: Power monitoring
+foundation**.
+
+## ⚠️ Upstream status — read before merging
+
+**The upstream `codyc1515/ha-contact-energy` repository was archived on
+8 October 2024 by the original author and is read-only.** The last meaningful
+commit is `16826d2b82efb294e33f48f70647d21f551b6bf1` (30 January 2024).
+
+This means:
+
+- ✅ It still works (last community confirmation Sep 2024, and the API surface
+  is Contact's own mobile-app API — they maintain it for their own product).
+- ✅ The underlying Python library `contact-energy-nz` on PyPI (by
+  `tkhadimullin`, a separate author) is still actively maintained and tracks
+  API changes.
+- ❌ No further development from upstream. If Contact materially changes their
+  API, the integration will break until someone forks and patches it.
+
+**Acceptable for the use case** because (a) data isn't safety-critical,
+(b) Contact's portal CSV export remains a manual fallback, and (c) the worst
+case is we rewrite the integration ourselves using `contact-energy-nz`
+directly (see Fallback plan below).
+
+## Why
+
+A smart meter (installed Nov 2025) is collecting consumption data, but it's
+invisible to the homelab. Contact's "My Account" portal has no official CSV
+export. The community has built a Python lib + HACS integration that use
+Contact's mobile-app API — that gives us:
+
+- Hourly historical data (24 points/day, back to meter install date —
+  ~6 months)
+- Daily-updating ongoing consumption (24–48 hr delay from meter — the most
+  recent 1–2 days will read as zero until Contact's API catches up)
+- Flow into HA Energy Dashboard, Prometheus exporters, and Grafana dashboards
+- Foundation for the solar / battery feasibility model (Phase 3)
+- Bonus: the gas contract is visible via the same auth path (`STANDARD METER`
+  on the natural-gas ICP). Not wired up in this PR, but useful for the
+  Phase 3 electrification baseline.
+
+Verified against the live account 2026-05-12: auth ✓, smart meter discoverable
+✓, hourly data returned for a day older than the reporting lag.
+
+## Approach
+
+GitOps-friendly: init container clones the integration into
+`/config/custom_components/contact_energy` before HA starts. No HACS UI
+clicks, no manual config copying. Pinned to the last-known-good commit SHA
+rather than `main` (which is moot since upstream is archived).
+
+## Changes
+
+### 1. `kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml`
+
+Add an `initContainers` block under `controllers.home-assistant` that pulls
+the integration on every pod start.
+
+Key bits:
+
+- Uses `docker.io/alpine/git`, pinned by tag + multi-arch manifest-list digest
+- Clones to `/tmp`, then copies to `/config/custom_components/` on the
+  shared config PVC
+- Idempotent via a `.pinned-sha` marker file — only re-installs when the
+  pinned commit changes or `FORCE_UPDATE=true`
+- **Pinned to commit `16826d2b82efb294e33f48f70647d21f551b6bf1`** (last
+  upstream commit before archival)
+- Runs as the same UID/GID as the app container (568); matches the existing
+  pod's security profile — no root override needed
+
+### 2. Post-deploy step *(documented, not automated)*
+
+Once the pod restarts and integration code is present:
+
+1. Settings → Devices & Services → Add Integration → "Contact Energy"
+2. Enter Contact account email + password
+3. Integration backfills historical data automatically (takes a few minutes)
+4. Sensors appear under `sensor.contact_energy_*`
+
+Credentials are stored in HA's encrypted secret storage, not in this repo.
+
+## Validation
+
+After Flux applies and pod restarts:
+
+```bash
+# Verify init container completed
+kubectl logs -n home-automation deploy/home-assistant -c init-contact-energy
+
+# Verify integration files are in place
+kubectl exec -n home-automation deploy/home-assistant -- \
+  ls -la /config/custom_components/contact_energy
+
+# After UI config, check Energy dashboard for consumption data
+```
+
+Expected sensors:
+
+- `sensor.contact_energy_usage_kwh` — main consumption (uncharged + paid)
+- `sensor.contact_energy_free_kwh` — free hours of power if on relevant plan
+- `sensor.contact_energy_dollars_*` for cost equivalents
+
+Consumption sensors need to be added to the HA Energy Dashboard manually
+(Settings → Dashboards → Energy → Add grid consumption).
+
+## Fallback plan (if upstream breaks)
+
+If Contact changes their API and the integration stops working:
+
+**Option A — Build a fresh HA custom component on `contact-energy-nz`.**
+The integration we're pinning to does *not* use this library — it vendors
+its own sync `requests`-based client. So this fallback is a from-scratch
+rebuild, not a swap. The library wraps the same API and is actively
+maintained. ~200–300 lines of Python.
+
+**Option B — Run a sidecar Python script** that uses `contact-energy-nz`
+to fetch data and push to MQTT or InfluxDB directly. Bypasses HA's custom
+component model entirely. Smaller and simpler than Option A but loses HA
+Energy Dashboard native integration.
+
+**Option C — Manual CSV from Contact's portal**. Annoying but always works.
+Acceptable if Phase 3 feasibility model is the only consumer and we just
+need a one-off data dump.
+
+Decision deferred until/unless it actually breaks.
+
+## Rollback
+
+Remove the `initContainers` block from the HelmRelease. The
+`/config/custom_components/contact_energy` directory will persist on the PVC
+but HA will ignore it once the config entry is also removed via UI. To fully
+clean:
+
+```bash
+kubectl exec -n home-automation deploy/home-assistant -- \
+  rm -rf /config/custom_components/contact_energy
+```
+
+## Notes
+
+- Pinning to a specific commit SHA means Renovate is unnecessary here —
+  upstream isn't moving. Add a custom manager back if/when we move to an
+  actively maintained fork.
+
+## Related
+
+- Roadmap: [`./README.md`](./README.md)
+- Upstream (archived): https://github.com/codyc1515/ha-contact-energy
+- Python lib (active fallback): https://pypi.org/project/contact-energy-nz/
+- Pinned commit: https://github.com/codyc1515/ha-contact-energy/commit/16826d2b82efb294e33f48f70647d21f551b6bf1

--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -30,6 +30,62 @@ spec:
       home-assistant:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          # Installs the codyc1515/ha-contact-energy HACS integration into
+          # /config/custom_components/contact_energy before HA starts. Upstream
+          # was archived 2024-10-08; we pin to the last commit before archival.
+          # See docs/infrastructure-roadmap/contact-energy.md for rationale +
+          # fallback plan.
+          init-contact-energy:
+            image:
+              repository: docker.io/alpine/git
+              tag: v2.52.0@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3
+            command:
+              - /bin/sh
+              - -c
+            args:
+              - |
+                set -eu
+                REPO="https://github.com/codyc1515/ha-contact-energy.git"
+                REF="16826d2b82efb294e33f48f70647d21f551b6bf1"
+                DEST="/config/custom_components/contact_energy"
+                MARKER="${DEST}/.pinned-sha"
+                WORK="/tmp/ha-contact-energy"
+
+                if [ -f "${MARKER}" ] && [ "$(cat "${MARKER}")" = "${REF}" ] \
+                    && [ "${FORCE_UPDATE:-false}" != "true" ]; then
+                  echo "[init-contact-energy] Already pinned at ${REF} — skipping."
+                  exit 0
+                fi
+
+                echo "[init-contact-energy] Cloning ${REPO} @ ${REF}..."
+                rm -rf "${WORK}"
+                git clone --no-checkout --filter=blob:none "${REPO}" "${WORK}"
+                git -C "${WORK}" checkout "${REF}"
+
+                echo "[init-contact-energy] Installing to ${DEST}..."
+                mkdir -p /config/custom_components
+                rm -rf "${DEST}"
+                cp -r "${WORK}/custom_components/contact_energy" "${DEST}"
+                printf '%s' "${REF}" > "${MARKER}"
+
+                echo "[init-contact-energy] Cleaning up..."
+                rm -rf "${WORK}"
+
+                echo "[init-contact-energy] Done. Installed files:"
+                ls -la "${DEST}"
+            env:
+              FORCE_UPDATE: "false"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
         containers:
           app:
             image:


### PR DESCRIPTION
## Summary

- Adds `docs/infrastructure-roadmap/` — the 12-month, 5-workstream plan kicked off by the 2026-05-10 → 2026-05-11 fibre cut. Roadmap doc + decision log + sibling `contact-energy.md` rationale.
- Adds an init container to the Home Assistant HelmRelease that installs the [`codyc1515/ha-contact-energy`](https://github.com/codyc1515/ha-contact-energy) HACS integration at a pinned commit, so Contact Energy smart-meter data starts flowing into HA → Prometheus → Grafana without manual HACS clicks.

Part of the infrastructure roadmap **Phase 2 — Power monitoring foundation**.

## ⚠️ Upstream status

The upstream `codyc1515/ha-contact-energy` repo was archived 2024-10-08. Pinned to the last commit before archival (`16826d2b82efb294e33f48f70647d21f551b6bf1`, 2024-01-30). The underlying community Python lib `contact-energy-nz` on PyPI is still actively maintained — that's the escape hatch if Contact ever changes their API. Fallback plan (A: custom component on the library / B: sidecar / C: CSV) documented in `docs/infrastructure-roadmap/contact-energy.md`.

## Pre-merge validation

Verified 2026-05-12 against the live Contact Energy API with a throwaway probe before drafting:

- ✓ Auth via `from_credentials(email, password)` returns a token
- ✓ `accounts/v2` exposes the smart-meter contract (`Electricity / SMART METER`) and also the natural-gas contract (bonus — useful for Phase 3 electrification baseline; not wired up in this PR)
- ✓ `/usage/v2/{contract}` with `interval=hourly` returns 24 points/day for a day older than the documented 24–48 hr reporting lag

**Note on granularity:** the data is **hourly** (24 points/day), not half-hourly as the earlier draft claimed. The integration's source confirms this — `interval=hourly` is the only endpoint it calls. Docs corrected.

## How the init container works

- Image: `docker.io/alpine/git:v2.52.0` pinned by multi-arch manifest-list digest
- Runs as UID 568 (same as the HA app container) — fsGroup makes `/config` writable
- Idempotent via a `.pinned-sha` marker file inside the integration dir; only re-installs when the pinned SHA changes or `FORCE_UPDATE=true`
- `securityContext` matches the app container (`readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, all caps dropped)

## Post-merge steps (manual, one-time)

1. Wait for Flux to reconcile + HA pod to restart
2. `kubectl logs -n home-automation deploy/home-assistant -c init-contact-energy` to confirm install
3. HA UI → Settings → Devices & Services → Add Integration → "Contact Energy"
4. Enter Contact account email + password (stored in HA's encrypted secret store, **not** in this repo)
5. Add the new `sensor.contact_energy_*` entities to the Energy Dashboard

## Rollback

Remove the `initContainers` block. `/config/custom_components/contact_energy` will persist on the PVC but be ignored once the UI config entry is removed. Full cleanup: `kubectl exec -n home-automation deploy/home-assistant -- rm -rf /config/custom_components/contact_energy`.

## Files

- `docs/infrastructure-roadmap/README.md` — roadmap, decisions, open questions, data to gather
- `docs/infrastructure-roadmap/contact-energy.md` — long-form integration rationale + fallback plan
- `kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml` — init container added

## Validation

- `flux build kustomization home-assistant --namespace home-automation ...` rendered 10 resources
- `kubeconform -strict` against the rendered output: `Valid: 7, Invalid: 0, Errors: 0, Skipped: 3` (Secret / ReplicationSource / ReplicationDestination skipped per repo convention)