### PR TITLE
chore(mangarr): bump to sha-536c108 (production bug fixes)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-f9ae056@sha256:86ebfa6277a63f975c7a0627dd4edfb9502b43b12e4adbe18b8d4436740b1cf3
+              tag: sha-536c108@sha256:8e4e989ae1aa813116a05d4bc7e143f31be3d5dde28d1df88d22ffe9934b962d
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary

Three fixes from mangarr PR #36 surfaced after a few hours of real production routing:

- **Kavita scan 400** — `/api/Library/scan?libraryId=N` (query param, no body). Previous `{libraryId:N}` body returned `HTTP 400 "libraryId must be greater than 0"` after every successful filing.
- **AniList variant-tag misses** — classifier retries with trailing parenthetical stripped (e.g. `"Dragon Ball Super (Color)"` → `"Dragon Ball Super"`) on a not-found.
- **Reclassify dropdown was dead code** — now a Binding picker writing `series.manual_binding_id`. Migration 3 adds the column. Classifier step 0 short-circuits with `Via="manual"`. For titles AniList simply doesn't catalogue (TBATE), pin once and the override survives polls.

New manifest-list digest: `sha256:8e4e989ae1aa813116a05d4bc7e143f31be3d5dde28d1df88d22ffe9934b962d`

## Test plan

- [ ] Flux reconciles, pod rolls
- [ ] Migration 3 runs clean (`store: applied migration 3 "series-manual-binding"`)
- [ ] Activity log: Kavita scan 400 entries disappear after a poll tick
- [ ] Series page: "Dragon Ball Super (Color)" classifies on next poll (retry path)
- [ ] Series page: pin "The Beginning After the End" to a Manhwa binding via dropdown — Activity log shows `Via: manual` and series files into the chosen library