### PR TITLE
fix(suwayomi): seed server.conf via init-container copy

### DIFF
--- a/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
@@ -35,7 +35,24 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
-          init-db:
+          # Seed server.conf onto the writable PVC. Suwayomi's entrypoint runs
+          # sed -i against server.conf which fails on a configMap subPath bind
+          # mount ('Device or resource busy' during atomic rename). Copying the
+          # ConfigMap into the PVC sidesteps the bind-mount restriction while
+          # keeping the config in git via Reloader (annotation already set).
+          01-init-config:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.36
+            command:
+              - sh
+              - -c
+              - |
+                set -e
+                cp /configmap/server.conf /tachidesk-data/server.conf
+                echo "seeded server.conf:"
+                ls -la /tachidesk-data/server.conf
+          02-init-db:
             image:
               repository: ghcr.io/home-operations/postgres-init
               tag: 17.6.0@sha256:86a1992d46273c58fd4ad95b626081dfaabfe16bd56944675169e406d1a660dd
@@ -110,15 +127,20 @@ spec:
     persistence:
       config:
         existingClaim: *app
-        globalMounts:
-          - path: /home/suwayomi/.local/share/Tachidesk
+        advancedMounts:
+          suwayomi:
+            01-init-config:
+              - path: /tachidesk-data
+            app:
+              - path: /home/suwayomi/.local/share/Tachidesk
       config-file:
         type: configMap
         name: suwayomi
-        globalMounts:
-          - path: /home/suwayomi/.local/share/Tachidesk/server.conf
-            subPath: server.conf
-            readOnly: true
+        advancedMounts:
+          suwayomi:
+            01-init-config:
+              - path: /configmap
+                readOnly: true
       media:
         type: nfs
         server: citadel.internal


### PR DESCRIPTION
## Summary

After #1982 fixed the ConfigMap name, Suwayomi pod is now \`CrashLoopBackOff\` with:

\`\`\`
sed: cannot rename /home/suwayomi/.local/share/Tachidesk/sediR3dTF: Device or resource busy
\`\`\`

Suwayomi's container entrypoint runs \`sed -i\` against \`server.conf\` to apply some defaults. When server.conf is mounted as a ConfigMap \`subPath\` bind-mount, sed's atomic rename pattern (temp file → rename to target) fails because you can't rename across a bind mount.

## Fix

Switch from \`subPath\` mount to an init-container copy pattern:

1. \`01-init-config\` (new): busybox initContainer that mounts the ConfigMap at \`/configmap\` (whole dir) and the data PVC at \`/tachidesk-data\`, then \`cp /configmap/server.conf /tachidesk-data/\` puts a regular file on the writable PVC.
2. \`02-init-db\` (renamed): the existing postgres-init container, run after the config seed.
3. \`app\`: main container sees a real file in its data dir that sed can rewrite.

Uses bjw-s \`persistence.X.advancedMounts\` to scope mounts per-container.

Reloader still triggers pod restart on ConfigMap change → init runs again → server.conf gets re-seeded. GitOps semantics preserved.

## Test plan

- [ ] Merge
- [ ] Clean up the stuck HR: \`kubectl -n downloads delete secret -l owner=helm,name=suwayomi && flux resume hr suwayomi -n downloads\`
- [ ] Pod reaches Ready
- [ ] \`https://suwayomi.\${SECRET_DOMAIN}\` loads
- [ ] Extensions tab shows Keiyoushi + Yuzono repos