### PR TITLE
fix(multus): disable chart test controller to unbreak flux-local CI

### DIFF
--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -24,6 +24,11 @@ spec:
       retries: 3
   values:
     controllers:
+      # The chart ships a `test` controller used by `helm test` runs only.
+      # Disabled because the chart can't auto-pick a serviceAccount when 2
+      # are present (default + multus), breaking `flux-local test` in CI.
+      test:
+        enabled: false
       multus:
         containers:
           multus:


### PR DESCRIPTION
## Summary

Disables the multus chart's \`test\` controller. It's only used by \`helm test\` runs (not deployed in prod) but has been failing \`flux-local test\` rendering for weeks because the chart can't auto-pick a serviceAccount when 2 are present (default + multus).

## Why now

Wave 1 of the cluster memory rebalance (#1963) shipped a clean PR but the red \`Flux Local - Test\` + \`Flux Local - Success\` checks were noisy. They were the only failures in 308 tests — and they're masking the signal for the remaining Waves 2-4 and Phases 2-5. Fixing this restores green-on-green CI before we start the high-risk under-reserver changes in Wave 2.

## Change

\`\`\`yaml
values:
  controllers:
    test:
      enabled: false
\`\`\`

## Verification

\`\`\`
$ docker run ghcr.io/allenporter/flux-local:v7.11.0 test \\
    --enable-helm --path /workspace/kubernetes/flux --namespace network
8 passed in 5.94s
\`\`\`

## Test plan

- [ ] PR's \`Flux Local - Test\` job goes green
- [ ] Multus DaemonSet keeps running normally (this controller isn't part of deployed workload)