### PR TITLE
chore(mangarr): bump to sha-785ab0b (v3.0 /library wiring fix)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-554d273@sha256:fa8a6fd9e9e87e4742f2e287aeb71acd7bc60309fad311d64c25c52360eef42c
+              tag: sha-785ab0b@sha256:761e699cd87f6379035efd18c979df21f4f8d605066473385ada574463de17c0
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Wires the fresh-per-call Suwayomi adapter into the web handler so `/library` and `/api/bulk` actually work post-v3.0. Fixes mangarr PR #41.

## Test plan
- [ ] Pod rolls to sha-785ab0b (digest sha256:761e699c…)
- [ ] /library no longer shows "Configure Suwayomi" empty state
- [ ] Sync button populates the table
- [ ] POST /api/bulk no longer returns 503