### PR TITLE
feat(bookshelf): Readarr revival for automated author monitoring

### DIFF
--- a/kubernetes/apps/downloads/bookshelf/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/bookshelf/app/externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bookshelf
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: bookshelf-secret
+    template:
+      engineVersion: v2
+      data:
+        # App — 1Password item "bookshelf" must hold:
+        #   BOOKSHELF__API_KEY, BOOKSHELF__POSTGRES_USER, BOOKSHELF__POSTGRES_PASSWORD
+        READARR__API_KEY: "{{ .BOOKSHELF__API_KEY }}"
+        # Postgres (standard Servarr double-underscore schema)
+        READARR__POSTGRES__HOST: &dbHost postgres18-cluster-rw.database.svc.cluster.local
+        READARR__POSTGRES__PORT: "5432"
+        READARR__POSTGRES__USER: &dbUser "{{ .BOOKSHELF__POSTGRES_USER }}"
+        READARR__POSTGRES__PASSWORD: &dbPass "{{ .BOOKSHELF__POSTGRES_PASSWORD }}"
+        READARR__POSTGRES__MAINDB: bookshelf_main
+        READARR__POSTGRES__LOGDB: bookshelf_log
+        READARR__POSTGRES__CACHEDB: bookshelf_cache
+        # Postgres Init (creates the fresh DBs + user)
+        INIT_POSTGRES_DBNAME: bookshelf_main bookshelf_log bookshelf_cache
+        INIT_POSTGRES_HOST: *dbHost
+        INIT_POSTGRES_USER: *dbUser
+        INIT_POSTGRES_PASS: *dbPass
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: bookshelf
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/downloads/bookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bookshelf/app/helmrelease.yaml
@@ -1,0 +1,112 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app bookshelf
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: storage
+  values:
+    controllers:
+      bookshelf:
+        labels:
+          nfsMount: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6.0@sha256:86a1992d46273c58fd4ad95b626081dfaabfe16bd56944675169e406d1a660dd
+              pullPolicy: IfNotPresent
+            envFrom: &envFrom
+              - secretRef:
+                  name: bookshelf-secret
+        containers:
+          app:
+            # bookshelf = maintained Readarr revival (pennydreadful) with Hardcover
+            # metadata baked in. Uses the standard Servarr READARR__* env schema.
+            image:
+              repository: ghcr.io/pennydreadful/bookshelf
+              tag: hardcover-v0.4.19.45@sha256:8e32af474bd3b8af6fd6fe1d988db580f6dc2c8700deec298fb658ac1266c1ed
+            env:
+              READARR__APP__INSTANCENAME: Bookshelf
+              READARR__APP__THEME: dark
+              READARR__AUTH__METHOD: External
+              READARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              READARR__LOG__LEVEL: info
+              READARR__SERVER__PORT: &port 80
+              TZ: ${TIMEZONE}
+            envFrom: *envFrom
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Downloads
+          gethomepage.dev/name: Bookshelf
+          gethomepage.dev/app: *app
+          gethomepage.dev/icon: readarr.png
+          gethomepage.dev/description: eBook/Audiobook author monitoring
+          gethomepage.dev/widget.type: readarr
+          gethomepage.dev/widget.url: http://bookshelf.downloads
+          gethomepage.dev/widget.key: "{{ `{{HOMEPAGE_VAR_BOOKSHELF_TOKEN}}` }}"
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+    persistence:
+      config:
+        existingClaim: *app
+      tmp:
+        type: emptyDir
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /media

--- a/kubernetes/apps/downloads/bookshelf/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/bookshelf/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/keda/nfs-scaler
+  - ../../../../components/volsync-standard
+  - ../../../../components/priority/priority-06

--- a/kubernetes/apps/downloads/bookshelf/ks.yaml
+++ b/kubernetes/apps/downloads/bookshelf/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bookshelf
+  namespace: &namespace downloads
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-postgres18-cluster
+      namespace: database
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: volsync
+      namespace: storage
+  path: ./kubernetes/apps/downloads/bookshelf/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_MINUTE: "33"
+      VOLSYNC_B2_MINUTE: "56"

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./bazarr/ks.yaml
   - ./bazarr-foreign/ks.yaml
   - ./bazarr-uhd/ks.yaml
+  - ./bookshelf/ks.yaml
   - ./cross-seed/ks.yaml
   - ./dashbrr/ks.yaml
   - ./flaresolverr/ks.yaml

--- a/kubernetes/apps/home/homepage/app/config/services.yaml
+++ b/kubernetes/apps/home/homepage/app/config/services.yaml
@@ -101,6 +101,14 @@
           type: radarr
           url: http://radarr-uhd.downloads
           key: {{HOMEPAGE_VAR_RADARR_UHD_TOKEN}}
+    - Bookshelf:
+        href: https://bookshelf.${SECRET_DOMAIN}
+        icon: readarr.png
+        description: eBook/Audiobook author monitoring
+        widget:
+          type: readarr
+          url: http://bookshelf.downloads
+          key: {{HOMEPAGE_VAR_BOOKSHELF_TOKEN}}
     - Bazarr:
         href: https://bazarr.${SECRET_DOMAIN}
         icon: bazarr.png

--- a/kubernetes/apps/home/homepage/app/externalsecret.yaml
+++ b/kubernetes/apps/home/homepage/app/externalsecret.yaml
@@ -27,6 +27,7 @@ spec:
         HOMEPAGE_VAR_PROWLARR_TOKEN: "{{ .PROWLARR_API_KEY }}"
         HOMEPAGE_VAR_QBITTORRENT_USERNAME: "{{ .QBITTORRENT_USERNAME }}"
         HOMEPAGE_VAR_QBITTORRENT_PASSWORD: "{{ .QBITTORRENT_PASSWORD }}"
+        HOMEPAGE_VAR_BOOKSHELF_TOKEN: "{{ .BOOKSHELF__API_KEY }}"
         HOMEPAGE_VAR_RADARR_TOKEN: "{{ .RADARR_API_KEY }}"
         HOMEPAGE_VAR_RADARR_UHD_TOKEN: "{{ .RADARR_UHD_API_KEY }}"
         HOMEPAGE_VAR_SABNZBD_TOKEN: "{{ .SABNZBD_API_KEY }}"
@@ -60,6 +61,8 @@ spec:
         key: audiobookshelf
     - extract:
         key: bazarr
+    - extract:
+        key: bookshelf
     - extract:
         key: cloudflare
     - extract:


### PR DESCRIPTION
## What
Brings back **automated author-monitoring** (the gap Shelfmark doesn't fill) using **bookshelf** (pennydreadful) — the Readarr codebase with **working Hardcover metadata baked in**, so it doesn't suffer Readarr's defunct-metadata fate. Same provider as Shelfmark = consistent.

## Details
- Image `ghcr.io/pennydreadful/bookshelf:hardcover-v0.4.19.45` (digest-pinned), port 80, internal route `bookshelf.${SECRET_DOMAIN}`, 568/568 + supplementalGroups [10000], NFS media.
- **Fresh CNPG DBs** `bookshelf_main/log/cache` via the standard Servarr **`READARR__POSTGRES__*`** schema (double-underscore — the pennydreadful image is vanilla Readarr, not the home-operations single-underscore variant the old app used).
- Modeled on the retired Readarr app; homepage tile re-added (readarr widget type, API-compatible).
- Monitors authors → auto-grabs new ebook/audiobook releases via existing Prowlarr + qB/SAB.

## Prereq (owner)
1Password item `bookshelf` with: `BOOKSHELF__API_KEY`, `BOOKSHELF__POSTGRES_USER`, `BOOKSHELF__POSTGRES_PASSWORD`.

## Post-merge
Add author library; configure **Discord** webhook in Settings → Connect for new-book notifications.

## Validation
`task kubernetes:kubeconform` → `Kustomization bookshelf is valid`.