### PR TITLE
chore(talos): migrate all 3 stanton OS disks 990 PRO → PM9A3

### DIFF
--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -24,7 +24,7 @@ nodes:
   - hostname: "stanton-01"
     ipAddress: "10.90.3.101"
     installDiskSelector:
-      serial: "S73VNU0X303066H"
+      serial: "S5XMNE0TC58615"   # PM9A3 960GB (was 990 PRO S73VNU0X303066H, pulled 2026-05-26 for RMA return)
     talosImageURL: factory.talos.dev/metal-installer/786a10aa2924e5caf00392a569de037cec138416143517e618d151b8176af7f3
     controlPlane: true
     networkInterfaces:
@@ -103,7 +103,7 @@ nodes:
   - hostname: "stanton-02"
     ipAddress: "10.90.3.102"
     installDiskSelector:
-      serial: "S73VNU0X303413H"
+      serial: "S5XMNE2TC24056"   # PM9A3 960GB (was 990 PRO S73VNU0X303413H, pulled 2026-05-26 for RMA return)
     talosImageURL: factory.talos.dev/metal-installer/786a10aa2924e5caf00392a569de037cec138416143517e618d151b8176af7f3
     controlPlane: true
     networkInterfaces:
@@ -182,7 +182,7 @@ nodes:
   - hostname: "stanton-03"
     ipAddress: "10.90.3.103"
     installDiskSelector:
-      serial: "S73VNU0X303400H"
+      serial: "S5XMNE1TC99141"   # PM9A3 960GB (was 990 PRO S73VNU0X303400H, pulled 2026-05-26 for RMA return)
     talosImageURL: factory.talos.dev/metal-installer/786a10aa2924e5caf00392a569de037cec138416143517e618d151b8176af7f3
     controlPlane: true
     networkInterfaces:


### PR DESCRIPTION
Migrates the Talos control-plane OS/boot disk on all three stantons from the suspect-batch **Samsung 990 PRO 1TB** to burned-in **PM9A3 960GB** enterprise SSDs (power-loss protection, 1.3 DWPD).

Done as a per-node maintenance-mode reinstall (drain → remove etcd member → pull 990 → USB maintenance boot → `apply-config` installs to PM9A3 by serial → etcd/Ceph-mon/OSD rejoin → uncordon). Executed live 2026-05-26, sequence s02 (canary) → s01 → s03. Cluster verified healthy after each: etcd 3/3, Ceph HEALTH_OK (OSDs re-adopted, zero rebalance), CNPG 3/3.

`installDiskSelector.serial` updated:
- `S73VNU0X303066H` → `S5XMNE0TC58615` (stanton-01)
- `S73VNU0X303413H` → `S5XMNE2TC24056` (stanton-02)
- `S73VNU0X303400H` → `S5XMNE1TC99141` (stanton-03)

The pulled 990 PROs are retained as rollback anchors and will be secure-erased before RMA return. No Flux/runtime impact — bootstrap config only, kept in sync with the now-installed reality.