### PR TITLE
fix(tranga): pull DB name from 1Password instead of hardcoding

### DIFF
--- a/kubernetes/apps/downloads/tranga/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/tranga/app/externalsecret.yaml
@@ -14,14 +14,15 @@ spec:
       engineVersion: v2
       data:
         # Tranga reads these directly via Environment.GetEnvironmentVariable —
-        # POSTGRES_HOST includes the :port, POSTGRES_DB must NOT default to
-        # "postgres" (Tranga's default), so set it explicitly.
+        # POSTGRES_HOST includes the :port. All identity values (user, pass,
+        # DB name) come from the 'tranga' 1Password item so they can be
+        # rotated without touching git.
         POSTGRES_HOST: postgres18-cluster-rw.database.svc.cluster.local:5432
-        POSTGRES_DB: tranga_main
+        POSTGRES_DB: &dbName "{{ .TRANGA_POSTGRES_DB }}"
         POSTGRES_USER: &dbUser "{{ .TRANGA_POSTGRES_USER }}"
         POSTGRES_PASSWORD: &dbPass "{{ .TRANGA_POSTGRES_PASSWORD }}"
         # postgres-init init-container vars (creates DB + grants on first run)
-        INIT_POSTGRES_DBNAME: tranga_main
+        INIT_POSTGRES_DBNAME: *dbName
         INIT_POSTGRES_HOST: postgres18-cluster-rw.database.svc.cluster.local
         INIT_POSTGRES_USER: *dbUser
         INIT_POSTGRES_PASS: *dbPass


### PR DESCRIPTION
## Summary

Tranga's original ExternalSecret hardcoded \`POSTGRES_DB: tranga_main\` and \`INIT_POSTGRES_DBNAME: tranga_main\` directly in the manifest. Per Gavin's preference, app identity values (user, password, DB name) should live in the 1Password item so they can be rotated without touching git.

## What needs to be in the 'tranga' 1Password item (Kubernetes vault)

| Field | Example |
|---|---|
| \`TRANGA_POSTGRES_USER\` | \`tranga\` |
| \`TRANGA_POSTGRES_PASSWORD\` | 36-char alphanumeric |
| \`TRANGA_POSTGRES_DB\` | \`tranga_main\` |

## Change

ExternalSecret now pulls \`POSTGRES_DB\` and \`INIT_POSTGRES_DBNAME\` from \`TRANGA_POSTGRES_DB\` (single YAML anchor referenced twice). No app code change.

## Test plan

- [ ] 1Password \`tranga\` item created with all three fields
- [ ] Merge to main
- [ ] ESO syncs \`tranga-secret\` cleanly (no \`SecretSyncedError\`)
- [ ] postgres-init creates the DB whose name Gavin chose
- [ ] Pod reaches Ready