### PR TITLE
feat(mangarr): bump to sha-f1332ba (Library Map: Suwayomi overrides)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-0b02d8e@sha256:c5f9e2c6635a6972073ddf921faa50027e059fa6b27b41db537fa12d3859c8f3
+              tag: sha-f1332ba@sha256:5002e8921718be6af940266c30d685a7c687be61ecc53327528eb43ac15f4da5
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary

- Bumps mangarr image to `ghcr.io/gavinmcfall/mangarr:sha-f1332ba@sha256:5002e8921718be6af940266c30d685a7c687be61ecc53327528eb43ac15f4da5`
- Lands the **Library Map** feature: Settings page gains a Suwayomi Connection panel and the "Kavita Libraries" section becomes a two-card Library Map (Default AniList Classification + Suwayomi Category Overrides). Suwayomi categories can short-circuit AniList classification and route series to the chosen Kavita library.
- Spec: [`docs/specs/2026-05-30-library-map-suwayomi.md`](https://github.com/gavinmcfall/mangarr/blob/main/docs/specs/2026-05-30-library-map-suwayomi.md)
- PRs landed in mangarr:
  - `#30` Plan A — Suwayomi client + PathCache (all 4 auth modes)
  - `#31` Plan B — classifier integration + Settings persistence
  - `#32` Plan C — UI + web endpoints + Activity log Via column

## Test plan

- [ ] Flux reconcile picks up the new digest
- [ ] Pod rolls to `sha-f1332ba` and reaches Ready
- [ ] Existing AniList classification still works (no Suwayomi configured by default)
- [ ] Suwayomi Connection panel renders at `mangarr.${SECRET_DOMAIN}/settings`
- [ ] Test button against in-cluster Suwayomi (`http://suwayomi.downloads.svc.cluster.local:4567`) reports connected + category count
- [ ] Override row mapping a real Suwayomi category to a Kavita library is persisted and takes effect on the next poll tick
- [ ] Activity log Via column renders meaningful labels (full smoke test plan to follow)