### PR TITLE
chore(mangarr): bump image to sha-0e33dc9 (browse modal dismiss fix)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-62981cc@sha256:8879d4fc28445c36dc926acead9f0c6bfb3291313b490005d00d19ef9425ac3c
+              tag: sha-0e33dc9@sha256:92fc978991ad1084ddb31e4be3f3f5da83ed5e22fbb7996733f4221ba15fdb96
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
Bumps mangarr image from `sha-62981cc` to `sha-0e33dc9` to pick up the browse-modal dismiss bug (mangarr PR #23). After picking a folder via the Library Roots Browse button, the modal + backdrop now dismiss properly so the page becomes clickable again.