### PR TITLE
feat(lighthouse): bump to 0.22.0 with ComfyUI-Distributed worker-status patch

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           main:
             image:
               repository: ghcr.io/gavinmcfall/lighthouse
-              tag: 0.22.0@sha256:16a45ddfa747f270ec38cf1c33b8132441e70db8bd327ace34b9617070dd06b4
+              tag: 0.22.0@sha256:a1c492ecb450eeac4196d288e96f3bec6f8f8dbfc60ef25c7b761aaed791d106
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
           app:
             image:
               repository: ghcr.io/suwayomi/tachidesk
-              tag: v2.2.2100@sha256:6bb8fa8cf1cf86589e5851f2f1c2ede5c8248d53982ec1795a715dcde85b1da2
+              tag: v2.2.2187@sha256:32a98cfdd2caf88ef33fc61aab40cedac0f254584a5049370c195c51757a42c3
             env:
               TZ: ${TIMEZONE}
               # Suwayomi has no env-var config layer; JVM -D flags drive runtime overrides.


### PR DESCRIPTION
## Summary
- Bumps `ghcr.io/gavinmcfall/lighthouse` digest to `sha256:a1c492ec...` (tag `0.22.0`)
- Bakes vendor patch for ComfyUI-Distributed v1.4.0 `web/apiClient.js` probeWorker
- Fixes Distributed tab showing workers as offline/unreachable on https://lighthouse.nerdz.cloud despite workers being healthy on the LAN

## Why
Browser blocks mixed-content (HTTPS page → HTTP worker URL) probeWorker fetches, so ComfyUI-Distributed marks them offline. Patch makes probeWorker return assume-online for that specific case; dispatch still works (worker exposes CORS-headers + LAN ingress was opened in #2095).

## Upstream story
Patch lives at `containers/apps/lighthouse/patches/0001-distributed-assume-online-for-mixed-content-workers.patch` and is applied via `patch -p1` during image build against pinned upstream v1.4.0. Survives upstream bumps cleanly.

## Test plan
- [ ] flux reconcile shows lighthouse Kustomization READY
- [ ] Open https://lighthouse.nerdz.cloud, Distributed tab no longer shows red/offline for the 2 GPU workers
- [ ] Smoke S1 (single worker fan-out) still passes