### PR TITLE
fix(truenas): force HTTP/1.1 to backend (useClientProtocol false)

### DIFF
--- a/kubernetes/apps/network/external-services/app/truenas/backendtrafficpolicy.yaml
+++ b/kubernetes/apps/network/external-services/app/truenas/backendtrafficpolicy.yaml
@@ -10,7 +10,8 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: truenas
-  useClientProtocol: true
+  # TrueNAS port-80 nginx only speaks HTTP/1.1 cleartext; speaking HTTP/2 upstream causes protocol_error / 502
+  useClientProtocol: false
   connection:
     bufferLimit: 8Mi
   timeout:


### PR DESCRIPTION
## Final layer of the citadel.nerdz.cloud recovery (after #1957 + #1958)

With backend now on TrueNAS port 80 (plain HTTP), Envoy's `useClientProtocol: true` was forwarding HTTP/2 to the backend whenever the client used HTTP/2 (typical for browsers / curl over HTTPS). TrueNAS nginx on port 80 only speaks HTTP/1.1 cleartext, so it rejected → `protocol_error` → 502.

Envoy log evidence:
```
response_code_details: upstream_reset_before_response_started{protocol_error}
response_flags: UPE
```

Confirmed empirically: `curl --http1.1 https://citadel.nerdz.cloud/ui/` = **200**, default HTTP/2 client = **502**.

## Test plan

- [ ] Flux reconcile
- [ ] `curl -sk -o /dev/null -w '%{http_code}\n' https://citadel.nerdz.cloud/ui/` returns 200 (without forcing http1.1)
- [ ] Browser navigation works