### PR TITLE
chore(mangarr): bump image to sha-62981cc (Settings UX polish)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-4700503@sha256:95669703ec94b369db5ad56ac9edabbe0961cacc4475a0bb1b00b91063ef0937
+              tag: sha-62981cc@sha256:8879d4fc28445c36dc926acead9f0c6bfb3291313b490005d00d19ef9425ac3c
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
Bumps mangarr image from `sha-4700503` to `sha-62981cc` to pick up Settings UX polish (mangarr PR #22).

```
ghcr.io/gavinmcfall/mangarr:sha-62981cc@sha256:8879d4fc28445c36dc926acead9f0c6bfb3291313b490005d00d19ef9425ac3c
```

## What this brings live
- **Disk Space bars** — flipped to conventional macOS/Sonarr direction. Bar shows `% used` filling left->right; thresholds green (<75%) -> orange (75-90%) -> red (>90%). Inline percent label per row for colorblind clarity.
- **Save settings button** — moved into a sticky footer at the bottom of the Settings page.
- **Library Roots** — folder-icon Browse button per input opens a Sonarr-style path picker modal. New `GET /api/browse` + `/api/browse/fragment` allowlisted to `/media` + `/config` only.

## Test plan
- [x] Digest verified live via `crane digest`.
- [x] `task kubernetes:kubeconform` -> `Kustomization mangarr is valid`.
- [ ] After Flux reconciles: `https://mangarr.${SECRET_DOMAIN}/settings` shows new disk bars + sticky save footer + Browse buttons.