### PR TITLE
fix(rook-ceph): preserve configOverride trailing newline (|+)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -32,7 +32,12 @@ spec:
       createPrometheusRules: true
     toolbox:
       enabled: true
-    configOverride: |
+    # |+ keep-all-trailing-newlines is REQUIRED here. Flux's kustomize
+    # silently strips trailing blank lines from `|` literal blocks, and
+    # Ceph mon init-mon-fs then fails with "parse error: expected
+    # '<empty_line>' in line 10 at position 21". The `+` chomp preserves
+    # the blank line through serialization. Incident: 2026-05-17.
+    configOverride: |+
       [global]
       bdev_enable_discard = true
       bdev_async_discard = true


### PR DESCRIPTION
## Root cause (RCA, see commit body)

Flux's kustomize-controller silently strips trailing blank lines from `|` literal-block scalars during YAML re-serialization. The rendered `rook-config-override` ConfigMap then ends with `bdev_flock_retry = 3` and no trailing newline. Ceph mon init-mon-fs fails:

```
global_init: error reading config file.
parse error: expected '<empty_line>' in line 10 at position 21
```

Surfaces whenever a mon pod restarts. Today the trigger was the 2026-05-17 rook-ceph chart bump (#1835/#1836, since reverted via #1950 — but the rollback didn't fix it because chart version was never the actual cause).

## Fix

Single-char change to the chomping indicator: `configOverride: |` → `configOverride: |+`. The `+` instructs YAML to preserve ALL trailing newlines. Confirmed via `flux build kustomization … --dry-run` that the blank line now survives serialization (was getting stripped with bare `|`).

## Why not "drop configOverride entirely" (Option H)

Considered. Initial inclination after seeing 5/6 reference homelab repos don't use configOverride at all. But our 9 settings are PM9A3-specific tuning — `bluestore_min_alloc_size = 4096` matches the drive's 4K LBA at OSD creation time, etc. Current OSDs have it baked in (`ceph osd metadata 0` confirms). Dropping these would lose performance for any future OSD creation.

## Test plan

- [x] `flux build` dry-run confirms trailing blank line preserved
- [x] kubeconform clean (pre-existing HTTPRoute substitution warnings only)
- [ ] After merge: `kubectl -n rook-ceph get cm rook-config-override -o jsonpath='{.data.config}' | tail -c 30 | xxd` ends with `33 0a 0a` (= `3\n\n`)
- [ ] Resume the suspended cluster HR: `flux -n rook-ceph resume hr rook-ceph-cluster`
- [ ] Force-roll mon-c (delete pod) to verify it survives init-mon-fs cleanly: `kubectl -n rook-ceph delete pod -l mon=c`
- [ ] `ceph -s` shows HEALTH_OK with all 3 mons in quorum

## Follow-up in claude memory

- `project_rook_ceph_v1_19_5_mon_init_regression_2026-05-17.md` — full RCA + recovery timeline
- `reference_flux_kustomize_trailing_whitespace_strip.md` — reusable bug-pattern doc + forensic recipe for catching this elsewhere