### PR TITLE
fix(suwayomi): correct configMap volume reference

### DIFF
--- a/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
@@ -114,7 +114,7 @@ spec:
           - path: /home/suwayomi/.local/share/Tachidesk
       config-file:
         type: configMap
-        name: suwayomi-config
+        name: suwayomi
         globalMounts:
           - path: /home/suwayomi/.local/share/Tachidesk/server.conf
             subPath: server.conf


### PR DESCRIPTION
## Summary

Same bug pattern as #1979 — the persistence reference pointed at \`suwayomi-config\` but bjw-s app-template names the ConfigMap from \`configMaps.config:\` as just \`<release>\` (\`suwayomi\`).

Pod stuck \`Init:0/1\` (init-db waiting on volume mount) with:

\`\`\`
MountVolume.SetUp failed for volume "config-file" : configmap "suwayomi-config" not found
\`\`\`

One-line fix. Also: clean up the stuck HelmRelease the same way as Komf — \`kubectl -n downloads delete secret -l owner=helm,name=suwayomi\` after merge, then \`flux resume hr suwayomi -n downloads\` if the rollback loop persists. See [[reference_flux_hr_stuck_failed_no_rollback]] memory.

## Test plan

- [ ] Merge to main
- [ ] Flux reconcile
- [ ] init-db container runs and creates \`suwayomi_main\` DB on postgres18-cluster
- [ ] Pod reaches Ready
- [ ] \`https://suwayomi.${SECRET_DOMAIN}\` loads UI