### PR TITLE
chore(mangarr): bump to sha-554d273 (v3.0 bulk-downloader)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-172dbe5@sha256:b06702fa84e7078fcb1c960b914d4ee34e1dd868c064e144fd88c42ff302a9ac
+              tag: sha-554d273@sha256:fa8a6fd9e9e87e4742f2e287aeb71acd7bc60309fad311d64c25c52360eef42c
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
- Ships v3.0 bulk-downloader end-to-end (mangarr PRs #39 Plan A + #40 Plan B)
- Operator multi-selects from /library, gets per-provider confirmation modal, watches /downloads dashboard live
- Per-source FIFO + backoff ladder (5s/15s/60s/300s → errored at 5 consec failures) protects Suwayomi sources from rate-bans

## Test plan
- [ ] Pod rolls to sha-554d273 (digest sha256:fa8a6fd9…)
- [ ] /library lists Suwayomi-synced series with lazy missing counts
- [ ] Multi-select + Download Missing → confirmation modal renders per-provider breakdown
- [ ] /downloads shows live progress (3s HTMX poll)
- [ ] Pause / resume / delete row controls work via HX-Request row swaps
- [ ] Settings → Bulk Download card persists 3 pacing knobs