### PR TITLE
chore(mangarr): bump to sha-f9ae056 (Bindings card UX polish)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-0e6d313@sha256:eaadbb4a9cfb5359dfb3649e74002ff2113563250a086f6669b6daedfd8b2f0e
+              tag: sha-f9ae056@sha256:86ebfa6277a63f975c7a0627dd4edfb9502b43b12e4adbe18b8d4436740b1cf3
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary

Iterates on the Bindings card from #2069 (`sha-0e6d313`) per visual feedback after first boot:

- Per-field labels above each input (Library Name, Library Path, Kavita Library, 18+)
- Browse-from-path button restored on Library Path
- Kavita dropdown shows "Name — /folder" and auto-fills Library Path on selection (only when empty — won't clobber a typed path)
- Delete X moved into a per-row header band, visually separated from 18+
- Card-style per-row layout with 2-col grid that collapses to 1-col on narrow screens

mangarr PR: #35  
New manifest-list digest: `sha256:86ebfa6277a63f975c7a0627dd4edfb9502b43b12e4adbe18b8d4436740b1cf3`

## Test plan

- [ ] Flux reconciles, pod rolls to new image
- [ ] Settings page renders Bindings card with the new labels + Browse button
- [ ] Picking a Kavita library auto-fills the Library Path field
- [ ] Delete X clearly separated from 18+ checkbox