### PR TITLE
fix(kavita): security patch — bump 0.8.9 -> 0.9.0.2

### DIFF
--- a/kubernetes/apps/entertainment/kavita/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/kavita/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/kareadita/kavita
-              tag: 0.8.9@sha256:1f2acae7466d022f037ea09f7989eb7c487f916b881174c7a6de33dbfa8acb39
+              tag: 0.9.0.2@sha256:880a8feff0833e860575f8e08788e4b4f59f8659afd17206566aae88a525130d
             env:
               TZ: ${TIMEZONE}
             resources:


### PR DESCRIPTION
## Summary
Security patch — bumps Kavita image from \`0.8.9\` to \`0.9.0.2\` to pick up a published CVE fix. Digest verified live via \`crane digest ghcr.io/kareadita/kavita:0.9.0.2\`.

\`\`\`
ghcr.io/kareadita/kavita:0.9.0.2@sha256:880a8feff0833e860575f8e08788e4b4f59f8659afd17206566aae88a525130d
\`\`\`

## Test plan
- [x] Digest verified via \`crane digest\` (not assumed).
- [ ] After Flux reconciles: kavita pod rolls cleanly; \`https://manga.\${SECRET_DOMAIN}\` returns 200; existing library data intact (PVC unchanged).

## Notes
Cherry-picked from a stray commit on the (already-merged) \`chore/disable-pyro-01-talconfig\` branch to land it on a properly-named hotfix branch. That stray branch will be deleted in a follow-up cleanup.