### PR TITLE
fix(suwayomi): drop jdbc: prefix + pre-create downloads dir

### DIFF
--- a/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
@@ -52,6 +52,11 @@ spec:
                 cp /configmap/server.conf /tachidesk-data/server.conf
                 echo "seeded server.conf:"
                 ls -la /tachidesk-data/server.conf
+                # Suwayomi refuses to start with server.downloadsPath pointing
+                # at a non-existent directory; pre-create it on the shared NFS.
+                mkdir -p /media/Downloads/suwayomi
+                echo "ensured downloads dir exists:"
+                ls -ld /media/Downloads/suwayomi
           02-init-db:
             image:
               repository: ghcr.io/home-operations/postgres-init
@@ -163,7 +168,7 @@ spec:
 
             # === Database (PostgreSQL on shared postgres18-cluster) ===
             server.databaseType = "POSTGRESQL"
-            server.databaseUrl = "jdbc:postgresql://postgres18-cluster-rw.database.svc.cluster.local:5432/suwayomi_main"
+            server.databaseUrl = "postgresql://postgres18-cluster-rw.database.svc.cluster.local:5432/suwayomi_main"
             server.useHikariConnectionPool = true
 
             # === Downloads ===


### PR DESCRIPTION
## Summary

After #1983 fixed the sed/subPath issue, the pod is past init and running but Suwayomi crashes at startup with two errors:

\`\`\`
java.lang.RuntimeException: Driver org.postgresql.Driver claims to not accept jdbcUrl, jdbc:jdbc:postgresql://...
\`\`\`

\`\`\`
WARN  Invalid config value for server.downloadsPath: Path does not exist: /media/Downloads/suwayomi. Using default value: 
\`\`\`

## Fix

1. **Drop the `jdbc:` prefix** in `server.databaseUrl`. The Suwayomi docs example shows `postgresql://...` (no jdbc prefix); Suwayomi adds the prefix internally when constructing the Hikari pool. Mine had `jdbc:jdbc:postgresql://...` doubled, hence the rejection.
2. **Pre-create `/media/Downloads/suwayomi/`** in the existing `01-init-config` init container (already mounts /media for the cp). Suwayomi doesn't auto-create the downloads dir; if it doesn't exist, it logs a warning and silently falls back to the empty default path.

## Test plan

- [ ] Merge to main
- [ ] Flux reconciles
- [ ] Suwayomi container connects to Postgres successfully
- [ ] No "Path does not exist" warning
- [ ] Pod reaches Ready
- [ ] `https://suwayomi.${SECRET_DOMAIN}` loads UI