### PR TITLE
refactor(kavita): rename external hostname comics -> manga

### DIFF
--- a/kubernetes/apps/entertainment/kavita/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/kavita/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
           gethomepage.dev/widget.password: "{{ `{{HOMEPAGE_VAR_KAVITA_PASSWORD}}` }}"
           external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
         hostnames:
-          - comics.${SECRET_DOMAIN}
+          - manga.${SECRET_DOMAIN}
         parentRefs:
           - name: external
             namespace: network


### PR DESCRIPTION
## Summary

Kavita's library is overwhelmingly manga/manhwa/manhua, so `comics.${SECRET_DOMAIN}` undersells it. Move to `manga.${SECRET_DOMAIN}`.

## Impact

- external-dns creates the new `manga` record; old `comics` record removed on reconcile (sync policy).
- **Mihon Android OPDS** clients pointing at `comics.nerdz.cloud/api/opds/<key>` must be re-pointed to the new host.
- Browser bookmarks break — update them.
- No impact on Komf or Tranga — both reach Kavita via internal cluster DNS.
- No OIDC impact (not configured yet).

## Test plan

- [ ] Merge + Flux reconcile
- [ ] `manga.nerdz.cloud` resolves and serves Kavita
- [ ] Re-point Mihon OPDS URL