### PR TITLE
fix(scheduling): add pyro-01 fallback tolerations to critical infra pods

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
@@ -32,3 +32,11 @@ spec:
     config:
       data:
         INHERITED_ANNOTATIONS: kyverno.io/ignore
+    # Allow scheduling on pyro-01 (GPU worker) as a fallback. The operator
+    # owns CNPG cluster reconciliation; if it goes Pending due to no fit
+    # on any stanton, postgres clusters can't recover from any disruption.
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Equal
+        value: "true"
+        effect: NoExecute

--- a/kubernetes/apps/database/cloudnative-pg/pgbackrest/deployment.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/pgbackrest/deployment.yaml
@@ -59,6 +59,17 @@ spec:
             - mountPath: /client
               name: client
       serviceAccountName: pgbackrest-controller
+      # Allow scheduling on pyro-01 (GPU worker) as a fallback when all 3
+      # stantons are under pressure or one is cordoned for maintenance.
+      # Without this, a stanton drain can leave pgbackrest-controller
+      # Pending -> CNPG plugin gRPC dies -> cluster reconciliation halts
+      # -> postgres18-cluster instance reschedule blocked -> drain stuck.
+      # See incident 2026-05-18 (cluster-capacity-blockers memory).
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Equal
+          value: "true"
+          effect: NoExecute
       volumes:
         - name: server
           secret:

--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -34,3 +34,11 @@ spec:
       enabled: true
     serviceMonitor:
       enabled: true
+    # Allow scheduling on pyro-01 (GPU worker) as a fallback during stanton
+    # maintenance. Without this, metrics-server going Pending breaks
+    # kubectl top + HPA across the whole cluster.
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Equal
+        value: "true"
+        effect: NoExecute


### PR DESCRIPTION
## Summary

Adds \`nvidia.com/gpu:NoExecute\` tolerations to 3 critical infra workloads so they can fall back to pyro-01 when all 3 stantons are unavailable (or one is cordoned for maintenance).

## Why

The 2026-05-18 drain cascade proximate trigger was pgbackrest-controller having no fallback host. Sequence:
1. \`kubectl cordon stanton-01\`
2. pgbackrest-controller (the only replica, on stanton-01) needed to relocate
3. stanton-02 OOM, stanton-03 at pod-cap, pyro-01 GPU-tainted → all 4 nodes rejected
4. Pod went Pending → CNPG operator gRPC plugin connection died
5. \`postgres18-cluster instance-3\` stayed Pending → drain stuck on PDB

Toleration alone doesn't FORCE the pod to pyro-01 — scheduler still prefers untainted stantons. Only used when stantons are full or unavailable.

## Changes

| workload | file | rationale |
|---|---|---|
| pgbackrest-controller | \`pgbackrest/deployment.yaml\` | proximate cascade trigger |
| cloudnative-pg operator | \`cloudnative-pg/app/helmrelease.yaml\` | owns CNPG cluster reconciliation |
| metrics-server | \`kube-system/metrics-server/app/helmrelease.yaml\` | breaks kubectl top + HPA if Pending |

All use the same toleration:
\`\`\`yaml
tolerations:
  - key: nvidia.com/gpu
    operator: Equal
    value: "true"
    effect: NoExecute
\`\`\`

## Verification

\`flux-local test -A\` → **310 passed**.

## Test plan

- [ ] All 3 pods stay on stantons under normal conditions (scheduler should still prefer non-tainted nodes)
- [ ] No restarts or rescheduling triggered on apply (pods stay put)
- [ ] (Future) verify a stanton drain doesn't break pgbackrest plugin gRPC

## Context

Last logical blocker for safe stanton drains. Combined with previously-merged:
- Waves 1-4: memory rebalance (stanton-02 99% → 45%)
- Phase 2: CNPG anti-affinity required → preferred

Phase 4 (kubelet maxPods 110 → 250) is the only remaining task; it requires a rolling drain itself, so it tests this whole stack end-to-end.