### PR TITLE
fix(lighthouse): NetworkPolicy allow worker LAN on :8000 for callbacks

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/networkpolicy.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/networkpolicy.yaml
@@ -1,9 +1,15 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/networking.k8s.io/networkpolicy_v1.json
-# Only-via-Envoy: the licence-gate proxy (:8000) accepts ingress ONLY from the
-# Envoy Gateway pods (network ns). This is the guarantee that makes the proxy's
-# decode-not-verify JWT handling safe — nothing can hand it an unverified token
-# by bypassing Envoy. ComfyUI :8188 and model-serve :9090 take no cluster ingress.
+# licence-gate proxy (:8000) accepts ingress from TWO sources:
+#   1. Envoy Gateway pods (network ns) — OIDC-gated family/browser surface where
+#      Envoy verifies the JWT before forwarding. Guarantee that makes the proxy's
+#      decode-not-verify safe for family identities.
+#   2. GPU worker LAN subnet (10.90.101.0/24) — required for ComfyUI workers to
+#      POST /distributed/job_complete callbacks back to master after rendering.
+#      Workers authenticate with the brand bearer token (LIGHTHOUSE_DR_TOKEN),
+#      validated by proxy via crypto/subtle constant-time compare.
+#
+# ComfyUI :8188 takes no cluster ingress (only-via-licence-gate posture).
 #
 # Egress is intentionally NOT restricted here: the master must reach the external
 # LAN GPU workers (vengeancepc.internal / vixenpc.internal :8188), and the
@@ -21,7 +27,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # licence-gate proxy — only from Envoy Gateway (network ns).
+    # licence-gate proxy (:8000) — Envoy Gateway path (family/browser identities).
     - from:
         - namespaceSelector:
             matchLabels:
@@ -33,11 +39,19 @@ spec:
       ports:
         - port: 8000
           protocol: TCP
-    # model-serve (:9090) — only from the GPU worker LAN subnet, so external
-    # workers can fetch models (ADR 018). Bearer-token gated on top of this.
-    # NOTE: confirm 10.90.101.0/24 is the worker subnet; relies on the Service's
-    # externalTrafficPolicy: Local preserving the worker source IP. Fails closed
-    # (workers blocked) if the CIDR is wrong — not an exposure.
+    # licence-gate proxy (:8000) — GPU worker LAN subnet path (worker callbacks).
+    # ComfyUI workers POST /distributed/job_complete (and friends) back to master
+    # via the LB IP 10.99.8.216 → this Service :8000. Proxy validates brand bearer
+    # token before forwarding. Relies on externalTrafficPolicy: Local preserving
+    # worker source IP. Fails closed if CIDR is wrong — not an exposure.
+    - from:
+        - ipBlock:
+            cidr: 10.90.101.0/24
+      ports:
+        - port: 8000
+          protocol: TCP
+    # model-serve (:9090) — GPU worker LAN subnet, for workers fetching models
+    # (ADR 018). Bearer-token gated on top of this.
     - from:
         - ipBlock:
             cidr: 10.90.101.0/24


### PR DESCRIPTION
## Summary

Follow-up to #2094. PR #2094 exposed licence-gate :8000 at Cilium LB IP 10.99.8.216 so workers could POST `/distributed/job_complete` back to master — but the existing NetworkPolicy `lighthouse-only-from-envoy` only allows port 8000 ingress from Envoy Gateway pods. Worker LAN traffic to 10.99.8.216:8000 was **denied at the NetworkPolicy layer** even though the LB allocated correctly.

**Smoking gun (after #2094 deployed):** `curl http://10.99.8.216:8000/distributed/system_info` from VengeancePC hangs forever (no SYN-ACK because NetworkPolicy drops at pod ingress).

## Change

Add a new ingress rule allowing worker LAN subnet `10.90.101.0/24` on port 8000, mirroring the existing pattern for port 9090 (model-serve).

## Security posture

With this change there are TWO authorized sources to licence-gate :8000:

1. **Envoy Gateway** — OIDC-verified family/browser identities (unchanged)
2. **Worker LAN subnet** — brand-bearer-token-validated worker callbacks (new)

The decode-not-verify JWT pattern still relies on Envoy for family identities — worker LAN ingress carries `LIGHTHOUSE_DR_TOKEN` Bearer which the proxy validates via `crypto/subtle` constant-time compare. Two distinct auth modes, two distinct ingress paths.

Verified worker IPs are in this subnet (vengeance: 10.90.101.86, vixen: 10.90.101.79).

## Test plan

- [ ] Merge → Flux reconciles → NetworkPolicy updated
- [ ] From VengeancePC: `curl http://10.99.8.216:8000/distributed/system_info` returns `{"status": "success", ...}`
- [ ] Re-run smoke; render dispatches; callback succeeds; file at `/app/output/dopamine-racing/workshop-sdxl_*.png`