### PR TITLE
chore(home): retire nerdz-landing from cluster (now on Cloudflare)

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
   - ./filebrowser/ks.yaml
   - ./linkwarden/ks.yaml
   - ./manyfold/ks.yaml
-  - ./nerdz-landing/ks.yaml
+  # - ./nerdz-landing/ks.yaml  # retired → Cloudflare Worker 2026-05-26; Flux prunes the pod. Files kept for rollback — delete the dir after confidence.
   # - ./outline/ks.yaml
   - ./p4k-scanner/ks.yaml
   - ./paperless/ks.yaml


### PR DESCRIPTION
The hub moved to Cloudflare (opennext Worker) and is live at nerdz.cloud.
This comments out the nerdz-landing Flux Kustomization so Flux **prunes
the in-cluster pod** (it's already receiving zero traffic — the apex now
points at the Worker).

- Surgical: only the parent kustomization reference is commented out.
- **Not touched**: the cloudflared tunnel, `external.nerdz.cloud`, or any
  of the 32 service CNAMEs / the `kromgo.nerdz.cloud` endpoint the Worker
  still depends on.
- Manifest files kept (`kubernetes/apps/home/nerdz-landing/`) for a
  rollback window. Once the cutover is proven, delete the dir + remove
  the tunnel's `nerdz.cloud` ingress rule.

Merging this makes Flux delete the pod.