### PR TITLE
chore(lighthouse): bump model-serve 0.2.0 → 0.3.0

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -137,7 +137,7 @@ spec:
           model-serve:
             image:
               repository: ghcr.io/gavinmcfall/model-serve
-              tag: 0.2.0@sha256:8fd38fe94b706195dd33ce59bb809b2662312f232a35cfec80b16d8548c69c89
+              tag: 0.3.0@sha256:45003e76eb41eea52331483c20646b1907f03fdf1e3099baf4f6a0e88e3e015c
             env:
               MODELSERVE_LISTEN: ":9090"
               MODELSERVE_ROOT: "/models"


### PR DESCRIPTION
## Summary

Pins `model-serve` to v0.3.0 (digest `sha256:45003e76…`), which adds the optional `auth` field on `POST /models/ingest` from gavinmcfall/containers#1.

Unblocks HF-gated repo ingest (SD 3.5 Medium, Flux dev, Flux Krea dev, etc.) by forwarding a caller-supplied `Authorization` header to the source fetch. Backward-compatible — existing ingest requests without `auth` continue to work unchanged.

## Test plan

- [ ] Flux reconciles cortex/lighthouse kustomization
- [ ] Pod cycles to model-serve `0.3.0` (verify with `kubectl -n cortex get pod -l app.kubernetes.io/name=lighthouse -o jsonpath='{.items[0].spec.containers[?(@.name=="model-serve")].image}'`)
- [ ] Existing non-gated ingest still works (regression)
- [ ] SD 3.5 Medium ingest succeeds with `SOURCE_AUTH="Bearer hf_…"` set per `docs/operations/model-acquisition.md`