### PR TITLE
fix(resources): rebalance memory — wave 2a (OOM prevention) + multus uninstall SA

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
@@ -34,8 +34,9 @@ spec:
   resources:
     requests:
       cpu: 100m
+      memory: 5Gi
     limits:
-      memory: 1Gi
+      memory: 14Gi
 
   monitoring:
     enablePodMonitor: true

--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -23,9 +23,9 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 1536Mi
+      memory: 3Gi
     limits:
-      memory: 1536Mi
+      memory: 4Gi
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: "kubernetes.io/hostname"

--- a/kubernetes/apps/home/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/home/searxng/app/helmrelease.yaml
@@ -62,11 +62,11 @@ spec:
               startup:
                 enabled: true
             resources:
-              limits:
-                memory: 2Gi
-
               requests:
                 cpu: 10m
+                memory: 6Gi
+              limits:
+                memory: 10Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -70,8 +70,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 6Gi
               limits:
-                memory: 256Mi
+                memory: 10Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -24,11 +24,17 @@ spec:
       retries: 3
   values:
     controllers:
-      # The chart ships a `test` controller used by `helm test` runs only.
-      # Disabled because the chart can't auto-pick a serviceAccount when 2
-      # are present (default + multus), breaking `flux-local test` in CI.
+      # The chart ships `test` + `uninstall` hook controllers. They
+      # break `flux-local test` because with 2 ServiceAccounts in the
+      # namespace (default + multus) the chart can't auto-pick one.
+      # - `test` is just a chart-test artifact, fully disable.
+      # - `uninstall` is referenced by the `cni` persistence (cleanup
+      #   on helm uninstall), so disabling cascades — pin its SA instead.
       test:
         enabled: false
+      uninstall:
+        serviceAccount:
+          name: multus
       multus:
         containers:
           multus:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -110,9 +110,9 @@ spec:
         resources:
           requests:
             cpu: 300m
-            memory: 2Gi
+            memory: 6Gi
           limits:
-            memory: 4Gi
+            memory: 12Gi
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
## Summary

Wave 2a of cluster memory rebalance. Bumps 5 workloads to absorb their observed peak memory rather than relying on cluster headroom luck for spikes. All values from 14d Prometheus history.

Also fixes the multus chart's \`uninstall\` hook serviceAccount issue (same root cause as \`test\` fixed in #1964). Bundled here because it's needed for clean CI signal on this PR.

## Wave 2a changes

| workload | request | limit | peak |
|---|---|---|---|
| cloudflared | 0 → 6Gi | 256Mi → 10Gi | 9 GiB |
| searxng | 2Gi → 6Gi | 2Gi → 10Gi | 8.6 GiB |
| dragonfly ×7 | 1.5Gi → 3Gi | 1.5Gi → 4Gi | 3.1 GiB |
| postgres18-cluster ×3 | 0 → 5Gi | 1Gi → 14Gi | 10.4 GiB |
| prometheus | 2Gi → 6Gi | 4Gi → 12Gi | 8.7 GiB |

## Multus fix

\`uninstall\` controller is referenced by the \`cni\` persistence (cleanup-on-helm-uninstall workflow), so disabling cascades. Pinning \`serviceAccount.name: multus\` is the right fix. \`flux-local test\` locally: **310 passed, 0 failed**.

## Rolling restarts on apply

- postgres18-cluster: CNPG operator performs rolling instance restart (~3-5 min, no downtime if 2/3 healthy)
- dragonfly: operator rolling restart (7 pods, ~30s each)
- prometheus: single-pod restart (brief scrape gap)
- cloudflared / searxng: single-pod restart (brief tunnel/search outage)

## Net cluster effect

~50 GiB of fresh memory requests across the stantons. Stanton-02 expected to settle around 60-70% allocation (postgres + dragonfly + searxng all live there) — still well below pre-Wave-1's 99%.

## Test plan

- [ ] All HRs reconcile cleanly
- [ ] No CrashLoop/OOMKilled on touched pods within 15 min
- [ ] postgres18-cluster: 3/3 instances Ready after rolling restart
- [ ] dragonfly: 7/7 pods Ready
- [ ] prometheus: scraping resumes, queries work
- [ ] cloudflared: tunnels back up, external services reachable
- [ ] flux-local CI: all green (multus follow-up clears it)

## Out of scope (Wave 2b)

\`kube-apiserver\` static pods need a talconfig edit + \`task talos:apply-node\` per stanton, not Flux. Will be its own PR.