### PR TITLE
fix(resources): rebalance memory — wave 4 (underrequesters + heybuilds OOM loop)

### DIFF
--- a/kubernetes/apps/cortex/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/open-webui/app/helmrelease.yaml
@@ -78,9 +78,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 768Mi
               limits:
-                memory: 4Gi
+                memory: 2Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false

--- a/kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
@@ -37,7 +37,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 150Mi
+                memory: 512Mi
+              limits:
+                memory: 2Gi
     service:
       app:
         controller: *app

--- a/kubernetes/apps/downloads/heybuilds-viewer/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/heybuilds-viewer/app/helmrelease.yaml
@@ -64,8 +64,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
-                memory: 128Mi
+                memory: 512Mi
 
     defaultPodOptions:
       imagePullSecrets:

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -71,8 +71,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-              limits:
                 memory: 1Gi
+              limits:
+                memory: 2500Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/entertainment/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/immich/app/helmrelease.yaml
@@ -76,10 +76,10 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 1Gi
               limits:
                 gpu.intel.com/i915: 1
-                memory: 8Gi
+                memory: 2Gi
       machine-learning:
         strategy: RollingUpdate
         pod:
@@ -125,9 +125,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 1500Mi
               limits:
-                memory: 6Gi
+                memory: 3Gi
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -103,6 +103,6 @@ spec:
     resources:
       requests:
         cpu: 20m
-        memory: 128M
+        memory: 512Mi
       limits:
-        memory: 512M
+        memory: 1500Mi

--- a/kubernetes/apps/home/linkwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/home/linkwarden/app/helmrelease.yaml
@@ -44,9 +44,9 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 300Mi
+                memory: 1Gi
               limits:
-                #memory: 600Mi
+                memory: 2500Mi
     service:
       app:
         controller: linkwarden

--- a/kubernetes/apps/home/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/home/paperless/app/helmrelease.yaml
@@ -104,9 +104,9 @@ spec:
             resources:
               requests:
                 cpu: 35m
-                memory: 926Mi
+                memory: 1200Mi
               limits:
-                memory: 2Gi
+                memory: 2500Mi
     service:
       app:
         controller: *app

--- a/kubernetes/apps/home/paperless/paperless-ai/helmrelease.yaml
+++ b/kubernetes/apps/home/paperless/paperless-ai/helmrelease.yaml
@@ -36,9 +36,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 256Mi
+                memory: 1Gi
               limits:
-                memory: 2Gi
+                memory: 2500Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -82,13 +82,13 @@ spec:
         mgr:
           requests:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           limits:
-            memory: 2Gi
+            memory: 2500Mi
         mon:
           requests:
             cpu: 50m
-            memory: 512Mi
+            memory: 1Gi
           limits:
             memory: 2Gi
         osd:

--- a/kubernetes/apps/vitals/influxdb/app/helmrelease.yaml
+++ b/kubernetes/apps/vitals/influxdb/app/helmrelease.yaml
@@ -65,9 +65,9 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 512Mi
+                memory: 1500Mi
               limits:
-                memory: 8Gi
+                memory: 5Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Summary

Wave 4 of cluster memory rebalance. Bumps requests on workloads that currently rely on cluster headroom for steady-state usage, and fixes a long-running OOM loop on heybuilds-viewer.

## Underrequester bumps (request now covers observed normal-busy state)

| workload | request | limit | observed peak |
|---|---|---|---|
| influxdb | 512Mi → 1500Mi | 8Gi → 5Gi | 4.3 Gi |
| paperless | 926Mi → 1200Mi | 2Gi → 2500Mi | 1.3 Gi |
| paperless-ai | 256Mi → 1Gi | 2Gi → 2500Mi | 1.8 Gi |
| linkwarden | 300Mi → 1Gi | (commented) → 2500Mi | 1.6 Gi |
| immich (main) | 512Mi → 1Gi | 8Gi → 2Gi | 950M |
| immich machine-learning | 512Mi → 1500Mi | 6Gi → 3Gi | 1.3 Gi (steady) |
| prowlarr | 0 → 1Gi | 1Gi → 2500Mi | 1.2 Gi |
| flaresolverr | 150Mi → 512Mi | (unset) → 2Gi | 1.5 Gi |
| open-webui | 512Mi → 768Mi | 4Gi → 2Gi | 742M |
| n8n | 128M → 512Mi | 512M → 1500Mi | 802M |

## Rook-Ceph control plane

| workload | request | limit |
|---|---|---|
| mon (×3) | 512Mi → 1Gi | 2Gi (=) |
| mgr (×2) | 512Mi → 1Gi | 2Gi → 2500Mi |

## Bonus: heybuilds-viewer OOM loop

Discovered during scan: 126 restarts because the 128Mi limit was too tight even for the workload's steady 38Mi usage (lib loads spike briefly above 128Mi → OOMKill).

| workload | request | limit |
|---|---|---|
| heybuilds-viewer | 0 → 64Mi | 128Mi → 512Mi |

## Skipped (Wave 5 if needed)

- loki/grafana/external-dns-unifi (chart-internal resource yaml path — different structure)
- plane stack (multi-controller HR complexity)
- Small BestEffort items (teslamate/reloader/weave-gitops/dashbrr — cumulative ~2GiB, low impact)
- cilium DS (operator-managed)

## Verification

`flux-local test -A` → **310 passed**.

## Test plan

- [ ] All HRs reconcile cleanly
- [ ] No new OOMKilled events on touched pods within 15 min
- [ ] heybuilds-viewer restart count stops climbing
- [ ] immich main + machine-learning both functional
- [ ] paperless OCR jobs still complete
- [ ] influxdb continues writing without backpressure
- [ ] rook-ceph health stays OK through mon/mgr rolling restarts