### PR TITLE
fix(n8n): add reloader auto-restart annotation

### DIFF
--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -19,6 +19,8 @@ spec:
   values:
     controllers:
       n8n:
+        annotations:
+          reloader.stakater.com/auto: "true"
         initContainers:
           init-db:
             image:


### PR DESCRIPTION
## Summary

Add `reloader.stakater.com/auto: "true"` to the n8n controller. n8n was the only one of 25 postgres-init-using HelmReleases missing this annotation.

## Why

Discovered during the 2026-05-17 postgres super-pass drift incident:

- 25 apps in the repo run an `init-db` init-container (`ghcr.io/home-operations/postgres-init` or `ghcr.io/rafaribe/postgres-init`)
- 24 of them have `reloader.stakater.com/auto: "true"` so a secret-content change triggers an auto-rollout
- **n8n was the lone holdout** — when its `n8n-secret` content changes (via ESO sync from 1Password), Reloader doesn't touch the deployment, so the running pod keeps its stale env values

Today's recovery worked manually (force ESO refresh + `kubectl rollout restart`), but every future super-pass rotation would have required the same manual touch for n8n only. This commit eliminates that one-off.

## Test plan

- [ ] kubeconform validates (passed locally; pre-existing volsync ReplicationSource schema warnings are unrelated)
- [ ] Flux reconciles the HelmRelease
- [ ] n8n pod restarts (the new annotation in the spec triggers a single restart on apply)
- [ ] Pod comes up Ready
- [ ] n8n UI / API responds normally