### PR TITLE
fix(talos): raise net.core.r/wmem_max to 7340032 for QUIC (spegel)

### DIFF
--- a/kubernetes/bootstrap/talos/patches/global/sysctl.yaml
+++ b/kubernetes/bootstrap/talos/patches/global/sysctl.yaml
@@ -3,5 +3,7 @@ machine:
     fs.inotify.max_queued_events: "65536"
     fs.inotify.max_user_watches: "524288"
     fs.inotify.max_user_instances: "8192"
-    net.core.rmem_max: "2500000"
-    net.core.wmem_max: "2500000"
+    # 7340032 = 7168 KiB, the size quic-go requests; silences spegel's
+    # "failed to sufficiently increase receive buffer size" warning.
+    net.core.rmem_max: "7340032"
+    net.core.wmem_max: "7340032"


### PR DESCRIPTION
spegel (quic-go) logs at startup:
```
failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 7168 kiB, got: 4882 kiB)
```
because `net.core.rmem_max` was `2500000` (~2.4 MiB). Raises `rmem_max`/`wmem_max` to **7340032** (7168 KiB — the value quic-go requests) per the [quic-go UDP buffer guidance](https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes).

Already applied live to all three stantons via `talosctl apply-config --mode=no-reboot` (sysctls apply without reboot); confirmed `/proc/sys/net/core/{r,w}mem_max` = 7340032 on all three. Warning stops recurring on spegel's next restart. Closes the deferred QUIC-buffer TODO.