### PR TITLE
feat(lighthouse): expose licence-gate via Cilium LB for worker callbacks

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -184,9 +184,20 @@ spec:
     service:
       app:
         controller: lighthouse
+        # LoadBalancer with Cilium LB-IPAM IP so ComfyUI workers (on LAN, outside
+        # cluster) can POST /distributed/job_complete callbacks back to master.
+        # The licence-gate proxy on :8000 forwards everything to master :8188 by
+        # default, so callback paths pass through transparently — workers never
+        # touch master :8188 directly (only-via-licence-gate posture preserved).
+        # externalTrafficPolicy: Local preserves worker source IP for NetworkPolicy.
+        type: LoadBalancer
+        externalTrafficPolicy: Local
+        annotations:
+          io.cilium/lb-ipam-ips: ${LIGHTHOUSE_APP_LBIP}
         ports:
-          # The licence-gate proxy — the OIDC-gated family surface (via Envoy).
-          # ComfyUI :8188 is never Service-exposed.
+          # The licence-gate proxy — OIDC-gated family surface (via Envoy for
+          # browsers) AND worker-callback surface (direct LAN IP for workers
+          # POSTing /distributed/job_complete). ComfyUI :8188 is never Service-exposed.
           http:
             port: 8000
       # model-serve gets a LAN IP (Cilium LB-IPAM) so the external GPU workers can

--- a/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
@@ -1,6 +1,6 @@
 {
   "master": {
-    "host": "localhost"
+    "host": "http://10.99.8.216:8000"
   },
   "workers": [
     {

--- a/kubernetes/components/common/cluster-vars/cluster-settings.yaml
+++ b/kubernetes/components/common/cluster-vars/cluster-settings.yaml
@@ -46,6 +46,7 @@ data:
   POSTGRES18_CLUSTER_LBIP: "10.99.8.213"
   ANYTYPE_SYNC_LBIP: "10.99.8.214"
   LIGHTHOUSE_MODELSERVE_LBIP: "10.99.8.215"
+  LIGHTHOUSE_APP_LBIP: "10.99.8.216"  # licence-gate :8000 exposed to LAN so ComfyUI workers can POST /distributed/job_complete callbacks back to master (proxy forwards transparently to master :8188)
 
   # Dragonfly Redis DB Index Allocation:
   # | Index | App                      |


### PR DESCRIPTION
## Summary

ComfyUI workers (Vengeance, Vixen) on LAN need to POST `/distributed/job_complete` callbacks back to the cluster master after rendering, to deliver completed images. The current setup has them try `http://localhost:8188` (because `master.host: "localhost"` in gpu_config.json) — but **localhost from the worker's view is the worker itself, not master**, so the callback 404s and renders never make it back to the cluster.

Three-file change to fix:

1. **`cluster-settings.yaml`** — add `LIGHTHOUSE_APP_LBIP: "10.99.8.216"` (next free in the Cilium LB-IPAM pool, adjacent to model-serve's 10.99.8.215)
2. **`helmrelease.yaml` service.app** — change to `type: LoadBalancer` with the Cilium LB-IPAM annotation + `externalTrafficPolicy: Local` (matches the model-serve pattern). Licence-gate :8000 now exposed at 10.99.8.216
3. **`gpu_config.json`** — change `master.host` from `"localhost"` to `"http://10.99.8.216:8000"`

## Why this preserves the only-via-licence-gate security posture

Workers don't reach ComfyUI master `:8188` directly. The licence-gate proxy on `:8000` already forwards everything to master `:8188` by default — so callback paths like `/distributed/job_complete` pass through transparently. Master is still NOT Service-exposed.

The trade-off is exposing licence-gate (:8000) on two ingress paths:
- **Envoy `lighthouse.nerdz.cloud` (existing)** — OIDC-gated, family/admin browser identities
- **Cilium LB 10.99.8.216 (new)** — LAN-only, no OIDC; relied on for worker callbacks. **NetworkPolicy should scope this LAN ingress to the worker subnet only** (follow-up cleanup; matches the model-serve LB pattern which uses `externalTrafficPolicy: Local` + bearer-token gating)

## Discovery context

First successful `/distributed/queue` smoke 2026-06-02 ~19:00 NZT (commit chain `c77c18d` lighthouse + `3bc30dc4d` home-ops master 24Gi bump + ComfyUI-Distributed install on Vengeance) revealed Vengeance was actually rendering SDXL (27s + 10s cached) but the callback 404'd because `localhost:8188` resolved to Vengeance itself. Master's `gpu_config.json` had `master.host: "localhost"` which is the upstream plugin's default but only correct for single-machine setups.

## Test plan

- [ ] Merge → Flux reconciles cortex/lighthouse → kubectl -n cortex get svc → lighthouse-app shows TYPE=LoadBalancer EXTERNAL-IP=10.99.8.216
- [ ] Pod cycles with new ConfigMap (gpu_config.json with new master.host)
- [ ] From a LAN box: `curl http://10.99.8.216:8000/distributed/system_info` → 200 (proves the LB IP routes to licence-gate → forwards to master)
- [ ] Re-run smoke; render dispatches to Vengeance; callback succeeds; file lands at `/app/output/dopamine-racing/workshop-sdxl_*.png` via DistributedCollector → SaveImage chain