### PR TITLE
chore(lighthouse): bump licence-gate 0.1.1 → 0.1.2 (Origin strip fix)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -96,7 +96,7 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              tag: 0.1.1@sha256:9605b5da3d83ebd6256900f0c5c2c1672d642d3ddae9833f72c3c0ba7c831e54
+              tag: 0.1.2@sha256:a704baeae496eae620d9f2f9b7c1c7a35838edf11f04c0d2c756e78b648996ad
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"


### PR DESCRIPTION
## Summary

Pins `licence-gate` to v0.1.2 (digest `sha256:a704baeae496…`), which strips the `Origin` header on forward to upstream (containers#2 fix).

## Why

ComfyUI master has built-in DNS-rebinding protection that returns 403 when the request's `Origin` doesn't match its `Host`. Behind the licence-gate proxy, `Host` gets rewritten to `127.0.0.1:8188` (upstream loopback) but `Origin` was passed through unchanged as `lighthouse.nerdz.cloud` (browser-set) — causing master to reject every browser-originated request with:

```
WARNING: request with non matching host and origin 127.0.0.1 != lighthouse.nerdz.cloud, returning 403
```

This unblocks **S1 (family-adult OIDC browser flow)** which was the only remaining critical-path Plan-1 acceptance scenario blocked on technical issues (A2-A5 just need a second family-adult identity to log in once).

## Why the proxy-side fix, not master-side `--enable-cors-header`

Both fixes work. Gavin's call: *"nothing is more permanent than a temporary solution"* — loosening master's CORS defense as a workaround would have shipped, then stayed loosened forever. The proxy-side fix is architecturally correct: master keeps its rebinding defense, the proxy abstracts the address translation including header concerns.

## Test plan

- [ ] Merge → Flux reconciles cortex/lighthouse kustomization
- [ ] Pod cycles with licence-gate v0.1.2 (verify with `kubectl -n cortex get pod -l app.kubernetes.io/name=lighthouse -o jsonpath='{.items[0].spec.containers[?(@.name=="licence-gate")].image}'`)
- [ ] Browser S1 retry — DevTools console fetch of `/distributed/queue` with `credentials: 'include'` should return 200 + `prompt_id` populated + render dispatches to worker
- [ ] File lands at `/app/output/<your-pocket-id-username>/...png` (per-user prefix from proxy isolation)
- [ ] Audit log shows `identity_class: family`, `decision: allow`, `prompt_id: <uuid>`