### PR TITLE
fix(resources): rebalance memory requests/limits — wave 1 (big over-reservers)

### DIFF
--- a/kubernetes/apps/cortex/local-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/local-ai/app/helmrelease.yaml
@@ -73,10 +73,10 @@ spec:
             resources:
               requests:
                 cpu: 800m
-                memory: 16Gi
+                memory: 512Mi
                 gpu.intel.com/i915: "1"
               limits:
-                memory: 64Gi
+                memory: 8Gi
                 gpu.intel.com/i915: "1"
         pod:
           affinity:
@@ -204,10 +204,10 @@ spec:
             resources:
               requests:
                 cpu: 500m
-                memory: 4Gi
+                memory: 512Mi
                 nvidia.com/gpu: 1
               limits:
-                memory: 24Gi
+                memory: 8Gi
                 nvidia.com/gpu: 1
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -72,8 +72,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 2Gi
               limits:
-                memory: 16Gi
+                memory: 4Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/downloads/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/unpackerr/app/helmrelease.yaml
@@ -67,8 +67,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
-                memory: 4Gi
+                memory: 256Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/entertainment/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/plex/app/helmrelease.yaml
@@ -84,9 +84,10 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1500Mi
               limits:
                 gpu.intel.com/i915: 1
-                memory: 16Gi
+                memory: 3Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/home/manyfold/app/helmrelease.yaml
+++ b/kubernetes/apps/home/manyfold/app/helmrelease.yaml
@@ -92,8 +92,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 2Gi
               limits:
-                memory: 10Gi
+                memory: 3Gi
     defaultPodOptions:
       securityContext:
         runAsUser: 568

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -177,9 +177,9 @@ spec:
             resources:
               requests:
                 cpu: 1000m
-                memory: 4Gi
+                memory: 256Mi
               limits:
-                memory: 4Gi
+                memory: 1Gi
         storageClass:
           enabled: true
           isDefault: false


### PR DESCRIPTION
## Summary

Wave 1 of cluster-wide memory rebalance. Right-sizes 6 helmreleases (8 workloads) based on 14-day Prometheus `container_memory_working_set_bytes` history. Reclaims ~85 GiB of fictional reservation that was creating phantom scheduling pressure on stanton-02.

## Why now

The 2026-05-18 stanton-01 drain attempt failed because stanton-02 was at 99% memory request allocation (with only 30% actually used) — the scheduler had nowhere to relocate evicted pods. Full plan + per-workload data analysis at \`.private/cluster-capacity-plan/\` (gitignored).

## Changes

| workload | request | limit | observed peak |
|---|---|---|---|
| plex | 0 → 1500Mi | 16Gi → 3Gi | 1.6 Gi |
| sabnzbd | 0 → 2Gi | 16Gi → 4Gi | 1.9 Gi |
| unpackerr | 0 → 64Mi | 4Gi → 256Mi | 28 Mi |
| manyfold | 0 → 2Gi | 10Gi → 3Gi | 1.6 Gi (steady) |
| local-ai-intel | 16Gi → 512Mi | 64Gi → 8Gi | 122 Mi |
| local-ai-nvidia | 4Gi → 512Mi | 24Gi → 8Gi | 178 Mi |
| rook-ceph-mds (×2) | 4Gi → 256Mi | 4Gi → 1Gi | 88 Mi |

local-ai limits kept generous (8Gi) for model-load headroom — 14d window showed no actual inference, so observed peak isn't representative.

## Next waves

- Wave 2: critical OOM-risk under-reservers (kube-apiserver, postgres18-cluster, cloudflared, dragonfly, prometheus, searxng)
- Wave 3: remaining A list (arr stack, rook-ceph CSI plugins, etc)
- Wave 4: BestEffort→Burstable hygiene + remaining B list

## Test plan

- [ ] All HelmReleases reconcile cleanly post-merge
- [ ] No OOMKilled events on touched pods within 30 min
- [ ] stanton-02 \`kubectl describe node\` shows memory allocation drop from ~99% toward ~60%
- [ ] Plex playback works (transcoding may need limit bump if 3Gi too tight)
- [ ] Sabnzbd downloads/extracts complete normally
- [ ] manyfold UI responsive
- [ ] Ceph filesystem MDS stays Active+Standby (rolling restart expected)