### PR TITLE
chore(mangarr): bump to sha-d215fbd (series bulk Set)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-2e8c7e1@sha256:a382441cd210a90548000538b857c00a06efd36edc59dc5748a15c752d5b8e25
+              tag: sha-d215fbd@sha256:adeba13bc47ef0860175b2dca900eb06c7d9d0eab59c5c1ecb8dfb97bc4c2b9e
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
/series page UI refactor: single top-level Set button replaces per-row Sets. Stage many classification overrides via the dropdowns, commit in one click. Fixes mangarr #47.

## Test plan
- [ ] Pod rolls to sha-d215fbd (digest sha256:adeba13b…)
- [ ] /series shows single "Set selected bindings" button next to Rescan
- [ ] No per-row Set buttons
- [ ] Change a few dropdowns → click Set → toast "Saved N override(s)"
- [ ] Click Rescan → wait for classifier — verify auto-classified types render under each row's Type column