### PR TITLE
chore(mangarr): bump to sha-afa5312 (preview/series UX fixes)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-536c108@sha256:8e4e989ae1aa813116a05d4bc7e143f31be3d5dde28d1df88d22ffe9934b962d
+              tag: sha-afa5312@sha256:f890ad0db1e611007183bf24b4ce01baf66972110892204a02af6b07a7c40bce
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary

Three post-#2072 UX follow-ups from mangarr PR #37:

- **Preview now respects the manual binding override.** Scanner builds fresh in-memory rows from disk — the preview path was missing the DB-side `ManualBindingID`. Previewer now looks up by source_path and threads the override into Classify.
- **Preview shows real chapter counts for unmatched rows.** Was always 0 because `previewRow.ChapterCount = len(ChapterPlans)` and unmatched rows have no plan.
- **Series page Type column** shows the bound binding's name with a green "manual" pill instead of "unknown" when `ManualBindingID` is set. Gracefully renders "deleted binding" if the override points at a removed ID.

mangarr PR: #37  
New manifest-list digest: `sha256:f890ad0db1e611007183bf24b4ce01baf66972110892204a02af6b07a7c40bce`

## Test plan

- [ ] Flux reconciles, pod rolls
- [ ] Series page: "The Beginning After the End" Type column now shows "Manhwa" (green manual pill), no longer "unknown"
- [ ] Preview page: "The Beginning After the End" moves from Unmatched to Will File with real chapter count
- [ ] Unmatched page: still correctly empty (pending series stay out of unmatched list)