### PR TITLE
fix(rook-ceph): manage rook-config-override via Kustomize configMapGenerator

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -32,23 +32,14 @@ spec:
       createPrometheusRules: true
     toolbox:
       enabled: true
-    # |+ keep-all-trailing-newlines is REQUIRED here. Flux's kustomize
-    # silently strips trailing blank lines from `|` literal blocks, and
-    # Ceph mon init-mon-fs then fails with "parse error: expected
-    # '<empty_line>' in line 10 at position 21". The `+` chomp preserves
-    # the blank line through serialization. Incident: 2026-05-17.
-    configOverride: |+
-      [global]
-      bdev_enable_discard = true
-      bdev_async_discard = true
-      osd_class_update_on_start = false
-      bluestore_prefer_deferred_size = 0
-      bluestore_deferred_batch_ops = 16
-      bluestore_deferred_batch_ops_per_txn = 32
-      bluestore_min_alloc_size = 4096
-      bluestore_compression_algorithm = none
-      bdev_flock_retry = 3
-
+    # Empty string disables the chart's rook-config-override ConfigMap
+    # rendering (`{{- if .Values.configOverride -}}` in templates/configmap.yaml
+    # skips when value is empty). The CM is instead managed by Kustomize's
+    # configMapGenerator (file-based) so the bluestore tuning's trailing blank
+    # line — required by Ceph mon init-mon-fs — survives Flux's two YAML
+    # re-serialization layers. See ./rook-config-override.conf for the actual
+    # tuning values. Incident: 2026-05-17.
+    configOverride: ""
     cephClusterSpec:
       cleanupPolicy:
         allowUninstallWithVolumes: false

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -2,9 +2,24 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: rook-ceph
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./dashboard-httproute.yaml
   - ./objectstore-httproute.yaml
   - ./servicemonitor.yaml
+# rook-config-override is managed by Kustomize (NOT the chart) because both
+# Flux kustomize-controller AND helm-controller strip trailing blank lines
+# from `|` literal-block scalars during YAML re-serialization. Ceph mon
+# init-mon-fs requires the file to terminate with an empty line. File-based
+# configMapGenerator preserves the raw bytes (including the trailing blank
+# line) without re-parsing through a YAML library. HelmRelease values has
+# `configOverride: ""` so the chart skips rendering its own copy.
+configMapGenerator:
+  - name: rook-config-override
+    namespace: rook-ceph
+    files:
+      - config=./rook-config-override.conf
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/rook-config-override.conf
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/rook-config-override.conf
@@ -1,0 +1,11 @@
+[global]
+bdev_enable_discard = true
+bdev_async_discard = true
+osd_class_update_on_start = false
+bluestore_prefer_deferred_size = 0
+bluestore_deferred_batch_ops = 16
+bluestore_deferred_batch_ops_per_txn = 32
+bluestore_min_alloc_size = 4096
+bluestore_compression_algorithm = none
+bdev_flock_retry = 3
+


### PR DESCRIPTION
## Why this exists

PR #1960 tried `configOverride: |+` to preserve the trailing blank line that Ceph mon init-mon-fs requires. That made it through Flux's kustomize-controller (`flux build` confirmed) but **Flux helm-controller has a second YAML normalization layer** that strips trailing newlines between `helm template` and apply. Cluster CM ended up identically broken (`bdev_flock_retry = 3` with no trailing newline).

The chart template is innocent (`|` literal block, KEEP one trailing newline). Local `helm template` with our exact values produces the correct `\n\n` output. Only the Flux helm-controller apply step strips.

## Approach: bypass helm-controller for the CM

- HelmRelease values: `configOverride: ""` — chart's `templates/configmap.yaml` skips rendering when the value is empty
- New `rook-config-override.conf` — plain text file, bytes preserved exactly (ends with `\n\n`)
- `kustomization.yaml` adds `configMapGenerator` with file-based source — kustomize stores the raw bytes in `data.config` without YAML literal-block re-serialization
- `disableNameSuffixHash: true` so name stays `rook-config-override` (operator hardcodes this name)

## Verified via flux build

```
$ flux build kustomization ... | yq 'select(.metadata.name=="rook-config-override") | .data.config' | tail -c 30 | xxd
00000000: 3d20 6e6f 6e65 0a62 6465 765f 666c 6f63  = none.bdev_floc
00000010: 6b5f 7265 7472 7920 3d20 330a 0a0a       k_retry = 3...
```

Three trailing newlines preserved end-to-end.

## ⚠️ Pre-merge step required (one-off, no cluster impact)

Before merging this PR, run:

```bash
kubectl -n rook-ceph annotate cm rook-config-override \
  helm.sh/resource-policy=keep --overwrite
```

Without this, when helm-controller runs the new chart render (with empty `configOverride`), it will try to PRUNE the existing CM (currently labelled `meta.helm.sh/release-name: rook-ceph-cluster`). That brief gap could break mon-c if it restarts in the window. The `keep` annotation tells Helm "hands off this resource".

## Test plan

- [ ] Apply pre-merge annotation
- [ ] Merge PR + Flux reconcile
- [ ] Verify cluster CM ends with `\n\n`: `kubectl -n rook-ceph get cm rook-config-override -o jsonpath='{.data.config}' | tail -c 30 | xxd`
- [ ] Delete mon-c pod to force fresh init-mon-fs: `kubectl -n rook-ceph delete pod -l mon=c`
- [ ] mon-c comes up cleanly, joins quorum: `ceph -s` shows HEALTH_OK with 3 mons