### PR TITLE
fix(cnpg): 6-field cron for scheduled backups (daily was running hourly)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/scheduledbackup-weekly-full.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/scheduledbackup-weekly-full.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgres18-cluster-weekly-full-b2
   namespace: database
 spec:
-  schedule: "0 1 * * 0"        # Sunday 01:00 UTC — 2h before the daily incr, no pgbackrest lock collision
+  schedule: "0 0 1 * * 0"        # 6-field: Sunday 01:00 UTC — 2h before daily incr, no pgbackrest lock collision
   immediate: false             # premigration full (20260525-005008F) already re-based the chain
   backupOwnerReference: self
   method: plugin

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/scheduledbackup.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgres18-cluster-daily-b2
   namespace: database
 spec:
-  schedule: "0 3 * * *"
+  schedule: "0 0 3 * * *"        # 6-field (sec min hour dom mon dow): 03:00 daily. WAS "0 3 * * *" which CNPG's 6-field parser read as hourly-at-:03
   immediate: true
   backupOwnerReference: self
   method: plugin

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-immich/scheduledbackup-weekly-full.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-immich/scheduledbackup-weekly-full.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgres18-immich-weekly-full-b2
   namespace: database
 spec:
-  schedule: "0 1 * * 0"        # Sunday 01:00 UTC
+  schedule: "0 0 1 * * 0"        # 6-field: Sunday 01:00 UTC
   immediate: true              # immich has no fresh full yet — trigger one on first apply
   backupOwnerReference: self
   method: plugin

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-immich/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-immich/scheduledbackup.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgres18-immich-daily-b2
   namespace: database
 spec:
-  schedule: "0 3 * * *"
+  schedule: "0 0 3 * * *"        # 6-field (sec min hour dom mon dow): 03:00 daily. WAS "0 3 * * *" which CNPG's 6-field parser read as hourly-at-:03
   immediate: true
   backupOwnerReference: self
   method: plugin


### PR DESCRIPTION
## Problem
The previous PR (#2020) left the `cloudnative-pg-postgres18-cluster` kustomization failing dry-run — the CNPG admission webhook rejected the weekly-full schedule:
```
spec.schedule: Invalid value: "0 1 * * 0": Beginning of range (0) below minimum (1)
```

**Root cause: CNPG ScheduledBackup uses a 6-field cron (seconds first), not 5-field.**
- The new weekly `0 1 * * 0`: the trailing `0` (meant as Sunday) landed in the *month* field → rejected.
- The pre-existing daily `0 3 * * *`: misparsed as `sec=0 min=3 hour=*` = **every hour at :03**, not 03:00 daily. This is the real cause of the 7,537 backup-CR accumulation we cleaned (48/day = 2 clusters × 24h).

## Fix
- Daily → `0 0 3 * * *` (03:00 daily — actually daily now, 24× fewer backups)
- Weekly full → `0 0 1 * * 0` (Sunday 01:00)
- Both validated via `kubectl apply --dry-run=server` against the CNPG webhook.

Continuous WAL archiving still provides point-in-time RPO independent of backup frequency, so daily incrementals + weekly full is the right cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)