### PR TITLE
fix(kromgo): match coretemp chip label + add ceph capacity metrics

### DIFF
--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -88,7 +88,7 @@ metrics:
 
   - name: cluster_temp_avg
     # Average across CPU coretemp + PCH + NVMe sensors — biased toward "is the rack hot"
-    query: round(avg(node_hwmon_temp_celsius{chip=~"coretemp.*|.*pch.*|.*nvme.*"}), 1)
+    query: round(avg(node_hwmon_temp_celsius{chip=~".*coretemp.*|.*pch.*|.*nvme.*"}), 1)
     suffix: "°C"
     colors:
       - { color: "green", min: 0, max: 60 }
@@ -229,6 +229,30 @@ metrics:
 
   - name: cluster_storageclass_count
     query: count(kube_storageclass_info) OR vector(0)
+
+  # ── Ceph cluster capacity (rook-ceph-mgr) ──
+  # ceph_cluster_total_* is the usable (post-replication) pool capacity the
+  # mgr reports. Divisor 1099511627776 = 1024^4 = bytes→TiB. PromQL round()'s
+  # second arg is "nearest multiple" (not decimal places), so 0.01 ⇒ 2dp.
+  - name: ceph_capacity_total
+    query: round(ceph_cluster_total_bytes / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: ceph_capacity_used
+    query: round(ceph_cluster_total_used_bytes / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: ceph_capacity_free
+    query: round((ceph_cluster_total_bytes - ceph_cluster_total_used_bytes) / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: ceph_capacity_used_pct
+    query: round(ceph_cluster_total_used_bytes / ceph_cluster_total_bytes * 100, 0.1) OR vector(0)
+    suffix: "%"
+    colors:
+      - { color: "green", min: 0, max: 70 }
+      - { color: "orange", min: 70, max: 85 }
+      - { color: "red", min: 85, max: 9999 }
 
   # ── Workloads (Tier 3 — enabled by new KSM collectors) ──
   - name: cluster_statefulsets_ready
@@ -382,7 +406,7 @@ metrics:
   # node, the headline number anyone wants is "how hot is the 1080 Ti")
   # with coretemp fallback if the NVIDIA exporter is offline.
   - name: node_temp_stanton01
-    query: round(max(node_hwmon_temp_celsius{kubernetes_node="stanton-01",chip=~"coretemp.*"}), 1) OR vector(0)
+    query: round(max(node_hwmon_temp_celsius{kubernetes_node="stanton-01",chip=~".*coretemp.*"}), 1) OR vector(0)
     suffix: "°C"
     colors:
       - { color: "green", min: 0, max: 60 }
@@ -390,7 +414,7 @@ metrics:
       - { color: "red", min: 75, max: 9999 }
 
   - name: node_temp_stanton02
-    query: round(max(node_hwmon_temp_celsius{kubernetes_node="stanton-02",chip=~"coretemp.*"}), 1) OR vector(0)
+    query: round(max(node_hwmon_temp_celsius{kubernetes_node="stanton-02",chip=~".*coretemp.*"}), 1) OR vector(0)
     suffix: "°C"
     colors:
       - { color: "green", min: 0, max: 60 }
@@ -398,7 +422,7 @@ metrics:
       - { color: "red", min: 75, max: 9999 }
 
   - name: node_temp_stanton03
-    query: round(max(node_hwmon_temp_celsius{kubernetes_node="stanton-03",chip=~"coretemp.*"}), 1) OR vector(0)
+    query: round(max(node_hwmon_temp_celsius{kubernetes_node="stanton-03",chip=~".*coretemp.*"}), 1) OR vector(0)
     suffix: "°C"
     colors:
       - { color: "green", min: 0, max: 60 }
@@ -406,7 +430,7 @@ metrics:
       - { color: "red", min: 75, max: 9999 }
 
   - name: node_temp_pyro01
-    query: round(max(nvidia_smi_temperature_gpu), 1) OR round(max(node_hwmon_temp_celsius{kubernetes_node="pyro-01",chip=~"coretemp.*"}), 1) OR vector(0)
+    query: round(max(nvidia_smi_temperature_gpu), 1) OR round(max(node_hwmon_temp_celsius{kubernetes_node="pyro-01",chip=~".*coretemp.*"}), 1) OR vector(0)
     suffix: "°C"
     colors:
       - { color: "green", min: 0, max: 70 }


### PR DESCRIPTION
## Issues fixed

### 1. Per-node temps returned `0`
`node_temp_stanton0{1,2,3}` / `node_temp_pyro01` filtered `chip=~"coretemp.*"`, but node-exporter labels the chip **`platform_coretemp_0`**. PromQL fully-anchors regex, so the `platform_` prefix never matched → empty result → `OR vector(0)` → `0`.

Widened to `chip=~".*coretemp.*"` across all 5 affected queries (the four per-node temps + `cluster_temp_avg`, which was effectively NVMe-only before).

**Verified live against Prometheus:** stanton-01 = 73°C, stanton-02 ≈ 84°C, stanton-03 ≈ 70°C, `cluster_temp_avg` = 59°C.

### 2. Added Ceph cluster capacity
New metrics from `rook-ceph-mgr`'s `ceph_cluster_total_*` gauges (post-replication usable, TiB):

| metric | value |
|---|---|
| `ceph_capacity_total` | 5.24 TiB |
| `ceph_capacity_used` | 0.41 TiB |
| `ceph_capacity_free` | 4.83 TiB |
| `ceph_capacity_used_pct` | 7.8% (green/orange/red at 70/85) |

Note: PromQL `round(x, N)` rounds to the nearest *multiple* of `N` (not decimal places), so `0.01`/`0.1` are used for 2dp/1dp.

## Not in this PR
`nas_capacity` (TrueNAS total + per-dataset) is blocked on a data source — there are currently **zero** `truenas_*` series in Prometheus. The `graphite-exporter` ingest path (`10.99.8.210:9109`) is healthy but Citadel isn't pushing to it. Enabling TrueNAS graphite reporting is being handled separately; the kromgo metrics will follow once data flows.