### PR TITLE
fix(tranga): emptyDir mounts for nginx writable paths

### DIFF
--- a/kubernetes/apps/downloads/tranga/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/tranga/app/helmrelease.yaml
@@ -171,3 +171,26 @@ spec:
         path: /mnt/storage0/media
         globalMounts:
           - path: /media
+      # nginx (in the website container) is the stock upstream image that
+      # expects to be root. As UID 568 it can't write to /etc/nginx/conf.d
+      # (for envsubst output), /var/cache/nginx (client_temp), or /var/run
+      # (nginx.pid). emptyDir mounts give it writable space at those paths
+      # so it can run unprivileged.
+      nginx-conf-d:
+        type: emptyDir
+        advancedMounts:
+          tranga:
+            website:
+              - path: /etc/nginx/conf.d
+      nginx-cache:
+        type: emptyDir
+        advancedMounts:
+          tranga:
+            website:
+              - path: /var/cache/nginx
+      nginx-run:
+        type: emptyDir
+        advancedMounts:
+          tranga:
+            website:
+              - path: /var/run


### PR DESCRIPTION
## Summary

API container is happy (DB connected, workers cycling, periodic worker output in logs). Website container crashes at startup because the stock nginx upstream image needs to write to several paths and UID 568 (bjw-s default) can't:

\`\`\`
20-envsubst-on-templates.sh: ERROR: /etc/nginx/templates exists, but /etc/nginx/conf.d is not writable
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
\`\`\`

## Fix

Three emptyDir mounts scoped to the \`website\` container via \`advancedMounts\`:

- \`/etc/nginx/conf.d\` — for envsubst-rendered \`default.conf\`
- \`/var/cache/nginx\` — for client_temp, proxy_temp, etc.
- \`/var/run\` — for nginx.pid

No UID changes, no privileged caps. nginx runs unprivileged with writable scratch.

## Test plan

- [ ] Merge
- [ ] HR-stuck cleanup (\`kubectl delete secret -l owner=helm,name=tranga\` + \`flux resume hr tranga -n downloads\`) — install was Failed before this fix
- [ ] Pod 2/2 Ready
- [ ] \`https://tranga.${SECRET_DOMAIN}\` loads
- [ ] Website's network tab shows successful \`/api/\` calls to the sidecar API