### PR TITLE
chore(suwayomi): bump to v2.2.2187 (preview — 87 commits ahead)

### DIFF
--- a/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
           app:
             image:
               repository: ghcr.io/suwayomi/tachidesk
-              tag: v2.2.2100@sha256:6bb8fa8cf1cf86589e5851f2f1c2ede5c8248d53982ec1795a715dcde85b1da2
+              tag: v2.2.2187@sha256:32a98cfdd2caf88ef33fc61aab40cedac0f254584a5049370c195c51757a42c3
             env:
               TZ: ${TIMEZONE}
               # Suwayomi has no env-var config layer; JVM -D flags drive runtime overrides.


### PR DESCRIPTION
## Summary
Keiyoushi Bbato extension maintainer reported that Chapter 191 of Second Life Ranker downloads cleanly with Mihon 0.19.9 + Bbato 1.4.1, same extension version that fails with our Suwayomi-Server v2.2.2100 stable. The failure is in Suwayomi's extension runtime, not the extension.

Maintainer suggestion: try a newer Suwayomi build. v2.2.2187 is the latest preview (4 days old, 87 commits ahead of stable).

## Test plan
- [ ] Pod rolls cleanly (Suwayomi restarts, library + downloads preserved)
- [ ] Queue Chapter 191 (or any Bbato chapter that previously hit EmptyChapterException) and verify it downloads
- [ ] If it works → stalled-job arc fully closed for this case; future Bbato chapters work normally
- [ ] If it still fails → file a Suwayomi-Server upstream issue with the diagnostic chain (Mihon-works + Suwayomi-stable-fails + Suwayomi-preview-fails)