### PR TITLE
refactor(kopia): adopt entrypoint pattern, bump to v0.23.0

### DIFF
--- a/kubernetes/apps/storage/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/kopia/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/kopia
-              tag: 0.22.3@sha256:17ab64542280197a5368247deaefadc3e3bbe15714ab666c2455a06824e86efd
+              tag: 0.23.0@sha256:76865b421548b1d7bb26a8268f0f0bc828be4eec3f8d8b9c8ece991c99878f94
             env:
               KOPIA_WEB_ENABLED: true
               KOPIA_WEB_PORT: &port 80
@@ -26,16 +26,9 @@ spec:
             envFrom:
               - secretRef:
                   name: kopia-secret
-            command:
-              - /bin/sh
-              - -c
-              - |
-                export HOME=/tmp
-                export USER=kopia
-                # Connect to existing repository (fast - doesn't load full index)
-                kopia repository connect filesystem --path=/repository --override-hostname=volsync.storage.svc.cluster.local --override-username=volsync
-                # Start the server (disable CSRF for reverse proxy compatibility)
-                exec kopia server start --address=0.0.0.0:80 --without-password --insecure --disable-csrf-token-checks
+            args:
+              - --without-password
+              - --disable-csrf-token-checks
             probes:
               liveness:
                 enabled: true
@@ -91,22 +84,43 @@ spec:
           - name: internal
             namespace: network
             sectionName: https
+    configMaps:
+      config:
+        data:
+          repository.config: |-
+            {
+              "storage": {
+                "type": "filesystem",
+                "config": {
+                  "path": "/repository"
+                }
+              },
+              "hostname": "volsync.storage.svc.cluster.local",
+              "username": "volsync",
+              "description": "volsync",
+              "enableActions": false
+            }
     persistence:
+      config-file:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /config/repository.config
+            subPath: repository.config
       repository:
         type: nfs
         server: citadel.internal
         path: /mnt/storage0/backups/VolsyncKopia
         globalMounts:
           - path: /repository
-      config:
+      tmpfs:
         type: emptyDir
         advancedMounts:
           kopia:
             app:
-              - path: /config
-      tmp:
-        type: emptyDir
-        advancedMounts:
-          kopia:
-            app:
+              - path: /config/cache
+                subPath: cache
+              - path: /config/logs
+                subPath: logs
               - path: /tmp
+                subPath: tmp


### PR DESCRIPTION
## Summary

- Drop the custom `command:` override and use the upstream `ghcr.io/home-operations/kopia` entrypoint (which already wires `--insecure --address 0.0.0.0:$KOPIA_WEB_PORT --allow-extremely-dangerous-unauthenticated-server-on-the-network`)
- Pass `--without-password --disable-csrf-token-checks` via `args:`
- Replace inline `kopia repository connect filesystem` step with a ConfigMap-mounted `repository.config` (filesystem backend, `volsync` hostname/username — same identity the previous `--override-*` flags produced)
- Split `/config` into a configMap mount for `repository.config` and an emptyDir tmpfs for `cache/`, `logs/`, plus `/tmp`
- Bump image to `0.23.0@sha256:76865b421548b1d7bb26a8268f0f0bc828be4eec3f8d8b9c8ece991c99878f94` (crane-resolved)

## Why

kopia v0.23.0 restricts `--insecure` to loopback binds (kopia/kopia#5354). Upstream `home-operations/containers` PR #1412 added `--allow-extremely-dangerous-unauthenticated-server-on-the-network` to the image entrypoint, so any HelmRelease that uses the entrypoint (onedr0p, bjw-s, auricom, …) needs zero changes for the bump. home-ops was the outlier because it overrode `command:` to add `--disable-csrf-token-checks` and run a `repository connect` step at boot — bypassing the entrypoint and missing the upstream fix.

This refactor matches the standard community pattern, so future kopia breaking changes that get fixed in the image entrypoint will flow through without touching the HelmRelease.

Supersedes #1931.

## Test plan

- [ ] kubeconform validates the rendered manifests (already passed locally: 10 resources valid, 0 invalid)
- [ ] Flux reconciles the HelmRelease without rollback
- [ ] kopia pod becomes Ready
- [ ] `kopia.${SECRET_DOMAIN}` HTTPRoute returns the UI
- [ ] `kopia snapshot list --all` inside the pod shows existing snapshots (proves the repo connect via ConfigMap worked)
- [ ] Next scheduled volsync backup cycle completes successfully