### PR TITLE
feat(shelfmark): Anna's Archive book downloader with pocket-id SSO

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
   - ./readarr/ks.yaml
   - ./recyclarr/ks.yaml
   - ./sabnzbd/ks.yaml
+  - ./shelfmark/ks.yaml
   - ./sonarr/ks.yaml
   - ./sonarr-foreign/ks.yaml
   - ./sonarr-uhd/ks.yaml

--- a/kubernetes/apps/downloads/shelfmark/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/shelfmark/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: shelfmark
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: shelfmark-secret
+    template:
+      engineVersion: v2
+      data:
+        # 1Password item "shelfmark" must hold these fields:
+        #   AA_DONATOR_KEY            -> AA fast downloads
+        #   SHELFMARK_OIDC_CLIENT_ID  -> from the pocket-id OAuth client
+        #   SHELFMARK_OIDC_CLIENT_SECRET
+        AA_DONATOR_KEY: "{{ .AA_DONATOR_KEY }}"
+        OIDC_CLIENT_ID: "{{ .SHELFMARK_OIDC_CLIENT_ID }}"
+        OIDC_CLIENT_SECRET: "{{ .SHELFMARK_OIDC_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: shelfmark

--- a/kubernetes/apps/downloads/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/shelfmark/app/helmrelease.yaml
@@ -1,0 +1,141 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app shelfmark
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: storage
+  values:
+    controllers:
+      shelfmark:
+        labels:
+          nfsMount: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Pre-create the ingest folder on the shared NFS share. Shelfmark
+          # downloads land here; the existing local Calibre workflow picks them
+          # up (fix metadata -> convert -> file into the genre tree).
+          01-init-inbox:
+            image:
+              repository: docker.io/library/busybox
+              tag: "1.36"
+            command:
+              - sh
+              - -c
+              - |
+                set -e
+                mkdir -p /media/Library/Books/_inbox
+                ls -ld /media/Library/Books/_inbox
+        containers:
+          app:
+            image:
+              repository: ghcr.io/calibrain/shelfmark
+              tag: 1.3.0@sha256:e891eda444b261da48a839db652034bce4e20ac09c167f14adf939dedf96b572
+            env:
+              TZ: ${TIMEZONE}
+              FLASK_PORT: "8084"
+              # Downloads drop straight into the Calibre inbox on NFS.
+              INGEST_DIR: /media/Library/Books/_inbox
+              # --- SSO via pocket-id (OIDC) ---
+              # Callback to register in pocket-id:
+              #   https://shelfmark.${SECRET_DOMAIN}/api/auth/oidc/callback
+              AUTH_METHOD: oidc
+              OIDC_DISCOVERY_URL: https://id.${SECRET_DOMAIN}/.well-known/openid-configuration
+              # OIDC_AUTO_PROVISION defaults true -> first OIDC login auto-creates the user.
+              # Local admin login stays enabled as a fallback (not disabled yet).
+            envFrom:
+              # AA_DONATOR_KEY + OIDC_CLIENT_ID/SECRET from the ExternalSecret
+              - secretRef:
+                  name: shelfmark-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 8084
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      labels:
+        nfsMount: "true"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 8084
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Downloads
+          gethomepage.dev/name: Shelfmark
+          gethomepage.dev/app: *app
+          gethomepage.dev/icon: mdi-book-arrow-down
+          gethomepage.dev/description: Anna's Archive / IRC book downloader
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+    persistence:
+      config:
+        existingClaim: *app
+        globalMounts:
+          - path: /config
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /media
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/downloads/shelfmark/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/shelfmark/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/keda/nfs-scaler
+  - ../../../../components/volsync-standard
+  - ../../../../components/priority/priority-06

--- a/kubernetes/apps/downloads/shelfmark/ks.yaml
+++ b/kubernetes/apps/downloads/shelfmark/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app shelfmark
+  namespace: &namespace downloads
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: volsync
+      namespace: storage
+  path: ./kubernetes/apps/downloads/shelfmark/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_MINUTE: "20"
+      VOLSYNC_B2_MINUTE: "50"
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-block
+      VOLSYNC_ACCESSMODES: ReadWriteOnce


### PR DESCRIPTION
## What
Deploys **Shelfmark** to the `downloads` namespace — an Anna's Archive / IRC book downloader that feeds the existing local Calibre workflow.

## How it fits
Fetched books land in the shared NFS inbox `/media/Library/Books/_inbox`; desktop Calibre picks them up (metadata fix → convert → file into the genre tree). No change to Calibre-Web / Audiobookshelf.

## Details
- Image `ghcr.io/calibrain/shelfmark:1.3.0` (digest-pinned), port 8084, internal route `shelfmark.${SECRET_DOMAIN}`.
- Runs 568/568 + supplementalGroups [10000] (matches the media share); VolSync-backed config PVC.
- **AA fast downloads** via `AA_DONATOR_KEY`.
- **SSO via pocket-id (OIDC)**: `AUTH_METHOD=oidc`, discovery `id.${SECRET_DOMAIN}`; local admin kept as fallback; users auto-provisioned.

## Prereqs (already done by owner)
- 1Password item `shelfmark` with `AA_DONATOR_KEY`, `SHELFMARK_OIDC_CLIENT_ID`, `SHELFMARK_OIDC_CLIENT_SECRET`.
- pocket-id confidential client, callback `https://shelfmark.${SECRET_DOMAIN}/api/auth/oidc/callback`.

## Validation
`task kubernetes:kubeconform` → `Kustomization shelfmark is valid`.

## Post-merge
Open `shelfmark.${SECRET_DOMAIN}` → set Anna's Archive as source → **Test Connection** on OIDC before first login.