### PR TITLE
fix(gatus): correct kromgo + filebrowser healthcheck definitions

### DIFF
--- a/kubernetes/apps/home/filebrowser/app/kustomization.yaml
+++ b/kubernetes/apps/home/filebrowser/app/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - ./helmrelease.yaml
 components:
   - ../../../../components/keda/nfs-scaler
-  - ../../../../components/gatus/guarded
+  - ../../../../components/gatus/external
   - ../../../../components/volsync-standard
   - ../../../../components/priority/priority-10

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -23,4 +23,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_STATUS: "404"
+      GATUS_STATUS: "200"


### PR DESCRIPTION
## Summary
Two Gatus checks were failing **every probe** (not flapping) since well before the PM9A3 migration. Both apps are healthy — the **check definitions** were stale/mismatched. (kavita, the third failing endpoint, was already fixed in #2034.)

## kromgo — expected `404`, gets `200`
- kromgo `v0.9.1 → v0.10.0` (#1945, merged 2026-05-18) changed its root `/` from returning **404** to returning **200** (`page intentionally blank`).
- The `external` check was pinned to `GATUS_STATUS: "404"`, so it fired on normal operation and masked any real outage signal.
- **Fix:** `GATUS_STATUS: "404" → "200"`.
- Verified: `curl https://kromgo.${SECRET_DOMAIN}/` → `HTTP 200`.

## filebrowser — `guarded` component on a public service
- filebrowser is publicly exposed (`parentRefs: external` → public Cloudflare DNS) behind PocketID OIDC.
- It used the `guarded` Gatus component, whose check is a DNS A-lookup with condition `len([BODY]) == 0` — i.e. it asserts the name should **not** resolve publicly. Since filebrowser *does* resolve publicly, the check always failed.
- **Fix:** swap `components/gatus/guarded → components/gatus/external`. filebrowser returns `HTTP 200` externally, matching the external component's default `[STATUS] == 200`.

## Validation
- `kustomize build` (LoadRestrictionsNone) of both `kromgo/app` and `filebrowser/app` succeed.
- Rendered filebrowser endpoint now emits `group: external` with `[STATUS] == ${GATUS_STATUS:-200}`.

## Not included
- `http2: client connection lost` on the kube-apiserver VIP (`10.90.3.100`) for large transfers — separate, workstation→VIP path issue; control plane (etcd 3/3, all apiservers ready, kubelets 0 errors, nodes Ready) is healthy. Tracked separately.