### PR TITLE
fix(kopia): enable quick maintenance + bump maint image to 0.23.0

### DIFF
--- a/kubernetes/apps/storage/kopia/sync/cronjob-maintenance.yaml
+++ b/kubernetes/apps/storage/kopia/sync/cronjob-maintenance.yaml
@@ -22,7 +22,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: kopia-maintenance
-              image: ghcr.io/home-operations/kopia:0.22.3@sha256:17ab64542280197a5368247deaefadc3e3bbe15714ab666c2455a06824e86efd
+              image: ghcr.io/home-operations/kopia:0.23.0@sha256:76865b421548b1d7bb26a8268f0f0bc828be4eec3f8d8b9c8ece991c99878f94
               command: ["/bin/sh", "-c"]
               args:
                 - |
@@ -34,6 +34,8 @@ spec:
                     --override-username=kopia \
                     --override-hostname=maintenance \
                     --cache-directory=/cache
+                  echo "Ensuring quick maintenance is enabled (idempotent)..."
+                  kopia maintenance set --enable-quick=true
                   echo "Running full maintenance..."
                   kopia maintenance run --full
                   echo "Maintenance complete!"


### PR DESCRIPTION
## Summary

- Add `kopia maintenance set --enable-quick=true` to the maintenance CronJob script (idempotent)
- Bump maintenance image to `0.23.0@sha256:76865b42...` to match the server pod (post-#1948)

## Why

Live repo state (2026-05-17): `Quick Cycle: scheduled: false`. Without Quick, per-epoch compaction only runs ~1/day during the Full cycle. Recent maintenance history shows mostly no-op runs (`Compacted 0(0 B) index blobs for epoch 0`) with only one real compaction per ~24h (epoch 64→68 over 6 days). Meanwhile each volsync snapshot adds new index blobs — net result is the 1719-blob backlog and the `Found too many index blobs` warning that's been latent for a while and surfaced during the v0.23.0 smoke test.

Only the maintenance owner (`kopia@maintenance`) can run `kopia maintenance set`, which is the CronJob's identity — so this is the right place to put it. Server pod (`volsync@volsync.storage.svc.cluster.local`) couldn't change it even if asked.

## Test plan

- [ ] kubeconform validates (passed locally: 10/10 valid)
- [ ] Flux reconciles the CronJob update
- [ ] Manual catch-up job runs: `kubectl -n storage create job --from=cronjob/kopia-maintenance kopia-maint-catchup-$(date +%s)`
- [ ] `kopia maintenance info` post-run shows `Quick Cycle: scheduled: true`
- [ ] Blob count in `kopia repository status` trends down over the next 1-2 hours as Quick cycles trigger