### PR TITLE
chore(mangarr): bump image to sha-4700503 (Phase 2 features)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-25c96b5@sha256:865bab673328b154b569820a87f485683abf3dcc940025d98850eeac1deb291d
+              tag: sha-4700503@sha256:95669703ec94b369db5ad56ac9edabbe0961cacc4475a0bb1b00b91063ef0937
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
Bumps mangarr image from \`sha-25c96b5\` to \`sha-4700503\` to pick up Phase 2 (mangarr PRs #20 + #21).

\`\`\`
ghcr.io/gavinmcfall/mangarr:sha-4700503@sha256:95669703ec94b369db5ad56ac9edabbe0961cacc4475a0bb1b00b91063ef0937
\`\`\`

## What this brings live
- **\`/health\` + \`/api/health\`** — 7 checks (download-roots / library-roots / kavita / anilist / sqlite / disk-space / rename-scheme). Gatus-ready JSON, sidebar Health page with status pills.
- **\`/metrics\`** — native Prometheus endpoint exposing 16 \`mangarr_*\` gauges + counters (files filed, kavita scans, anilist lookups, disk free/total, health status per check, backup count, series counts by category, etc.) plus Go runtime + process collectors. Add a scrape rule to pick it up.
- **\`/preview\`** — dry-run the whole pipeline without touching disk or Kavita. Shows what would happen if you flipped settings, hit Save.
- **\`/api/series/{id}/assign\`** — one-click classify-and-file from the Unmatched page. Writes the override into the classification cache (keyed by title) so the *next* chapter of e.g. "Dragon Ball Super (Color)" auto-classifies without going to AniList again.
- Sidebar nav now: Series · Preview · Unmatched · Activity · Health · Tasks · Settings (7 entries).

## Test plan
- [x] Digest verified live via \`crane digest\`.
- [x] \`task kubernetes:kubeconform\` → \`Kustomization mangarr is valid\`.
- [ ] After Flux reconciles: \`https://mangarr.\${SECRET_DOMAIN}\` renders the new pages; \`curl /metrics\` returns Prometheus text format; existing Settings + "Dragon Ball Super (Color)" Unmatched row preserved (PVC unchanged).

## Follow-up
Add a Prometheus ServiceMonitor for mangarr if you want metrics scraping wired into the cluster Prom.