### PR TITLE
fix(komf): use env: interpolation for nested provider keys

### DIFF
--- a/kubernetes/apps/entertainment/komf/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/komf/app/helmrelease.yaml
@@ -159,9 +159,13 @@ spec:
                     orderBooks: true
 
             metadataProviders:
-              # malClientId set via env: KOMF_MAL_CLIENT_ID
-              # comicVineApiKey set via env: KOMF_COMICVINE_API_KEY
-              # bangumiToken set via env: KOMF_BANGUMI_TOKEN
+              # Komf's env-var auto-bind covers top-level keys (kavita.*, komga.*, etc.)
+              # but nested config like metadataProviders.malClientId requires explicit
+              # env: interpolation. The env var values themselves come from the
+              # komf-secret ExternalSecret.
+              malClientId: "env:KOMF_MAL_CLIENT_ID"
+              comicVineApiKey: "env:KOMF_COMICVINE_API_KEY"
+              bangumiToken: "env:KOMF_BANGUMI_TOKEN"
               defaultProviders:
                 mangaUpdates:
                   priority: 10


### PR DESCRIPTION
## Summary

After #1979 fixed the ConfigMap mount, the Komf pod still crashed with:

\`\`\`
java.lang.IllegalArgumentException: MyAnimeList clientId is not set
  at snd.komf.providers.ProvidersModule.createMalMetadataProvider(ProvidersModule.kt:439)
\`\`\`

Cause: Komf only auto-binds env vars to **top-level** YAML keys (\`kavita.*\`, \`komga.*\`, etc.). Nested keys like \`metadataProviders.malClientId\` are NOT auto-bound from a same-named env var. The \`KOMF_MAL_CLIENT_ID\` was being injected into the container by the ExternalSecret, but Komf never read it.

Fix: use Komf's documented \`env:VARNAME\` interpolation in the YAML config. Applied to \`malClientId\`, \`comicVineApiKey\`, and \`bangumiToken\` (the latter two providers are currently \`enabled: false\` but wiring is now consistent).

## Test plan

- [ ] PR merges to main
- [ ] Flux reconciles the HelmRelease
- [ ] Pod starts and reaches Ready
- [ ] \`https://komf.nerdz.cloud\` loads the UI