### PR TITLE
feat(tranga): deploy manga monitor + downloader stack

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -34,4 +34,5 @@ resources:
   - ./sonarr-uhd/ks.yaml
   - ./suwayomi/ks.yaml
   - ./tqm/ks.yaml
+  - ./tranga/ks.yaml
   - ./unpackerr/ks.yaml

--- a/kubernetes/apps/downloads/tranga/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/tranga/app/externalsecret.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tranga
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: tranga-secret
+    template:
+      engineVersion: v2
+      data:
+        # Tranga reads these directly via Environment.GetEnvironmentVariable —
+        # POSTGRES_HOST includes the :port, POSTGRES_DB must NOT default to
+        # "postgres" (Tranga's default), so set it explicitly.
+        POSTGRES_HOST: postgres18-cluster-rw.database.svc.cluster.local:5432
+        POSTGRES_DB: tranga_main
+        POSTGRES_USER: &dbUser "{{ .TRANGA_POSTGRES_USER }}"
+        POSTGRES_PASSWORD: &dbPass "{{ .TRANGA_POSTGRES_PASSWORD }}"
+        # postgres-init init-container vars (creates DB + grants on first run)
+        INIT_POSTGRES_DBNAME: tranga_main
+        INIT_POSTGRES_HOST: postgres18-cluster-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: *dbUser
+        INIT_POSTGRES_PASS: *dbPass
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: tranga

--- a/kubernetes/apps/downloads/tranga/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/tranga/app/helmrelease.yaml
@@ -1,0 +1,173 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tranga
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: storage
+  values:
+    controllers:
+      tranga:
+        labels:
+          nfsMount: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Pre-create downloads dir on the shared NFS. Tranga drops chapters
+          # into /Manga (mapped to /media/Downloads/tranga). Pattern matches
+          # Suwayomi — apps don't always mkdir, so we do it for them.
+          01-init-downloads:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.36
+            command:
+              - sh
+              - -c
+              - |
+                set -e
+                mkdir -p /media/Downloads/tranga
+                ls -ld /media/Downloads/tranga
+          02-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6.0@sha256:86a1992d46273c58fd4ad95b626081dfaabfe16bd56944675169e406d1a660dd
+            envFrom: &envFrom
+              - secretRef:
+                  name: tranga-secret
+        containers:
+          app:
+            image:
+              repository: docker.io/glax/tranga-api
+              tag: latest@sha256:dd7d8fc08ee3455c5e02feea35d70ce1bf2b58b671d72e1cbd861933d91219c7
+            env:
+              TZ: ${TIMEZONE}
+              # Tranga options (all read via Environment.GetEnvironmentVariable
+              # per API/Constants.cs + API/TrangaSettings.cs upstream).
+              # DB creds come via envFrom.
+              CREATE_COMICINFO_XML: "true"
+              CHECK_CHAPTERS_BEFORE_START: "true"
+              FLARESOLVERR_URL: http://flaresolverr.downloads.svc.cluster.local:8191
+              # Override the default /Manga output path so Tranga writes to
+              # our Downloads tier directly (per Option C). Saves a separate
+              # NFS subpath mount and avoids the chicken-and-egg of mounting
+              # a directory that doesn't exist yet.
+              DOWNLOAD_LOCATION: /media/Downloads/tranga
+            envFrom: *envFrom
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &api-port 6531
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                # Bundles Chromium for JS-rendered scanlation sources.
+                # 1Gi handles a few concurrent headless tabs comfortably.
+                memory: 1500Mi
+          website:
+            image:
+              repository: docker.io/glax/tranga-website
+              tag: latest@sha256:68c1f4ca19b90bda9ad533036d71c94c1f31567e34b93eae5a87bc3c3fc13616
+            env:
+              TZ: ${TIMEZONE}
+              # nginx envsubst fills the proxy_pass target from this.
+              # Sidecar pattern: API is on localhost in the same pod.
+              API_URL: http://localhost:6531
+            probes:
+              liveness: &web-probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &web-port 80
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *web-probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: *app
+        # Website is the user-facing entry; it proxies /api → tranga-api.
+        ports:
+          http:
+            port: *web-port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Downloads
+          gethomepage.dev/name: Tranga
+          gethomepage.dev/app: *app
+          gethomepage.dev/icon: mdi-book-multiple
+          gethomepage.dev/description: Manga monitor + downloader
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+    persistence:
+      config:
+        existingClaim: *app
+        globalMounts:
+          - path: /usr/share/tranga-api
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /media

--- a/kubernetes/apps/downloads/tranga/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/tranga/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/keda/nfs-scaler
+  - ../../../../components/volsync-standard
+  - ../../../../components/priority/priority-06

--- a/kubernetes/apps/downloads/tranga/ks.yaml
+++ b/kubernetes/apps/downloads/tranga/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tranga
+  namespace: &namespace downloads
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-postgres18-cluster
+      namespace: database
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: volsync
+      namespace: storage
+  path: ./kubernetes/apps/downloads/tranga/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_MINUTE: "22"
+      VOLSYNC_B2_MINUTE: "52"
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-block
+      VOLSYNC_ACCESSMODES: ReadWriteOnce


### PR DESCRIPTION
## Summary

Adds Tranga (\`glax/tranga-api\`) + Tranga-Website (\`glax/tranga-website\`) in the \`downloads\` namespace as a sidecar pair (single pod, two containers). Tranga is a REST API + worker that monitors manga series, downloads new chapters as CBZ, and triggers Kavita library scans. The website is an nginx+nuxt SPA that proxies API requests to the sidecar via \`localhost:6531\`.

## Configuration

| | |
|---|---|
| API image | \`docker.io/glax/tranga-api:latest@sha256:dd7d8fc0…\` (rolling release on main; fork/self-tag plumbing deferred) |
| Website image | \`docker.io/glax/tranga-website:latest@sha256:68c1f4ca…\` |
| DB | New \`tranga_main\` on shared \`postgres18-cluster\` via postgres-init |
| Downloads | \`/media/Downloads/tranga/\` (DOWNLOAD_LOCATION env override) |
| FlareSolverr | Reuses existing cluster-local \`flaresolverr.downloads.svc:8191\` |
| Auth | None (internal-only behind Tailscale) |
| Route | \`tranga.\${SECRET_DOMAIN}\` on internal gateway → service port 80 (website) |
| 1P item | \`tranga\` with \`TRANGA_POSTGRES_USER\` + \`TRANGA_POSTGRES_PASSWORD\` (already created) |

## Lessons applied (from Suwayomi 4-PR slog)

- Pre-create downloads dir via init container (\`mkdir -p\`)
- All config via env vars — no ConfigMap subpath/sed bind-mount risk
- \`POSTGRES_HOST\` includes \`:port\`; \`POSTGRES_DB\` must be set explicitly (Tranga's default is \`postgres\`, not the DB we want)
- \`DOWNLOAD_LOCATION\` env overrides \`/Manga\` — single \`/media\` NFS mount covers it
- \`runAsUser: 568\` (Dockerfile ends \`USER 0\`; override to non-root)

## Test plan

- [ ] Merge to main
- [ ] Flux reconciles, postgres-init creates \`tranga_main\` DB
- [ ] Pod 1/1 Ready (both \`app\` and \`website\` containers)
- [ ] \`https://tranga.\${SECRET_DOMAIN}\` loads website UI
- [ ] Website's API tab / Swagger reachable via \`/api\` proxy
- [ ] Add a test manga via the API/UI, confirm CBZ lands in \`/media/Downloads/tranga/\`
- [ ] Configure Kavita scan webhook in Tranga UI, confirm scan triggers