### PR TITLE
fix(truenas-capacity): opt configmap out of Flux var substitution

### DIFF
--- a/kubernetes/apps/observability/exporters/truenas-capacity/app/configmap.yaml
+++ b/kubernetes/apps/observability/exporters/truenas-capacity/app/configmap.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: truenas-capacity-script
+  annotations:
+    # The script is full of shell ${VAR} / $(...) expansions. Without this,
+    # Flux's postBuild envsubst eats them (e.g. strips ${TRUENAS_API_KEY} and
+    # ${TRUENAS_URL}), leaving an empty Bearer header and no host. Opt this
+    # resource out of substitution so the script reaches the pod verbatim.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 data:
   # Pulls pool + dataset capacity from the TrueNAS REST API (read-only API
   # key) and pushes it as graphite plaintext to the existing graphite-exporter,


### PR DESCRIPTION
## Bug
The `truenas-capacity` CronJob (merged in #2055) **failed every run**. Root cause: Flux's `postBuild` envsubst processes ConfigMap data and treats the push script's shell `${VAR}` expansions as Flux variables, stripping the undefined ones. The deployed script became:

```sh
auth="Authorization: Bearer "          # ${TRUENAS_API_KEY} stripped
curl -sf -H "$auth" "/api/v2.0/pool"   # ${TRUENAS_URL} stripped → no host
```

→ `curl` with no key and no host → `set -e` exit → `BackoffLimitExceeded`.

## Fix
Add `kustomize.toolkit.fluxcd.io/substitute: disabled` to the ConfigMap so it reaches the pod verbatim. Keeps the script readable (vs. doubling every `$` like the graphite-exporter mapping does).

## Verified in-cluster (debug pod mirroring the CronJob)
- DNS: `citadel.internal` → 10.90.1.69 ✅
- TrueNAS API with the deployed secret key: **HTTP 200** ✅
- graphite-exporter reachable, `nc` present ✅
- The only failure was the env-stripping, confirmed by diffing the live ConfigMap against source.

After merge the CronJob runs every 5m; `truenas_*` series and kromgo `nas_capacity_*` will populate on the first successful push.