### PR TITLE
fix(smartctl-exporter): auto-scan devices instead of hardcoded /dev/nvmeX

### DIFF
--- a/kubernetes/apps/observability/exporters/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/smartctl-exporter/app/helmrelease.yaml
@@ -28,9 +28,11 @@ spec:
   values:
     fullnameOverride: *app
     config:
-      devices:
-        - /dev/nvme0n1 # Ceph Disk
-        - /dev/nvme1n1 # Primary Disk
+      # No explicit devices -> smartctl_exporter auto-scans (smartctl --scan-open) each
+      # node's real drives. The previous raw /dev/nvmeX list was wrong on 2/3 nodes
+      # (PCIe enumeration assigns numbers differently per node) and would break again
+      # after the PM9A3 /var cutover. Auto-scan fixes both and self-adapts.
+      devices: []
     serviceMonitor:
       enabled: true
     prometheusRules:


### PR DESCRIPTION
## Problem
The exporter hardcoded `/dev/nvme0n1` + `/dev/nvme1n1`, but PCIe enumeration assigns nvme numbers differently per node. Result: correct on only stanton-02; on stanton-01 the labels were reversed; on stanton-03 it monitored the brand-new (then-unused) PM9A3 and **missed the Ceph OSD entirely**.

## Fix
Set `config.devices: []` → smartctl_exporter runs with no `--smartctl.device` flags → auto-scans (`smartctl --scan-open`) each node's real drives. Self-adapts through tomorrow's PM9A3 `/var` cutover (no hardcoded paths to update when the 990 PROs come out).

## Verification
`helm template` (chart 0.16.1): `devices:[]` emits **0** `--smartctl.device` flags (vs 2 with the old list); exporter still runs (path/interval/web args intact). kustomize build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)