### PR TITLE
fix(zot): disable dedupe (incompatible with S3 + local cache)

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/config/config.json
+++ b/kubernetes/apps/kube-system/zot/app/config/config.json
@@ -2,7 +2,7 @@
   "distSpecVersion": "1.1.1",
   "storage": {
     "rootDirectory": "/var/lib/zot",
-    "dedupe": true,
+    "dedupe": false,
     "gc": true,
     "gcDelay": "1h",
     "gcInterval": "24h",


### PR DESCRIPTION
zot (from #2111) crash-looped on startup:

> invalid database config, dedupe set to true with remote storage and database, but no remote database configured

With the S3 storage driver and a local boltdb cache, zot requires `dedupe: false` (dedupe with remote storage needs a remote cache DB like DynamoDB, which we don't run). `gc` stays enabled.

Everything else was healthy — Kustomization Applied, ExternalSecret SecretSynced, OBC created — only the container config was wrong.

Verified: `kustomize build` + `kubeconform` pass (4 resources Valid); rendered ConfigMap shows `dedupe: false`.