### PR TITLE
fix(kavita): update Gatus subdomain comics -> manga

### DIFF
--- a/kubernetes/apps/entertainment/kavita/ks.yaml
+++ b/kubernetes/apps/entertainment/kavita/ks.yaml
@@ -29,4 +29,4 @@ spec:
       VOLSYNC_CAPACITY: 4Gi
       VOLSYNC_MINUTE: "12"
       VOLSYNC_B2_MINUTE: "28"
-      GATUS_SUBDOMAIN: comics
+      GATUS_SUBDOMAIN: manga


### PR DESCRIPTION
Follow-up to #2032. The hostname rename moved Kavita's route to manga but left GATUS_SUBDOMAIN: comics in ks.yaml, so the Gatus external check kept probing the dead comics host and went red. One-line fix.