### PR TITLE
feat(cortex): sustainable model ingest — models PVC RWX + model-serve 0.2.0

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -137,7 +137,7 @@ spec:
           model-serve:
             image:
               repository: ghcr.io/gavinmcfall/model-serve
-              tag: 0.1.0@sha256:a52603e552f2abe32fe58b286056b7aeff6c49b09583260873c02ccd6ea3c355
+              tag: 0.2.0@sha256:8fd38fe94b706195dd33ce59bb809b2662312f232a35cfec80b16d8548c69c89
             env:
               MODELSERVE_LISTEN: ":9090"
               MODELSERVE_ROOT: "/models"

--- a/kubernetes/apps/cortex/lighthouse/app/pvc.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/pvc.yaml
@@ -1,19 +1,19 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/persistentvolumeclaim_v1.json
-# Cluster-canonical model store (ADR 018). Mounted RW by the model-serve sidecar
-# (admin upload + serve to workers) and RO by the comfyui-master container in the
-# same pod. ceph-block RWO is fine for a single-replica master; allowVolumeExpansion
-# lets us `kubectl patch pvc` to grow when ~80% full.
+# Cluster-canonical model store (ADR 018). Served + ingested by the model-serve
+# sidecar (RW, POST /models/ingest) and read by the comfyui-master container (RO).
+# RWX ceph-filesystem so the ingest path (and future readers) co-mount without the
+# RWO single-attach constraint — i.e. add models live, no scale-down/exec.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: lighthouse-models
 spec:
-  accessModes: ["ReadWriteOnce"]
+  accessModes: ["ReadWriteMany"]
   resources:
     requests:
       storage: 300Gi
-  storageClassName: ceph-block
+  storageClassName: ceph-filesystem
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/persistentvolumeclaim_v1.json
 # Per-user output buckets (/output/<user>/). RWX so Plan 6 portal can multi-read.


### PR DESCRIPTION
Replaces the scale-down+temp-pod model-upload hack with a proper ingestion path.

- **model-serve 0.2.0** adds token-auth `POST /models/ingest {url, dest, sha256?}` — the Go binary fetches the source server-side, streams to a temp file (hashing), optionally verifies the sha256, atomically renames into the store, and returns the computed sha256. Works in the distroless image (no shell/exec), no pod scaling, GitOps/CLI-triggerable. (`ghcr.io/gavinmcfall/model-serve:0.2.0@sha256:8fd38fe9…`)
- **lighthouse-models PVC**: RWO ceph-block → **RWX ceph-filesystem** so the ingest path (and future readers) co-mount alongside the running master — no single-attach constraint.

"Add a model" becomes one authenticated API call. The previous RWO upload methods (kubectl cp / sync-job) were dead-on-arrival against the distroless image + single-attach.

**One-time migration after merge:** the existing empty RWO PVC must be deleted so Flux reprovisions it RWX (accessMode/class immutable). No data loss (no models uploaded yet).