### PR TITLE
chore(mangarr): bump to sha-1aa4595 (modal/activity/filter + sidebar badge)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-e1de293@sha256:76d91e65e37738bae2faddb9a1903fd954d1916e4c7ec99eeb522d8486f166be
+              tag: sha-1aa4595@sha256:677e90cd0c0dbc57ef380b8ebe23aab0c0aeaaa25c496289493f1c0fe05b4e27
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Two mangarr PRs bundled in one pod-roll to avoid double-churning Gavin's in-flight bulk downloads:
- **#43** — modal Cancel + Queue-downloads-navigates + ActionBulkQueued activity row + /library search/sort
- **#44** — live Downloads-in-flight sidebar badge

## Test plan
- [ ] Pod rolls to sha-1aa4595 (digest sha256:677e90cd…)
- [ ] Modal Cancel dismisses the overlay
- [ ] Queue downloads → navigates to /downloads, modal gone
- [ ] Activity log shows `bulk-queued` rows with `Via=bulk:<provider>`
- [ ] /library filter input narrows by title/source substring
- [ ] Column headers sort ASC/DESC with ▲/▼ indicator
- [ ] Sidebar shows `Downloads [N]` badge while jobs are running
- [ ] In-flight One Piece / Bbato / FlameScans downloads resume cleanly