### PR TITLE
feat(licence-gate): bump to 0.1.3 with /userdata per-user scoping

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           main:
             image:
               repository: ghcr.io/gavinmcfall/lighthouse
-              tag: 0.22.0@sha256:16a45ddfa747f270ec38cf1c33b8132441e70db8bd327ace34b9617070dd06b4
+              tag: 0.22.0@sha256:a1c492ecb450eeac4196d288e96f3bec6f8f8dbfc60ef25c7b761aaed791d106
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -96,7 +96,7 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              tag: 0.1.2@sha256:a704baeae496eae620d9f2f9b7c1c7a35838edf11f04c0d2c756e78b648996ad
+              tag: 0.1.3@sha256:a981888c261bd10aa99cf2e06753b1b8ec110a337239858129465232f7e81951
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"

--- a/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/suwayomi/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
           app:
             image:
               repository: ghcr.io/suwayomi/tachidesk
-              tag: v2.2.2100@sha256:6bb8fa8cf1cf86589e5851f2f1c2ede5c8248d53982ec1795a715dcde85b1da2
+              tag: v2.2.2187@sha256:32a98cfdd2caf88ef33fc61aab40cedac0f254584a5049370c195c51757a42c3
             env:
               TZ: ${TIMEZONE}
               # Suwayomi has no env-var config layer; JVM -D flags drive runtime overrides.


### PR DESCRIPTION
## Summary
- Bumps `ghcr.io/gavinmcfall/licence-gate` to `0.1.3` (digest `sha256:a981888c...`)
- Adds per-user bucket scoping on every `/userdata/*` route — each family caller gets an isolated workflow-save namespace
- Fixes the workflow-save 405 (proxy was decoding `%2F`→`/`, master saw multi-segment path against single-segment route pattern)

## Why
ComfyUI master has no per-user concept for `/userdata` — saves were landing in a shared namespace any family member could overwrite, and listings enumerated other users' files. Surfaced during Plan 1b smoke 2026-06-04.

## Upstream story
Containers PR: gavinmcfall/containers#4 (merged f93781a). 14 isolation unit tests + 8 proxy integration tests including two-callers-disjoint-buckets canary.

## Test plan
- [ ] flux reconcile shows lighthouse Kustomization READY
- [ ] Workflow save in https://lighthouse.nerdz.cloud returns 200 (not 405)
- [ ] Two browser sessions (Gavin + Serina) see their own workflow lists, not each other's
- [ ] S1 smoke (single-worker fan-out) still passes