### PR TITLE
fix(volsync): clone copyMethod for hot DBs + 1h alert grace

### DIFF
--- a/kubernetes/apps/database/mariadb/ks.yaml
+++ b/kubernetes/apps/database/mariadb/ks.yaml
@@ -30,4 +30,7 @@ spec:
       APP: *app
       VOLSYNC_CAPACITY: 8Gi
       VOLSYNC_MINUTE: "10"
+      # Clone bypasses snapshot-binding race; mariadb's active writes were
+      # hitting the polling window and generating OOS alerts (2026-05-19).
+      VOLSYNC_COPYMETHOD: Clone
       VOLSYNC_B2_MINUTE: "4"

--- a/kubernetes/apps/security/pocket-id/ks.yaml
+++ b/kubernetes/apps/security/pocket-id/ks.yaml
@@ -32,3 +32,6 @@ spec:
       VOLSYNC_CLAIM: *app
       VOLSYNC_MINUTE: "0"
       VOLSYNC_B2_MINUTE: "0"
+      # Clone bypasses snapshot-binding race; pocket-id active writes were
+      # hitting the polling window and generating OOS alerts (2026-05-19).
+      VOLSYNC_COPYMETHOD: Clone

--- a/kubernetes/apps/storage/volsync/app/prometheusrule.yaml
+++ b/kubernetes/apps/storage/volsync/app/prometheusrule.yaml
@@ -21,8 +21,11 @@ spec:
             summary: >-
               {{ $labels.obj_namespace }}/{{ $labels.obj_name }} volume
               is out of sync.
+          # 1h tolerates one missed hourly cycle; most "out of sync" events
+          # self-resolve at the next scheduled run. 15m was too tight and
+          # paged on normal transient hiccups (verified 2026-05-19).
           expr: |
             volsync_volume_out_of_sync == 1
-          for: 15m
+          for: 1h
           labels:
             severity: critical

--- a/kubernetes/components/volsync/nfs-truenas-relaxed/replicationsource.yaml
+++ b/kubernetes/components/volsync/nfs-truenas-relaxed/replicationsource.yaml
@@ -16,7 +16,7 @@ spec:
     cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
     cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
     compression: zstd-fastest
-    copyMethod: Snapshot
+    copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}
     moverSecurityContext:
       runAsUser: ${VOLSYNC_UID:=568}
       runAsGroup: ${VOLSYNC_GID:=568}

--- a/kubernetes/components/volsync/nfs-truenas/replicationsource.yaml
+++ b/kubernetes/components/volsync/nfs-truenas/replicationsource.yaml
@@ -16,7 +16,7 @@ spec:
     cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
     cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
     compression: zstd-fastest
-    copyMethod: Snapshot
+    copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}
     moverSecurityContext:
       runAsUser: ${VOLSYNC_UID:=568}
       runAsGroup: ${VOLSYNC_GID:=568}

--- a/kubernetes/components/volsync/s3-backblaze/replicationsource.yaml
+++ b/kubernetes/components/volsync/s3-backblaze/replicationsource.yaml
@@ -16,7 +16,7 @@ spec:
     cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
     cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
     compression: zstd-fastest
-    copyMethod: Snapshot
+    copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}
     moverSecurityContext:
       runAsUser: ${VOLSYNC_UID:=568}
       runAsGroup: ${VOLSYNC_GID:=568}

--- a/kubernetes/components/volsync/s3-cloudflare/replicationsource.yaml
+++ b/kubernetes/components/volsync/s3-cloudflare/replicationsource.yaml
@@ -16,7 +16,7 @@ spec:
     cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
     cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
     compression: zstd-fastest
-    copyMethod: Snapshot
+    copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}
     moverSecurityContext:
       runAsUser: ${VOLSYNC_UID:=568}
       runAsGroup: ${VOLSYNC_GID:=568}


### PR DESCRIPTION
## Summary

Two changes to make volsync more resilient and stop spurious paging:

1. **Make `copyMethod` substitutable** in the 4 volsync RS templates (was hardcoded `Snapshot`).
2. **Switch mariadb + pocket-id to `copyMethod: Clone`** — both apps were hitting the snapshot-binding polling race on their hourly cycle and generating `VolSyncVolumeOutOfSync` alerts.
3. **Bump alert grace `for: 15m` → `for: 1h`** — most "out of sync" events self-resolve at the next hourly cycle. 15m was too tight, paged on normal transient hiccups.

## Why now

Got 4 pages overnight (mariadb x3 at 03:16/03:26/03:36 NZT, pocket-id at 04:36 NZT). Triage showed the underlying syncs DO complete, but the controller logs ~20 `"data PVC not available"` ERROR lines per sync cycle as it polls "is the snapshot bound yet?" in a sub-100ms loop. Occasionally the snapshot creation races with active DB writes and the whole cycle drops → metric goes to 1 → alert fires at 15m → re-fires until next hour's run succeeds.

`copyMethod: Clone` creates a full PVC clone (~30s) and rsyncs from it. Bypasses the snapshot-binding race entirely. Trade-off: ~2x source PVC storage during sync. Negligible for mariadb (small) and pocket-id (tiny).

## Changes

| File | Change |
|---|---|
| `components/volsync/nfs-truenas/replicationsource.yaml` | `copyMethod: Snapshot` → `${VOLSYNC_COPYMETHOD:=Snapshot}` |
| `components/volsync/nfs-truenas-relaxed/replicationsource.yaml` | same |
| `components/volsync/s3-backblaze/replicationsource.yaml` | same |
| `components/volsync/s3-cloudflare/replicationsource.yaml` | same |
| `apps/database/mariadb/ks.yaml` | add `VOLSYNC_COPYMETHOD: Clone` |
| `apps/security/pocket-id/ks.yaml` | add `VOLSYNC_COPYMETHOD: Clone` |
| `apps/storage/volsync/app/prometheusrule.yaml` | `for: 15m` → `for: 1h` |

All other apps keep `Snapshot` (faster init, less storage — appropriate for cold media app configs).

## Verification

\`flux-local test -A\` → **310 passed**.

## Test plan

- [ ] mariadb RS reconciles to new spec, next scheduled sync (top of hour + 10) runs via Clone
- [ ] pocket-id same
- [ ] Verify Clone PVCs created in `database` + `security` namespaces during sync, then cleaned up
- [ ] No new VolSyncVolumeOutOfSync pages overnight tonight
- [ ] Other apps (radarr/sonarr/etc) keep Snapshot behavior

## Out of scope

- csi-snapshotter worker thread bump (rook-ceph chart values change — separate PR if this isn't enough)
- DB anti-affinity to spread source pods (long-term hygiene)