### PR TITLE
fix(cnpg): soften postgres anti-affinity required → preferred

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
@@ -29,7 +29,7 @@ spec:
   affinity:
     enablePodAntiAffinity: true
     topologyKey: kubernetes.io/hostname
-    podAntiAffinityType: required
+    podAntiAffinityType: preferred
 
   resources:
     requests:

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-immich/postgres18-immich.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-immich/postgres18-immich.yaml
@@ -31,7 +31,7 @@ spec:
   affinity:
     enablePodAntiAffinity: true
     topologyKey: kubernetes.io/hostname
-    podAntiAffinityType: required
+    podAntiAffinityType: preferred
 
   resources:
     requests:


### PR DESCRIPTION
## Summary

Switches \`podAntiAffinityType\` from \`required\` to \`preferred\` on both CNPG Clusters (postgres18-cluster, postgres18-immich). Removes the last logical blocker for safe stanton drains.

## Why

The 2026-05-18 drain attempt cascade was:
1. Cordon stanton-01 → pgbackrest-controller goes Pending (no fallback)
2. CNPG operator loses plugin gRPC connection
3. Cluster phase stuck: "Cluster cannot proceed to reconciliation due to an error while interacting with plugins"
4. postgres18-cluster instance-3 can't reschedule anywhere (anti-affinity \`required\` rules out all nodes)
5. Cluster stuck at 2/3 → PDB blocks eviction of instance-2 → drain blocked indefinitely

With \`preferred\`, the scheduler still prefers spread but allows temporary co-location during maintenance. Two instances may briefly share a host during a drain window.

## Trade-off

- **Before**: drain-impossible. Lose any single stanton during normal operation = 2/3 forever, manual recovery
- **After**: lose the co-located host = 1/3 briefly, but cluster keeps functioning and CNPG can recover

## Test plan

- [ ] CNPG operator reconciles changes (no rolling restart triggered by spec change alone)
- [ ] postgres18-cluster + postgres18-immich both stay 3/3 Ready
- [ ] Sanity-check pods stay on different stantons under normal conditions (preferred should still win)
- [ ] (Future) verify a stanton drain actually works after Phase 3 (pgbackrest toleration) + Phase 4 (kubelet maxPods)

## Context

Memory rebalance Waves 1-4 already merged. Together they free the scheduling headroom; this phase removes the hard anti-affinity that was blocking pod placement. Phase 3 next will add a pyro-01 toleration to pgbackrest-controller so the plugin survives stanton-only drains.