### PR TITLE
fix(truenas): point Service + HTTPRoute at port 80

### DIFF
--- a/kubernetes/apps/network/external-services/app/truenas/httproute.yaml
+++ b/kubernetes/apps/network/external-services/app/truenas/httproute.yaml
@@ -23,4 +23,4 @@ spec:
             value: /
       backendRefs:
         - name: truenas
-          port: 443
+          port: 80

--- a/kubernetes/apps/network/external-services/app/truenas/service.yaml
+++ b/kubernetes/apps/network/external-services/app/truenas/service.yaml
@@ -9,8 +9,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: https
+    - name: http
       protocol: TCP
-      port: 443
-      targetPort: 443
-      appProtocol: https
+      port: 80
+      targetPort: 80
+      appProtocol: http


### PR DESCRIPTION
## Why

`citadel.nerdz.cloud` returns Envoy `upstream connect error … Connection refused`. Probe shows TrueNAS HTTPS (port 443) is currently closed on Citadel; port 80 serves the web UI.

## What

- `service.yaml`: port/targetPort 443 → 80, appProtocol https → http, port name https → http
- `httproute.yaml`: backendRefs.port 443 → 80

Standard home-ops pattern: TLS terminates at the Cilium gateway with cert-manager cert; backend speaks plain HTTP.

## Test plan

- [ ] Flux reconcile applies
- [ ] `curl -sk -o /dev/null -w '%{http_code}\n' https://citadel.nerdz.cloud/ui/` returns 200
- [ ] Browser navigation to `https://citadel.nerdz.cloud/ui/` shows TrueNAS UI
- [ ] Bare `https://citadel.nerdz.cloud/` redirects cleanly (may need an HTTPRoute URLRewrite filter if TrueNAS issues absolute Location to literal IP — follow-up if so)