### PR TITLE
fix(lighthouse): HTTPRoute backendRef → lighthouse-app

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/httproute.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/httproute.yaml
@@ -20,5 +20,5 @@ spec:
     - matches:
         - path: { type: PathPrefix, value: / }
       backendRefs:
-        - name: lighthouse
+        - name: lighthouse-app
           port: 8000


### PR DESCRIPTION
## Summary

- HTTPRoute `cortex/lighthouse` was referencing Service `lighthouse`, but the bjw-s app-template renders Services as `{release}-{service-key}` — so HelmRelease `lighthouse` with `service.app:` produces Service `lighthouse-app`.
- Fix: one-character backendRef change `name: lighthouse` → `name: lighthouse-app`.

## Symptom (pre-fix)

`https://lighthouse.nerdz.cloud/` → Pocket-ID auth succeeds → **Envoy returns 404 on every request**.

HTTPRoute status confirmed the cause:

```
Accepted: True
ResolvedRefs: False
  message: "Failed to process route rule 0 backendRef 0: service cortex/lighthouse not found."
```

`kubectl -n cortex get svc` shows the actual rendered names:

```
lighthouse-app           ClusterIP      8000/TCP
lighthouse-model-serve   LoadBalancer   9090:30269/TCP
```

## Test plan

- [ ] Flux reconciles `cortex/lighthouse` HTTPRoute
- [ ] `kubectl -n cortex get httproute lighthouse -o yaml` shows `ResolvedRefs: True`
- [ ] `https://lighthouse.nerdz.cloud/` returns the ComfyUI master UI (or its actual response — proxy-defined) after Pocket-ID auth, not a 404
- [ ] Smoke A1 still passes (no regression to API path routing)