### PR TITLE
feat(cnpg): weekly full backups + explicit daily incr

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./postgres18-cluster.yaml
   - ./pooler.yaml
   - ./scheduledbackup.yaml
+  - ./scheduledbackup-weekly-full.yaml
   - ./prometheusrule.yaml
   - ./service.yaml
 components:

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/scheduledbackup-weekly-full.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/scheduledbackup-weekly-full.yaml
@@ -3,18 +3,18 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: postgres18-immich-daily-b2
+  name: postgres18-cluster-weekly-full-b2
   namespace: database
 spec:
-  schedule: "0 3 * * *"
-  immediate: true
+  schedule: "0 1 * * 0"        # Sunday 01:00 UTC — 2h before the daily incr, no pgbackrest lock collision
+  immediate: false             # premigration full (20260525-005008F) already re-based the chain
   backupOwnerReference: self
   method: plugin
   target: primary
   cluster:
-    name: postgres18-immich
+    name: postgres18-cluster
   pluginConfiguration:
     name: pgbackrest.dalibo.com
     parameters:
       selectedRepository: "1"
-      backupType: incr        # explicit (was implicit default); weekly full re-bases the chain
+      backupType: full         # re-bases the incremental chain weekly (caps depth at ~7)

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/scheduledbackup.yaml
@@ -17,3 +17,4 @@ spec:
     name: pgbackrest.dalibo.com
     parameters:
       selectedRepository: "1"
+      backupType: incr        # explicit (was implicit default); weekly full re-bases the chain

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-immich/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-immich/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./postgres18-immich.yaml
   - ./pooler.yaml
   - ./scheduledbackup.yaml
+  - ./scheduledbackup-weekly-full.yaml
   - ./service.yaml
 components:
   - ../../../../components/gatus/infrastructure

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-immich/scheduledbackup-weekly-full.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-immich/scheduledbackup-weekly-full.yaml
@@ -3,11 +3,11 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: postgres18-immich-daily-b2
+  name: postgres18-immich-weekly-full-b2
   namespace: database
 spec:
-  schedule: "0 3 * * *"
-  immediate: true
+  schedule: "0 1 * * 0"        # Sunday 01:00 UTC
+  immediate: true              # immich has no fresh full yet — trigger one on first apply
   backupOwnerReference: self
   method: plugin
   target: primary
@@ -17,4 +17,4 @@ spec:
     name: pgbackrest.dalibo.com
     parameters:
       selectedRepository: "1"
-      backupType: incr        # explicit (was implicit default); weekly full re-bases the chain
+      backupType: full         # re-bases the incremental chain weekly (caps depth at ~7)


### PR DESCRIPTION
## Problem
The daily `ScheduledBackup` never set `backupType`, so the dalibo pgbackrest plugin defaulted every backup to **incremental** — growing the chain to **1,573 incrementals off a single Dec-18 full**. A recovery would have to replay the full + all 1,573 incrementals (slow + fragile).

## Fix
- **New weekly full** (Sun 01:00 UTC) for both `postgres18-cluster` and `postgres18-immich` — re-bases the chain, capping incremental depth at ~7.
- **Daily made explicitly `backupType: incr`** (was implicit default).
- Sunday full at 01:00 is 2h before the daily incr at 03:00 → no pgbackrest single-backup-lock collision.
- immich weekly is `immediate: true` (it had no fresh full); cluster weekly is `immediate: false` (a manual fresh full `20260525-005008F` already re-based it).

## Verification
- `backupType: full` produces a real full — stanza `Full` count went 1→2 (the param the daily was missing).
- Logical restore of all **42 roles / 50 databases** into a fresh `owner: app` cluster succeeded cleanly (data intact: n8n 91 tables, autobrr 23 tables).
- Both kustomize builds validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)