### PR TITLE
feat(talos): kubelet maxPods 110→250 + control-plane resources

### DIFF
--- a/kubernetes/bootstrap/talos/patches/controller/cluster.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/cluster.yaml
@@ -1,8 +1,25 @@
 cluster:
   allowSchedulingOnControlPlanes: true
+  # Control-plane resource requests/limits sized from 14d Prometheus
+  # observed peak (kube-apiserver 8.4 GiB, kcm 1.6 GiB, scheduler 335 MiB).
+  # Bundled with the maxPods reboot in 2026-05-19 maintenance window since
+  # the apply cost was already sunk. See PHASE4-RUNBOOK.md.
+  apiServer:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 4Gi
+      limits:
+        memory: 10Gi
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
+    resources:
+      requests:
+        cpu: 100m
+        memory: 768Mi
+      limits:
+        memory: 2Gi
   coreDNS:
     disabled: true
   proxy:
@@ -10,3 +27,9 @@ cluster:
   scheduler:
     extraArgs:
       bind-address: 0.0.0.0
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/bootstrap/talos/patches/global/kubelet.yaml
+++ b/kubernetes/bootstrap/talos/patches/global/kubelet.yaml
@@ -6,3 +6,7 @@ machine:
     extraConfig:
       featureGates:
         ImageVolume: true
+      # Default 110 pods/node was the cap that broke the 2026-05-18 stanton-01
+      # drain attempt (stanton-03 was at 115/110). 250 future-proofs against
+      # the same scheduling failure mode.
+      maxPods: 250


### PR DESCRIPTION
## Summary

Catches the git source-of-truth up with the cluster state that was applied via \`talosctl\` during the 2026-05-19 maintenance window across all 4 nodes (stantons + pyro-01 before its decommission).

## Changes

**kubelet maxPods**: 110 → 250
- stanton-03 hit the default 110 cap during the 2026-05-18 drain attempt (115/110 with stale Completed pods)
- 250 gives substantial headroom for normal operation + drain absorption

**Control-plane resources** (only applies to stantons via patches/controller):
- \`cluster.apiServer\`: req 200m/4Gi, lim 10Gi (observed peak 8.4 GiB)
- \`cluster.controllerManager\`: req 100m/768Mi, lim 2Gi (peak 1.6 GiB)
- \`cluster.scheduler\`: req 50m/256Mi, lim 1Gi (peak 335 MiB)

Values sized from 14d Prometheus \`container_memory_working_set_bytes\` history.

## Why now (not in Wave 2b earlier)

Originally scoped out per a cloned-repo corpus check — 7/8 home-ops-style repos leave Talos defaults for these. Reversed during Phase 4 because the rolling-drain cost was already sunk for the maxPods bump, so the apiserver/kcm/scheduler resource bump was 'free' in the same window.

## Apply procedure (already done — this PR catches git up)

Per-node sequential:
\`\`\`
kubectl cordon <node>
kubectl drain <node> --ignore-daemonsets --delete-emptydir-data --timeout=15m
cd kubernetes/bootstrap/talos
talosctl apply-config --nodes <ip> --file clusterconfig/<file> --mode=staged
talosctl shutdown --nodes <ip>
# (PM9A3 install on stantons)
# power on, wait Ready
kubectl get node <name> -o jsonpath='{.status.allocatable.pods}'  # expect 250
kubectl uncordon <node>
# wait for Ceph HEALTH_OK + CNPG 3/3 before next node
\`\`\`

## Verification (already done live)

\`\`\`
$ kubectl get nodes -o custom-columns=NAME:.metadata.name,MAXPODS:.status.allocatable.pods
NAME         MAXPODS
stanton-01   250
stanton-02   250
stanton-03   250
\`\`\`

apiserver/kcm/scheduler resources verified via:
\`kubectl -n kube-system get pod kube-apiserver-stantonNN -o jsonpath='{.spec.containers[0].resources}'\` — matches.

## Test plan

- [ ] flux-local + diff CI checks pass
- [ ] No reconciliation drift on merge (Talos config is OS-layer, Flux doesn't manage it — this PR only updates source-of-truth)