### PR TITLE
chore(mangarr): bump to sha-828f8bf (AniList TTL cache)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-d215fbd@sha256:adeba13bc47ef0860175b2dca900eb06c7d9d0eab59c5c1ecb8dfb97bc4c2b9e
+              tag: sha-828f8bf@sha256:02a43806dad46202dee08e08e47e754170868ef3704e645a9e7fd277edd31db7
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
In-memory TTL cache for AniList lookups — fixes classifier non-determinism caused by AniList's 30 req/min rate limit. Fixes mangarr #48.

## Test plan
- [ ] Pod rolls to sha-828f8bf (digest sha256:02a43806…)
- [ ] Hit Rescan → first pass populates the cache
- [ ] Hit Rescan again immediately → zero AniList traffic in network/logs on the second pass
- [ ] Activity log shows consistent rule:N entries across multiple polls instead of unmatched flapping