### PR TITLE
chore(mangarr): bump to sha-e1de293 (/library lazy-storm fix)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-785ab0b@sha256:761e699cd87f6379035efd18c979df21f4f8d605066473385ada574463de17c0
+              tag: sha-e1de293@sha256:76d91e65e37738bae2faddb9a1903fd954d1916e4c7ec99eeb522d8486f166be
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Fixes the Download-Missing-does-nothing bug — counts now resolve during Sync via bounded-parallel ListChapters and render inline. Form's hx-target moved to body for bulletproof modal swap. Fixes mangarr PR #42.

## Test plan
- [ ] Pod rolls to sha-e1de293 (digest sha256:76d91e65…)
- [ ] /library renders counts inline (no rows stuck at "…")
- [ ] Sync takes ~few seconds, then page reloads with values
- [ ] Download Missing → modal overlay appears
- [ ] Queue downloads → /downloads shows the new job