### PR TITLE
chore(observability): un-wire nvidia-gpu-exporter (pyro-01 decommissioned)

### DIFF
--- a/kubernetes/apps/observability/exporters/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/kustomization.yaml
@@ -12,7 +12,6 @@ resources:
   - ./jetkvm-power/ks.yaml
   - ./mariadb-exporter/ks.yaml
   - ./nut-exporter/ks.yaml
-  - ./nvidia-gpu-exporter/ks.yaml
   - ./plex-exporter/ks.yaml
   - ./smartctl-exporter/ks.yaml
   - ./snmp-exporter/ks.yaml


### PR DESCRIPTION
Phase 1 of removing the orphaned nvidia-gpu-exporter. The GTX 1080 Ti lived in pyro-01 (no longer in the cluster), so the exporter's `nvidia.com/gpu` node affinity can never schedule — the HelmRelease is idle with no pods.

Removes the `./nvidia-gpu-exporter/ks.yaml` reference from the exporters kustomization so Flux prunes the `nvidia-gpu-exporter` Kustomization CR → HelmRelease + Service.

**Files kept intentionally** — they'll be deleted in a follow-up once the resources are confirmed gone from the cluster.

Follows the kromgo metric removal (#2060).