### PR TITLE
fix(dragonfly): scale 6 → 4 replicas to survive single-node loss

### DIFF
--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -6,7 +6,12 @@ metadata:
   name: dragonfly
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.37.2
-  replicas: 6
+  # 4 replicas (was 6) — 6 across 3 viable stantons (pyro tainted) ran 2 per
+  # node, which couldn't lose any stanton without violating maxSkew=1 spread.
+  # 4 across 3 nodes (typically 2/1/1) survives losing one node cleanly.
+  # Discovered 2026-05-19 during Phase 4 stanton-01 drain (dragonfly-4 went
+  # Pending because no node could satisfy spread + pod-cap).
+  replicas: 4
   env:
     - name: MAX_MEMORY
       valueFrom:


### PR DESCRIPTION
## Summary

Reduces dragonfly cluster from 6 replicas to 4. The previous configuration couldn't survive losing any single stanton.

## Root cause

Dragonfly has `topologySpreadConstraints` with `maxSkew: 1` and `whenUnsatisfiable: DoNotSchedule`. With 6 replicas across 3 viable stantons (pyro-01 has GPU taint that dragonfly doesn't tolerate), each node ran exactly 2 dragonfly pods. Losing any stanton meant:
- 6 replicas / 2 remaining viable nodes = 3 per node minimum
- maxSkew=1 violated (3 vs 2)
- New pods stuck Pending indefinitely

This was discovered 2026-05-19 during Phase 4 stanton-01 drain. dragonfly-3 was on stanton-01 and the new dragonfly-4 had nowhere to go, blocking the drain via the dragonfly PDB.

## Why 4 instead of 6

- 4 replicas across 3 viable nodes typically distributes 2/1/1 — losing any node leaves 3 working replicas
- maxSkew=1 satisfied even when 1 node is unavailable (1/2/1 → 1/2 → still max-1)
- Dragonfly's emulated-cluster mode tolerates shard count changes; 4 shards is still a working cluster

## Trade-off

- Less write-throughput parallelism (4 shards vs 6) — acceptable for our cache workload
- Less aggregate memory (4 × 3Gi = 12 GiB vs 6 × 3Gi = 18 GiB) — also acceptable given current usage well under cap

## Test plan

- [ ] Operator scales down dragonfly-5 then dragonfly-4 cleanly
- [ ] Dragonfly clients keep working through the scale-down
- [ ] After scale-down, distribution across stantons doesn't violate spread constraints
- [ ] Phase 4 drain of stanton-01 can now proceed without dragonfly PDB block