### PR TITLE
feat(observability): TrueNAS capacity exporter + nas_capacity kromgo metrics

### DIFF
--- a/kubernetes/apps/observability/exporters/graphite-exporter/app/configmap.yaml
+++ b/kubernetes/apps/observability/exporters/graphite-exporter/app/configmap.yaml
@@ -657,3 +657,25 @@ data:
         mountpoint: "$${2}"
         instance: "$${1}"
         unit: "inodes"
+
+    ################################################
+    # pool + dataset capacity
+    # Pushed by the truenas-capacity CronJob (TrueNAS REST API), NOT netdata.
+    # Paths: truenas.capacity.pool.<pool>.{size,allocated,free}
+    #        truenas.capacity.dataset.<dataset>.{used,available}
+    # Dataset "/" is flattened to "_" (storage0/media -> storage0_media).
+    ################################################
+
+    - match: 'truenas\.capacity\.pool\.(.*)\.(size|allocated|free)'
+      match_type: "regex"
+      name: "truenas_pool_$${2}_bytes"
+      labels:
+        job: "truenas"
+        pool: "$${1}"
+
+    - match: 'truenas\.capacity\.dataset\.(.*)\.(used|available)'
+      match_type: "regex"
+      name: "truenas_dataset_$${2}_bytes"
+      labels:
+        job: "truenas"
+        dataset: "$${1}"

--- a/kubernetes/apps/observability/exporters/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - ./snmp-exporter/ks.yaml
   - ./speedtest-exporter/ks.yaml
   - ./tautulli-exporter/ks.yaml
+  - ./truenas-capacity/ks.yaml

--- a/kubernetes/apps/observability/exporters/truenas-capacity/app/configmap.yaml
+++ b/kubernetes/apps/observability/exporters/truenas-capacity/app/configmap.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: truenas-capacity-script
+data:
+  # Pulls pool + dataset capacity from the TrueNAS REST API (read-only API
+  # key) and pushes it as graphite plaintext to the existing graphite-exporter,
+  # which maps it to truenas_pool_*_bytes / truenas_dataset_*_bytes for
+  # Prometheus. SCALE 24.10 dropped the native collectd/graphite push, so this
+  # CronJob replaces it for the capacity numbers we care about.
+  #
+  # Dataset names contain "/" which is the graphite path separator, so they're
+  # flattened ("/", " ", "." -> "_"): storage0/media -> storage0_media. The
+  # graphite-exporter mapping turns that back into a `dataset` label.
+  push.sh: |
+    #!/bin/sh
+    set -eu
+
+    : "${TRUENAS_URL:?must be set, e.g. http://citadel.internal}"
+    : "${TRUENAS_API_KEY:?must be set from the truenas-capacity secret}"
+    GRAPHITE_HOST="${GRAPHITE_HOST:-graphite-exporter.observability.svc.cluster.local}"
+    GRAPHITE_PORT="${GRAPHITE_PORT:-9109}"
+
+    auth="Authorization: Bearer ${TRUENAS_API_KEY}"
+    ts="$(date +%s)"
+
+    pools="$(curl -sf --max-time 20 -H "$auth" "${TRUENAS_URL}/api/v2.0/pool")"
+    datasets="$(curl -sf --max-time 20 -H "$auth" "${TRUENAS_URL}/api/v2.0/pool/dataset?extra.flat=true")"
+
+    lines="$(
+      printf '%s' "$pools" | jq -r --arg ts "$ts" '.[] |
+        (.name | gsub("[ /.]"; "_")) as $p |
+        "truenas.capacity.pool.\($p).size \(.size) \($ts)",
+        "truenas.capacity.pool.\($p).allocated \(.allocated) \($ts)",
+        "truenas.capacity.pool.\($p).free \(.free) \($ts)"'
+      printf '%s' "$datasets" | jq -r --arg ts "$ts" '.[] |
+        (.name | gsub("[ /.]"; "_")) as $d |
+        "truenas.capacity.dataset.\($d).used \(.used.parsed // 0) \($ts)",
+        "truenas.capacity.dataset.\($d).available \(.available.parsed // 0) \($ts)"'
+    )"
+
+    count="$(printf '%s\n' "$lines" | grep -c . || true)"
+    if [ "$count" -eq 0 ]; then
+      echo "no metrics parsed from TrueNAS API" >&2
+      exit 1
+    fi
+
+    printf '%s\n' "$lines" | nc -w 5 "$GRAPHITE_HOST" "$GRAPHITE_PORT"
+    echo "pushed ${count} capacity metrics to ${GRAPHITE_HOST}:${GRAPHITE_PORT}"

--- a/kubernetes/apps/observability/exporters/truenas-capacity/app/cronjob.yaml
+++ b/kubernetes/apps/observability/exporters/truenas-capacity/app/cronjob.yaml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.0/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: truenas-capacity
+spec:
+  # graphite-exporter holds pushed gauges with a TTL, and kromgo reads instant
+  # values, so a 5-minute push keeps the capacity numbers fresh without load.
+  schedule: "*/5 * * * *"
+  suspend: false
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          containers:
+            - name: push
+              image: alpine:3.23
+              command:
+                - /bin/sh
+                - -c
+                - apk add --no-cache curl jq > /dev/null 2>&1 && /scripts/push.sh
+              env:
+                - name: TRUENAS_URL
+                  value: "http://citadel.internal"
+                - name: GRAPHITE_HOST
+                  value: "graphite-exporter.observability.svc.cluster.local"
+                - name: GRAPHITE_PORT
+                  value: "9109"
+                - name: TRUENAS_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: truenas-capacity-secret
+                      key: TRUENAS_API_KEY
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities: { drop: ["ALL"] }
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: script
+              configMap:
+                name: truenas-capacity-script
+                defaultMode: 0555
+            - name: tmp
+              emptyDir: {}

--- a/kubernetes/apps/observability/exporters/truenas-capacity/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/truenas-capacity/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./configmap.yaml
+  - ./cronjob.yaml

--- a/kubernetes/apps/observability/exporters/truenas-capacity/app/secret.sops.yaml
+++ b/kubernetes/apps/observability/exporters/truenas-capacity/app/secret.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: truenas-capacity-secret
+stringData:
+    #ENC[AES256_GCM,data:JOWvtANCp2byRW4R0Uwbum3Gs8mGEPG5/bGvlMzrzqbX0XDrvkgGlAM6XoKFALznpgst3Ma6u0IVTodEKEMgT/KijWtXOkGZUZ2iGy0=,iv:b+Z5PJRFPG6+qZPiFIuWtgywXNkO8FMNNb9ECrhNzqc=,tag:XmNTLGJoWllzJXvDh9om3Q==,type:comment]
+    #ENC[AES256_GCM,data:D0pAlcPyI3tK9RMRmDUgxJa+GPkiZTEwnIZoPcx68AcO9r6bQwTXLUJgld4YWQwSrYMBQnLRUHkb10wAeuP0qD/K2hgOKtuiGw0=,iv:QG8GGCzbUUU/Z51+1Yx5T70Jx/H86KmCgOCc8hucIk0=,tag:je1d/DyegCEuxOK0VqBxRw==,type:comment]
+    #ENC[AES256_GCM,data:CZlYm08BOEBjyDIymwprW4mN6HSWu3RsTEN6EhttAUHmzOWVzw6RhdzTsgfm9pQR807loGT3JRzASEqmPcn2sLCZ0vGJ/gY99w==,iv:WBTwyuMTQVnKFbGfly3xEtCx7Efvwf2o5xBGY4CTGPE=,tag:cwVUOTeYV7b2TLzwgF1Xew==,type:comment]
+    #ENC[AES256_GCM,data:KaLivKe8j4zTt30mlDdVzBqUONZlsLFPrJJwNNY29mlHoZlD43Soo258hTLUi/vqcvvRqgeaVhC5uFqY2ngoNr4=,iv:vgyyuwTTiGcL2Xw4DTV6RSl4lbmW18Xxj9LrWPl9DRk=,tag:D8uJYnEvCw95JzHPK5211Q==,type:comment]
+    TRUENAS_API_KEY: ENC[AES256_GCM,data:GDJgXRkP+Ll6r7Wz3E3yYsjywAFAQnBoZxVERImkV3GrpDm3a7ZyuVSdoPm0dX4QSP08XFNuoe2/j1u3eGmDh3WL,iv:3128JOQQel5CNm8TlfCHBAgtQFYZbF5Jcw0g0lej/QY=,tag:G0Uz4O63o4bb0gSCfzwlYA==,type:str]
+sops:
+    age:
+        - recipient: age1s3dkl4qn66zsj38zl4nkjdw8c6j4d9v8ddd9vwajcfjrz04s2fgsgg3lxy
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNUXZMR2ozVXdvbEFXcmJU
+            bUk2T0JrektGdzBuSG10RlUwVWhCS0dMNDJJCkxBRndjQURWSTFSL3Z6eFJBT2Fw
+            L0lxZXdtbHN3blIrNFpTaGhPOEt6QU0KLS0tIFpqMWd2ZHdWb3RMNTJiNE55SmlW
+            UmUxL3IzMHNkcDBCSlR1RndPVEJoMU0KTJs2oE0kW8MpLDjgsGjlSf+qR8Pf/bLA
+            cWUn4CkHamsCcSMzPpCJ/7plHDLOtO/O723qJZR9OyoJmcbfnbCmdA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-29T08:59:34Z"
+    mac: ENC[AES256_GCM,data:MjfppKc00BOUKjU9ZLCTo3dowb6it4u3mYlghPlNzG2avmKrXQca8WKj9mP05JWJQQXgPW6suEItYYRWXD0ibkFCDmnKjsHe0oTGJxCYxVBe17yLhTRArBeYgHUDnmAyL4kLh8fpLrev1Fq1XCce1dU6qgG/wkjGkA8XTeon7/w=,iv:VzhXjNePRZdQ79cqFjmRakO3e/60DiCKd4jqN6HIZSE=,tag:kcGHV6KJ8J9yseWrg3VS3w==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/observability/exporters/truenas-capacity/ks.yaml
+++ b/kubernetes/apps/observability/exporters/truenas-capacity/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app truenas-capacity
+  namespace: &namespace observability
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/observability/exporters/truenas-capacity/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -476,3 +476,51 @@ metrics:
   - name: citadel_power_state
     # 1 = powered on, 0 = off. Useful for dashboard "node is offline" badge.
     query: max(ipmi_chassis_power_state{host="citadel"}) OR vector(0)
+
+  # ─────────────────────────────────────────────────────────────────────
+  # TrueNAS / Citadel NAS capacity (ZFS pool storage0)
+  # Fed by the truenas-capacity CronJob → graphite-exporter →
+  # truenas_pool_*_bytes / truenas_dataset_*_bytes. SCALE 24.10 dropped the
+  # native graphite push, so the CronJob pulls the TrueNAS REST API instead.
+  # Divisor 1099511627776 = 1024^4 = bytes→TiB; round()'s 2nd arg is
+  # "nearest multiple" so 0.01/0.1 give 2dp/1dp. Values stay at 0 until the
+  # first CronJob push lands.
+  # ─────────────────────────────────────────────────────────────────────
+  - name: nas_capacity_total
+    query: round(sum(truenas_pool_size_bytes) / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: nas_capacity_used
+    query: round(sum(truenas_pool_allocated_bytes) / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: nas_capacity_free
+    query: round(sum(truenas_pool_free_bytes) / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: nas_capacity_used_pct
+    query: round(sum(truenas_pool_allocated_bytes) / sum(truenas_pool_size_bytes) * 100, 0.1) OR vector(0)
+    suffix: "%"
+    colors:
+      - { color: "green", min: 0, max: 70 }
+      - { color: "orange", min: 70, max: 85 }
+      - { color: "red", min: 85, max: 9999 }
+
+  # Per-dataset used (TiB) — headline datasets. Per-dataset "available" all
+  # equals pool-free (no quotas), so only "used" is meaningful here. The full
+  # breakdown lives in Prometheus as truenas_dataset_used_bytes{dataset=...}.
+  - name: nas_dataset_media_used
+    query: round(truenas_dataset_used_bytes{dataset="storage0_media"} / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: nas_dataset_backups_used
+    query: round(truenas_dataset_used_bytes{dataset="storage0_backups"} / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: nas_dataset_minio_used
+    query: round(truenas_dataset_used_bytes{dataset="storage0_minio"} / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"
+
+  - name: nas_dataset_game_servers_used
+    query: round(truenas_dataset_used_bytes{dataset="storage0_game-servers"} / 1099511627776, 0.01) OR vector(0)
+    suffix: " TiB"


### PR DESCRIPTION
## Why
The repo's `graphite-exporter` was built to receive TrueNAS metrics via collectd/graphite push, but **SCALE 24.10 (Electric Eel) removed the native graphite/remote-export option** (`reporting.config` only has retention tiers now). Result: **zero `truenas_*` series in Prometheus** — so `nas_capacity` couldn't be built. No off-the-shelf exporter image fits 24.10 + API-key auth either.

## What (option B — CronJob → existing graphite-exporter)
Replace the dead push path with a **pull**:

- **`truenas-capacity` CronJob** (every 5m, `observability/exporters/truenas-capacity/`): `alpine` + `curl`/`jq` reads pool + dataset capacity from the TrueNAS **REST API** with a **read-only (GET-only) API key**, formats graphite plaintext, and pushes to the already-running `graphite-exporter` (`:9109`).
- **`graphite-exporter` mappings**: `truenas.capacity.pool.*` / `truenas.capacity.dataset.*` → `truenas_pool_{size,allocated,free}_bytes` and `truenas_dataset_{used,available}_bytes` (dataset `/` flattened to `_`).
- **kromgo metrics**: `nas_capacity_{total,used,free,used_pct}` (pool `storage0`) + per-dataset `used` badges (media/backups/minio/game-servers). Full per-dataset breakdown stays queryable in Prometheus as `truenas_dataset_used_bytes{dataset=...}` for Grafana.

## Secret handling
API key (`prometheus-capacity-exporter`, allowlist `[{GET, *}]`) stored via **SOPS** — the 1Password Connect token is read-only and can't create items. Easy to migrate to an ExternalSecret later if a 1Password item is added.

## Verification
- API + key tested live over HTTP: `storage0` = 72.75 TiB total, 18.93 TiB free; 11 datasets (media = 58.5 TB).
- Push script: `sh -n` clean; its exact `jq` output matches the new mapping regexes 1:1.
- `kustomize build` passes for truenas-capacity, graphite-exporter, kromgo, and the exporters parent; `kubeconform` passes on CronJob/ConfigMap/ks.
- kromgo `nas_*` values use `OR vector(0)`, so they read `0` until the **first post-merge CronJob push**, then populate.

## Notes
- `node_temp`/`ceph_capacity` fixes are in #2053 (separate). This PR's kromgo edits are appended at EOF, so the two don't conflict.