### PR TITLE
feat(suwayomi): rename hostname suwayomi.* -> tachi.*

### DIFF
--- a/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
@@ -124,7 +124,7 @@ spec:
           gethomepage.dev/description: Mihon/Tachiyomi self-hosted server
           internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
         hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - "tachi.${SECRET_DOMAIN}"
         parentRefs:
           - name: internal
             namespace: network

--- a/kubernetes/apps/downloads/suwayomi/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./redirect-httproute.yaml
 components:
   - ../../../../components/keda/nfs-scaler
   - ../../../../components/volsync-standard

--- a/kubernetes/apps/downloads/suwayomi/app/redirect-httproute.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/redirect-httproute.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# Permanent redirect from the old suwayomi.${SECRET_DOMAIN} host to the new
+# tachi.${SECRET_DOMAIN}. internal-dns still publishes the old hostname so
+# existing bookmarks keep resolving and get a 301 to the canonical host.
+# Remove this route once nothing references the old hostname.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: suwayomi-redirect
+  annotations:
+    internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+spec:
+  hostnames:
+    - suwayomi.${SECRET_DOMAIN}
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: tachi.${SECRET_DOMAIN}
+            statusCode: 301


### PR DESCRIPTION
## Summary

Primary URL for Suwayomi is now `tachi.${SECRET_DOMAIN}` instead of `suwayomi.${SECRET_DOMAIN}`. `tachi` refers to upstream Tachiyomi (the Android project Suwayomi-Server forks from) — shorter, easier to type/remember.

A redirect HTTPRoute keeps `suwayomi.${SECRET_DOMAIN}` resolving and serves a 301 to `tachi.${SECRET_DOMAIN}` so existing bookmarks and clients keep working. Same shape as the earlier audiobookshelf → books rename, but on the `internal` gateway rather than `external`.

## Changes
- `helmrelease.yaml` — `hostnames` from `{{ .Release.Name }}.${SECRET_DOMAIN}` → `tachi.${SECRET_DOMAIN}` (1 line).
- `redirect-httproute.yaml` (new) — HTTPRoute on `internal` gateway, hostname `suwayomi.${SECRET_DOMAIN}`, RequestRedirect to `tachi.${SECRET_DOMAIN}` with 301. Annotated for `internal-dns` so the old name keeps resolving.
- `kustomization.yaml` — register the new HTTPRoute.

## Test plan
- [x] `task kubernetes:kubeconform` → `Kustomization suwayomi is valid` (the app/ dir is skipped because it uses Flux postBuild substitution; the unifi `${SECRET_DOMAIN}` regex false-positive is pre-existing+unrelated).
- [ ] After Flux reconciles: `curl -sI https://tachi.${SECRET_DOMAIN}` → 200 + UI; `curl -sI https://suwayomi.${SECRET_DOMAIN}` → 301 → `tachi.${SECRET_DOMAIN}`.

## Follow-up
Remove `redirect-httproute.yaml` (+ the line in `kustomization.yaml`) once nothing references the old hostname anymore.