### PR TITLE
fix(komf): correct configMap volume reference

### DIFF
--- a/kubernetes/apps/entertainment/komf/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/komf/app/helmrelease.yaml
@@ -106,7 +106,7 @@ spec:
           - path: /config
       config-file:
         type: configMap
-        name: komf-config
+        name: komf
         globalMounts:
           - path: /config/application.yml
             subPath: application.yml


### PR DESCRIPTION
## Summary

After merging #1977 (Komf deploy), the pod stayed `ContainerCreating` with:

\`\`\`
MountVolume.SetUp failed for volume "config-file" : configmap "komf-config" not found
\`\`\`

bjw-s app-template names the ConfigMap from \`configMaps.config:\` as the release name itself (\`komf\`), not \`<release>-<key>\` (\`komf-config\`).

One-line fix in the persistence reference.

## Test plan

- [ ] PR merges to main
- [ ] Flux reconciles (~30 min or trigger)
- [ ] \`kubectl -n entertainment get pods -l app.kubernetes.io/name=komf\` shows 1/1 Ready
- [ ] \`https://komf.nerdz.cloud\` loads the Komf UI