### PR TITLE
chore(mangarr): bump to sha-2e8c7e1 (stalled-job detector)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-1aa4595@sha256:677e90cd0c0dbc57ef380b8ebe23aab0c0aeaaa25c496289493f1c0fe05b4e27
+              tag: sha-2e8c7e1@sha256:a382441cd210a90548000538b857c00a06efd36edc59dc5748a15c752d5b8e25
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Stalled-job detector ships — chapters Suwayomi gives up on (empty pageList, max retries) are auto-errored so the job completes cleanly within the stall timeout instead of wedging like Job #6 / Second Life Ranker / Bbato Chapter 191 did for 9 hours yesterday. Fixes mangarr PR #46.

## Test plan
- [ ] Pod rolls to sha-2e8c7e1 (digest sha256:a382441c…)
- [ ] /settings shows three new Bulk Download inputs (stall timeout 30 / max retries 3 / disable-auto-error-empty unchecked)
- [ ] No active jobs → sidebar Downloads has no badge
- [ ] (Future-test, when a real stall happens) job auto-completes within ~30 min, /downloads shows the row with "N missing" red pill, /activity has bulk-chapter-errored entry