### PR TITLE
fix(mangarr): bump to sha-0b02d8e (Kavita /api/Library/Libraries)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-e0e2889@sha256:f03161b9b8b137be125c2997bc119e92c25028dbfbd0a510583a8e96fe8ffd9d
+              tag: sha-0b02d8e@sha256:c5f9e2c6635a6972073ddf921faa50027e059fa6b27b41db537fa12d3859c8f3
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary

- Bumps mangarr image to `ghcr.io/gavinmcfall/mangarr:sha-0b02d8e@sha256:c5f9e2c6635a6972073ddf921faa50027e059fa6b27b41db537fa12d3859c8f3`
- Pulls in mangarr [PR #29](https://github.com/gavinmcfall/mangarr/pull/29): corrects the library list endpoint from `/api/Library` (returns 204 on Kavita 0.9.x) to `/api/Library/Libraries` (returns the full library array).

Resolves the live error users hit on the Settings page after PR #28:

```
Kavita unreachable: kavita list libraries decode: EOF
```

## Test plan

- [x] mangarr unit tests + vet + build clean
- [x] Verified against live cluster Kavita 0.9.0.2: `/api/Library/Libraries` returns Manga/Manhwa/Manhua array
- [ ] After Flux reconcile, Settings page Sync button populates dropdowns with real library names