### PR TITLE
feat(audiobookshelf): move to books hostname with 301 redirect

### DIFF
--- a/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
@@ -104,7 +104,7 @@ spec:
           gethomepage.dev/widget.key: "{{ `{{HOMEPAGE_VAR_AUDIOBOOKSHELF_TOKEN}}` }}"
           external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
         hostnames:
-          - audiobookshelf.${SECRET_DOMAIN}
+          - books.${SECRET_DOMAIN}
         parentRefs:
           - name: external
             namespace: network

--- a/kubernetes/apps/entertainment/audiobookshelf/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/audiobookshelf/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./backendtrafficpolicy.yaml
+  - ./redirect-httproute.yaml
 components:
   - ../../../../components/keda/nfs-scaler
   - ../../../../components/gatus/external

--- a/kubernetes/apps/entertainment/audiobookshelf/app/redirect-httproute.yaml
+++ b/kubernetes/apps/entertainment/audiobookshelf/app/redirect-httproute.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# Permanent redirect from the old audiobookshelf.${SECRET_DOMAIN} host to the
+# new books.${SECRET_DOMAIN}. external-dns still publishes the old hostname so
+# existing bookmarks / ABS clients that haven't been re-pointed keep resolving
+# and get a 301 to the canonical host. Remove this route once nothing references
+# the old hostname.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: audiobookshelf-redirect
+  annotations:
+    external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+spec:
+  hostnames:
+    - audiobookshelf.${SECRET_DOMAIN}
+  parentRefs:
+    - name: external
+      namespace: network
+      sectionName: https
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: books.${SECRET_DOMAIN}
+            statusCode: 301


### PR DESCRIPTION
## Summary

Rename Audiobookshelf's external host `audiobookshelf.${SECRET_DOMAIN}` → `books.${SECRET_DOMAIN}` (it holds ebooks + audiobooks; "books" reads cleaner and pairs with Kavita's `manga` rename in #2032). A standalone HTTPRoute 301-redirects the old host to the new one so bookmarks and not-yet-re-pointed clients keep working.

## Changes

- `helmrelease.yaml`: route hostname `audiobookshelf` → `books`
- `redirect-httproute.yaml` (new): `audiobookshelf.${SECRET_DOMAIN}` → 301 → `books.${SECRET_DOMAIN}`, with external-dns target so the old host still resolves
- `kustomization.yaml`: wire in the redirect route

Matches the repo's existing `RequestRedirect` pattern (`network/envoy-gateway/httproute.yaml`).

## Validation

`flux build | kubeconform` passes once `${SECRET_DOMAIN}` is substituted (verified locally with the real domain). Local pre-substitution kubeconform shows a cosmetic hostname-pattern warning on the redirect route because `${SECRET_DOMAIN}` renders empty without the cluster-settings `substituteFrom` — Flux Local CI substitutes properly and passes. The 3 ReplicationSource/Destination "invalid" results are the pre-existing volsync kopia-mover schema gap.

## Impact

- external-dns publishes both `books` (serves) and `audiobookshelf` (301 redirects).
- **ABS mobile app** stores its server URL and may not follow a 301 on API calls — re-point it manually to be safe.
- Browser bookmarks auto-redirect.

## Test plan

- [ ] Merge + Flux reconcile
- [ ] `books.nerdz.cloud` serves ABS
- [ ] `audiobookshelf.nerdz.cloud` 301s to `books.nerdz.cloud`
- [ ] Re-point ABS mobile app server URL

## Follow-up

Remove `redirect-httproute.yaml` once nothing references the old hostname.