### PR TITLE
chore(cortex): remove dead refs from kustomization

### DIFF
--- a/kubernetes/apps/cortex/kustomization.yaml
+++ b/kubernetes/apps/cortex/kustomization.yaml
@@ -9,9 +9,5 @@ components:
 
 resources:
   # Applications
-  - ./local-ai/ks.yaml
-  - ./qdrant/ks.yaml
   - ./mem0/ks.yaml
   - ./mempalace/ks.yaml
-  - ./open-webui/ks.yaml
-  - ./openclaw/ks.yaml


### PR DESCRIPTION
## Summary

`kubernetes/apps/cortex/kustomization.yaml` references 4 directories (`local-ai`, `qdrant`, `open-webui`, `openclaw`) that were deleted in [84ff181df](https://github.com/gavinmcfall/home-ops/commit/84ff181df). The deletion didn't update the kustomization, so every PR has been failing Flux Local CI with:

\`\`\`
accumulating resources from './local-ai/ks.yaml': open /workspace/kubernetes/apps/cortex/local-ai/ks.yaml: no such file or directory
\`\`\`

This drops the 4 dead references. Only `mem0/` and `mempalace/` remain — matching what actually exists on disk.

## Why this matters

Branch protection doesn't require Flux Local to pass, so PRs can still merge — but the persistent red CI signal masks real chart regressions on future PRs.

## Test plan

- [ ] Flux Local CI passes on this PR
- [ ] After merge, future PRs no longer fail the cortex accumulation error