### PR TITLE
fix(lighthouse): bump main container memory limit 8Gi → 24Gi

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -77,9 +77,15 @@ spec:
             resources:
               requests:
                 cpu: 500m
-                memory: 2Gi
+                memory: 4Gi
               limits:
-                memory: 8Gi
+                # Bumped 8Gi → 24Gi after OOMKill 2026-06-02 during first /distributed/queue
+                # smoke (exit 137). Master is --cpu orchestrator-only per design but the
+                # comfy-aimdo plugin pins ~14GB host RAM regardless of --cpu, AND ComfyUI
+                # appears to load the checkpoint (~6.5GB for SDXL) at validation time
+                # before dispatch. 24Gi covers comfy-aimdo pin + SDXL load + ~3-4Gi buffer.
+                # Node stanton-03 has 95GB memory, 51% allocated — comfortable.
+                memory: 24Gi
             securityContext:
               # ComfyUI + torch write caches under HOME=/app (image rootfs), so
               # this container can NOT use a read-only root filesystem.


### PR DESCRIPTION
## Summary

OOMKilled (exit 137) during first `/distributed/queue` smoke 2026-06-02 ~18:36 NZT. Master accepted the prompt and returned a `prompt_id`, then loaded the SDXL checkpoint into memory for dispatch validation, hit the 8Gi limit, killed.

Architecturally master is `--cpu` orchestrator-only per ADR 015 + design and SHOULDN'T need to load model weights — but in practice:
- `comfy-aimdo` plugin pins ~14GB host RAM regardless of `--cpu` mode (same plugin that OOM'd Vengeance's 16GB WSL distro yesterday)
- ComfyUI validates checkpoint references at queue time which appears to trigger a load even when `delegate_master=true`

## Budget breakdown (24Gi limit)

| | Memory |
|---|---|
| comfy-aimdo pinned host RAM | ~14 GiB |
| SDXL checkpoint load (worst case) | ~6.5 GiB |
| ComfyUI baseline + working buffer | ~3.5 GiB |

Requests also bumped 2Gi → 4Gi to give the scheduler a more realistic baseline (master idle is ~2GB; 4Gi reservation prevents the pod from being squeezed out under node pressure).

## Node capacity check

stanton-03 has 95GB memory, 51% allocated. 24Gi pod limit fits comfortably with headroom for other workloads.

## Test plan

- [ ] Merge → Flux reconciles cortex/lighthouse kustomization
- [ ] Pod cycles with new memory limit (`kubectl -n cortex get pod -l app.kubernetes.io/name=lighthouse -o jsonpath='{.items[0].spec.containers[?(@.name=="main")].resources.limits.memory}'` → `24Gi`)
- [ ] Retry `/distributed/queue` smoke; no OOMKill; render dispatches to worker; file lands at `/app/output/<user>/workshop-sdxl_*.png`

## Phase-2 follow-up (not blocking)

Worth investigating why master loads models when `--cpu master_delegate_only=true` is set. May be a `comfy-aimdo` config knob to disable pinning on orchestrator-only nodes, OR a ComfyUI flag to skip checkpoint preload at validation time. Reducing master's memory footprint back to ~4-8GB would be the right long-term posture.