### PR TITLE
Revert rook-ceph v1.19.5 → v1.19.3 (incident rollback)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.5
+    tag: v1.19.3
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: v1.19.5
+      version: v1.19.3
       sourceRef:
         kind: HelmRepository
         name: rook-ceph-charts

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.5
+    tag: v1.19.3
   url: oci://ghcr.io/rook/rook-ceph-cluster


### PR DESCRIPTION
## Incident summary

`CephMonDownQuorumAtRisk` — `mon.c on stanton-01` in CrashLoopBackOff since 2026-05-17 ~21:50 UTC.

Same parse error as 2026-04-15 (commit `5cbc1ad5a`):

```
global_init: error reading config file. parse error: expected '<empty_line>' in line 10 at position 21
```

The chart v1.19.5 silently strips the trailing blank line we added in the `configOverride` block. Rendered ConfigMap ends with `bdev_flock_retry = 3` and no trailing newline. Ceph's parser hits EOF where it wants `<empty_line>` and dies.

## Why we're safe right now

Rook operator's mon disruption budget is REFUSING to roll mons a + b:
```
Error EBUSY: not enough monitors would be available (b) after stopping mons [a]
```
Quorum holds at 2/3 on the v1.19.3 deployment template. But any independent restart of mon a or b loses quorum.

## What this PR does

Reverts both v1.19.5 bumps to v1.19.3:
- `kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml`
- `kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml`
- `kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml`

Reverts:
- #1835 (operator group v1.19.3 → v1.19.5)
- #1836 (cluster chart v1.19.3 → v1.19.5)

## Test plan

- [ ] Merge + Flux reconcile (~2-3 min)
- [ ] mon-c deployment template returns to v1.19.3, ConfigMap regenerated WITH trailing newline
- [ ] mon-c pod transitions out of CrashLoopBackOff
- [ ] `ceph -s` shows `3/3 mons`, `HEALTH_OK`
- [ ] No regression in mons a + b (they should NOT be re-rolled by this — same template they're already on)

## Follow-up (NOT part of this PR)

Investigate v1.19.5 chart's `configmap.yaml` template change off-incident. Likely needs upstream report + chart fix or a configOverride structure change on our side.

Hex-dump diagnostic + full incident write-up in claude memory: `project_rook_ceph_v1_19_5_mon_init_regression_2026-05-17.md`