### PR TITLE
feat(entertainment): deploy mangarr (manga organizer)

### DIFF
--- a/kubernetes/apps/entertainment/kustomization.yaml
+++ b/kubernetes/apps/entertainment/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./immich/ks.yaml
   - ./kavita/ks.yaml
   - ./komf/ks.yaml
+  - ./mangarr/ks.yaml
   - ./seerr/ks.yaml
   - ./pasta/ks.yaml
   - ./plex/ks.yaml

--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -1,0 +1,114 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app mangarr
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: storage
+  values:
+    controllers:
+      mangarr:
+        labels:
+          nfsMount: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gavinmcfall/mangarr
+              tag: sha-1efd7f7@sha256:0972d7fb122ca0ee6f3fa3cf314c06c3ae59e9d1a1aaf0f7ecea82da54c2600b
+            env:
+              TZ: ${TIMEZONE}
+              MANGARR_DOWNLOAD_ROOTS: /media/Downloads/suwayomi,/media/Downloads/tranga
+              MANGARR_DB_PATH: /config/mangarr.db
+              MANGARR_HTTP_ADDR: :8590
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8590
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Entertainment
+          gethomepage.dev/name: mangarr
+          gethomepage.dev/app: *app
+          gethomepage.dev/icon: mdi-book-multiple-outline
+          gethomepage.dev/description: Manga organiser (the missing *arr tier)
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+    persistence:
+      config:
+        existingClaim: *app
+        globalMounts:
+          - path: /config
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /media

--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -41,7 +41,9 @@ spec:
               tag: sha-1efd7f7@sha256:0972d7fb122ca0ee6f3fa3cf314c06c3ae59e9d1a1aaf0f7ecea82da54c2600b
             env:
               TZ: ${TIMEZONE}
-              MANGARR_DOWNLOAD_ROOTS: /media/Downloads/suwayomi,/media/Downloads/tranga
+              MANGARR_DOWNLOAD_ROOTS: >-
+                /media/Downloads/suwayomi,
+                /media/Downloads/tranga
               MANGARR_DB_PATH: /config/mangarr.db
               MANGARR_HTTP_ADDR: :8590
             probes:

--- a/kubernetes/apps/entertainment/mangarr/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/keda/nfs-scaler
+  - ../../../../components/volsync-standard
+  - ../../../../components/priority/priority-06

--- a/kubernetes/apps/entertainment/mangarr/ks.yaml
+++ b/kubernetes/apps/entertainment/mangarr/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mangarr
+  namespace: &namespace entertainment
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: volsync
+      namespace: storage
+  path: ./kubernetes/apps/entertainment/mangarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_MINUTE: "33"
+      VOLSYNC_B2_MINUTE: "53"
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-block
+      VOLSYNC_ACCESSMODES: ReadWriteOnce


### PR DESCRIPTION
Deploys [mangarr](https://github.com/gavinmcfall/mangarr) — the missing *arr tier for the manga stack — to `entertainment` namespace.

## What mangarr does
Watches `/media/Downloads/{suwayomi,tranga}` for new series, classifies each by AniList `countryOfOrigin` (JP→Manga, KR→Manhwa, CN/TW→Manhua), files into the matching type-library, triggers a Kavita rescan. Standalone Go service, embedded HTMX UI, single 20.9 MB static container.

## Manifest highlights
- **Image** `ghcr.io/gavinmcfall/mangarr:sha-1efd7f7@sha256:0972d7fb...` (digest-pinned per home-ops convention).
- **Route** internal-only: `mangarr.${SECRET_DOMAIN}` on `internal` gateway. Tailscale-only by design.
- **Storage** 2Gi VolSync-backed `mangarr` PVC (Kopia/B2, schedule slots `:33` / B2 `:53`).
- **Media** NFS to `citadel.internal:/mnt/storage0/media` at `/media`.
- **Security** uid 568, `readOnlyRootFilesystem: true` + emptyDir `/tmp`, drop-all-caps, seccomp RuntimeDefault.
- **Probes** TCP 8590 (mangarr has no `/health` endpoint).
- **Components** `keda/nfs-scaler` + `volsync-standard` + `priority/priority-06` — exact same set as komf.
- **No ExternalSecret** for MVP: Kavita API key entered via mangarr's Settings UI on first run (env-override is on the [mangarr backlog](https://github.com/gavinmcfall/mangarr)).

## First-run setup (after Flux reconciles)
1. Open `https://mangarr.${SECRET_DOMAIN}` (Tailscale).
2. Settings → set Kavita base URL `http://kavita.entertainment.svc.cluster.local:5000`, paste Kavita API key, set library roots (`/media/Library/Books/Manga`, `/manhwa`, `/manhua`), set per-type Kavita library IDs, save.
3. Rescan now → series discovered → classified → filed → Kavita scan triggered → Activity log records each step.

## Validation
- `task kubernetes:kubeconform` → `Kustomization mangarr is valid`. Unifi false-positive on `${SECRET_DOMAIN}` regex is pre-existing+unrelated.
- Container smoke-tested pre-PR on the mangarr repo: all UI pages render, Settings round-trip works, SIGTERM graceful.