### PR TITLE
chore(mangarr): bump to sha-172dbe5 (series page reflects every scanned title)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-afa5312@sha256:f890ad0db1e611007183bf24b4ce01baf66972110892204a02af6b07a7c40bce
+              tag: sha-172dbe5@sha256:b06702fa84e7078fcb1c960b914d4ee34e1dd868c064e144fd88c42ff302a9ac
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary

Fixes the Series-vs-Preview row-count mismatch from production: Series page was showing 3 titles, Preview was showing 6. Root cause: `Poller.RunOnce` only wrote series rows via `MarkUnmatched` on the failure branch — happy-path matched titles never touched the table.

mangarr PR #38 also folds in 5 review-extensions findings:
- `UpsertSeries` ON CONFLICT no longer touches `series.type` or `manual_binding_id` (prevents per-tick clobber of the FileOne-written Type and the UI-set override)
- `MarkUnmatched` is now a status-only UPDATE (no double-write per unmatched series)
- `resolveManualOverride` helper extracted, used by both RunOnce and Preview

New manifest-list digest: `sha256:b06702fa84e7078fcb1c960b914d4ee34e1dd868c064e144fd88c42ff302a9ac`

## Test plan

- [ ] Flux reconciles, pod rolls
- [ ] Series page shows all 6 titles (SOLO LEVELING, Mashle, Infinite Mage join the existing DBS/One Piece/TBATE rows)
- [ ] Reclassify dropdown is reachable for the previously-invisible 3
- [ ] Existing manual overrides on DBS / TBATE survive the upgrade (`ON CONFLICT` doesn't touch `manual_binding_id`)