### PR TITLE
chore(kromgo): remove pyro-01 metrics (node decommissioned)

### DIFF
--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -204,7 +204,7 @@ metrics:
 
   # ─────────────────────────────────────────────────────────────────────
   # nerdz.cloud — observability audit 2026-05 additions
-  # Depends on expanded kube-state-metrics collectors and nvidia-gpu-exporter
+  # Depends on expanded kube-state-metrics collectors
   # ─────────────────────────────────────────────────────────────────────
 
   # ── Storage (Tier 4) ──
@@ -332,35 +332,6 @@ metrics:
     query: round(max(igpu_engines_video_0_busy), 1)
     suffix: "%"
 
-  # ── NVIDIA GPU (pyro-01, via utkuozdemir/nvidia_gpu_exporter) ──
-  # NVML-based — dcgm-exporter was tried first but DCGM doesn't support
-  # consumer Pascal cards (GTX 1080 Ti). Each query wraps OR vector(0)
-  # so the dashboard stays green if the exporter pod restarts or the GPU
-  # is genuinely idle (1080 Ti reports near-0W idle).
-  - name: nvidia_gpu_temp_c
-    query: max(nvidia_smi_temperature_gpu) OR vector(0)
-    suffix: "°C"
-    colors:
-      - { color: "green", min: 0, max: 70 }
-      - { color: "orange", min: 71, max: 83 }
-      - { color: "red", min: 84, max: 9999 }
-
-  - name: nvidia_gpu_util_pct
-    query: round(max(nvidia_smi_utilization_gpu_ratio) * 100) OR vector(0)
-    suffix: "%"
-
-  - name: nvidia_gpu_power_watts
-    query: round(sum(nvidia_smi_power_draw_watts), 1) OR vector(0)
-    suffix: "w"
-
-  - name: nvidia_gpu_mem_used_mb
-    query: round(sum(nvidia_smi_memory_used_bytes) / 1024 / 1024) OR vector(0)
-    suffix: " MiB"
-
-  - name: nvidia_gpu_mem_free_mb
-    query: round(sum(nvidia_smi_memory_free_bytes) / 1024 / 1024) OR vector(0)
-    suffix: " MiB"
-
   # ── Per-node power ──
   # Each stanton has a JetKVM with a DC Power Control extension inline
   # between the wall adapter and the MS-01's barrel jack. The extension's
@@ -371,10 +342,9 @@ metrics:
   # is offline or has no DC extension attached:
   #   est = total_ups_watts × node_cpu_share
   #
-  # pyro-01 is a desktop PC (no inline DC adapter applicable) so it stays
-  # on the estimate-only path. No IPMI/BMC on MS-01 (board AHWSA), no
-  # smart PDU. AMT vPro is available but doesn't expose power sensors on
-  # this firmware — see docs/infrastructure-roadmap/amt-enablement.md.
+  # No IPMI/BMC on MS-01 (board AHWSA), no smart PDU. AMT vPro is available
+  # but doesn't expose power sensors on this firmware — see
+  # docs/infrastructure-roadmap/amt-enablement.md.
   - name: node_power_est_stanton01
     query: |
       round(jetkvm_dc_power_watts{node="stanton-01"}, 1)
@@ -394,11 +364,6 @@ metrics:
       round(jetkvm_dc_power_watts{node="stanton-03"}, 1)
         OR round(scalar(sum(network_ups_tools_ups_realpower)) * (instance:node_cpu_utilisation:rate5m{instance="10.90.3.103:9100"} / scalar(sum(instance:node_cpu_utilisation:rate5m))), 1)
         OR vector(0)
-    suffix: "w"
-
-  - name: node_power_est_pyro01
-    # Desktop PC — no inline DC adapter possible. CPU-weighted estimate only.
-    query: round(scalar(sum(network_ups_tools_ups_realpower)) * (instance:node_cpu_utilisation:rate5m{instance="10.90.3.111:9100"} / scalar(sum(instance:node_cpu_utilisation:rate5m))), 1) OR vector(0)
     suffix: "w"
 
   # ── Per-node temperature ──
@@ -432,18 +397,6 @@ metrics:
       - { color: "orange", min: 80, max: 90 }
       - { color: "red", min: 90, max: 9999 }
 
-  # Pyro is the GPU node — GPU temp leads ("how hot is the 1080 Ti"). Coretemp
-  # is the fallback if the NVIDIA exporter is offline; it has no "Package id 0"
-  # label, so the fallback uses avg_over_time(max(...)) for the same
-  # sustained-not-spike treatment. (pyro-01 is currently powered down.)
-  - name: node_temp_pyro01
-    query: round(avg_over_time(max(nvidia_smi_temperature_gpu)[15m:30s]), 1) OR round(avg_over_time(max(node_hwmon_temp_celsius{kubernetes_node="pyro-01",chip=~".*coretemp.*"})[15m:30s]), 1) OR vector(0)
-    suffix: "°C"
-    colors:
-      - { color: "green", min: 0, max: 70 }
-      - { color: "orange", min: 71, max: 83 }
-      - { color: "red", min: 84, max: 9999 }
-
   # ── Per-node load (CPU utilisation %) ──
   - name: node_load_stanton01
     query: round(instance:node_cpu_utilisation:rate5m{instance="10.90.3.101:9100"} * 100, 1) OR vector(0)
@@ -469,13 +422,6 @@ metrics:
       - { color: "orange", min: 50, max: 80 }
       - { color: "red", min: 80, max: 9999 }
 
-  - name: node_load_pyro01
-    query: round(instance:node_cpu_utilisation:rate5m{instance="10.90.3.111:9100"} * 100, 1) OR vector(0)
-    suffix: "%"
-    colors:
-      - { color: "green", min: 0, max: 50 }
-      - { color: "orange", min: 50, max: 80 }
-      - { color: "red", min: 80, max: 9999 }
 
   # ── Citadel (Dell R730 via iDRAC8 ipmi-exporter) ──
   - name: node_power_citadel


### PR DESCRIPTION
pyro-01 is no longer in the cluster, so every kromgo metric tied to it read `0` permanently. Removed:

- `node_temp_pyro01`, `node_load_pyro01`, `node_power_est_pyro01`
- `nvidia_gpu_temp_c`, `nvidia_gpu_util_pct`, `nvidia_gpu_power_watts`, `nvidia_gpu_mem_used_mb`, `nvidia_gpu_mem_free_mb` — the GTX 1080 Ti lived in pyro-01, so `nvidia_smi_*` is gone with it

Also trimmed the per-node-power and observability-audit header comments that referenced pyro-01 / the nvidia exporter. **90 → 82 metrics.**

Build + YAML validated. If a GPU later lands on another node, the `nvidia_gpu_*` block is a trivial restore from git history.

> Note: the `nvidia-gpu-exporter` Deployment under `observability/exporters/` is now orphaned (was pinned to pyro-01) — separate cleanup if you want it gone too.