### PR TITLE
chore(mangarr): bump image to sha-25c96b5 (Sonarr-style UI re-skin)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-1efd7f7@sha256:0972d7fb122ca0ee6f3fa3cf314c06c3ae59e9d1a1aaf0f7ecea82da54c2600b
+              tag: sha-25c96b5@sha256:865bab673328b154b569820a87f485683abf3dcc940025d98850eeac1deb291d
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Bumps mangarr image from \`sha-1efd7f7\` to \`sha-25c96b5\` to pick up the Sonarr-style UI re-skin (mangarr PR #2). Same handlers, same data shapes — purely a visual swap.

\`\`\`
ghcr.io/gavinmcfall/mangarr:sha-25c96b5@sha256:865bab673328b154b569820a87f485683abf3dcc940025d98850eeac1deb291d
\`\`\`

## Test plan
- [x] Digest verified live via \`crane digest\`.
- [x] \`task kubernetes:kubeconform\` → \`Kustomization mangarr is valid\`.
- [ ] After Flux reconciles: \`https://mangarr.\${SECRET_DOMAIN}\` renders the new dark/sidebar UI; existing Dragon Ball Super (Color) Unmatched row still present (PVC unchanged); Settings round-trip still works.