### PR TITLE
feat(mangarr): bump to sha-0e6d313 (Library Bindings v2)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-f1332ba@sha256:5002e8921718be6af940266c30d685a7c687be61ecc53327528eb43ac15f4da5
+              tag: sha-0e6d313@sha256:eaadbb4a9cfb5359dfb3649e74002ff2113563250a086f6669b6daedfd8b2f0e
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary

- Bumps mangarr from `sha-f1332ba` (Library Map) → `sha-0e6d313` (Library Bindings v2: Plan A + Plan B).
- Replaces the closed 3-type ContentType enum with user-defined bindings + priority-ordered classification rules. Users can now configure arbitrary library destinations through the Settings UI (target taxonomy: 3 Eastern + 18+ variants + Western Comics + Light Novels).
- Migration 2 auto-populates a starter set of bindings + rules from the existing v1 settings on first run, so the rollout is non-breaking. v1 model fields (LibraryRoots, KavitaLibIDsByType) stay populated for one release as a rollback safety net.

mangarr PRs:
- #33 — Plan A: data model, classifier, migrations, AniList widening
- #34 — Plan B: Settings UI, atomic POST, no-delete-while-referenced validation, activity-log Via renderer, empty states

New manifest-list digest: `sha256:eaadbb4a9cfb5359dfb3649e74002ff2113563250a086f6669b6daedfd8b2f0e`

## Test plan

- [ ] Flux reconciles HR for mangarr and pod rolls to new image.
- [ ] Pod becomes Ready within ~60s.
- [ ] Settings page loads with new Library Bindings, Classification Rules, Default Binding cards (empty-state prompts visible on first boot until Migration 2 seeds them).
- [ ] Activity log Via column renders new shapes correctly (`rule:N`, `path-rule:N`, `default-binding`, `unmatched`).
- [ ] AniList classification still works (no regression on Tranga path).
- [ ] Suwayomi category overrides still route to the configured binding.
- [ ] Rollback path: revert this commit puts the pod back on `sha-f1332ba`; v1 settings fields are still populated so the old classifier flow resumes.