### PR TITLE
feat(suwayomi): add global-update settings to server.conf

### DIFF
--- a/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
@@ -179,6 +179,18 @@ spec:
             server.autoDownloadNewChaptersLimit = 0
             server.autoDownloadIgnoreReUploads = true
 
+            # === Global update (scheduled new-chapter checks) ===
+            # Key names verified against Suwayomi-Server ServerConfig.kt source.
+            # "Pull everything" stance: don't skip series we're behind on or
+            # haven't started. globalUpdateInterval is hours (minimum 6).
+            server.globalUpdateInterval = 12
+            server.excludeUnreadChapters = false
+            server.excludeNotStarted = false
+            server.excludeCompleted = false
+            # Suwayomi-internal metadata refresh; Komf owns Kavita metadata, so
+            # leave Suwayomi from re-fetching covers/details every cycle.
+            server.updateMangas = false
+
             # === FlareSolverr (cluster-local service) ===
             server.flareSolverrEnabled = true
             server.flareSolverrUrl = "http://flaresolverr.downloads.svc.cluster.local:8191"


### PR DESCRIPTION
Global-update behaviour was on defaults (skip unread/not-started/completed all ON), fighting the 'pull everything' intent. Adds explicit block: interval 12h, exclude* all false, updateMangas false. Key names verified against Suwayomi-Server ServerConfig.kt source. server.conf-backed → repo ConfigMap is source of truth (init container re-copies on pod restart).