### PR TITLE
chore(mangarr): bump to sha-91148a4 (series auto pill + migration 7)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-828f8bf@sha256:02a43806dad46202dee08e08e47e754170868ef3704e645a9e7fd277edd31db7
+              tag: sha-91148a4@sha256:a8ee940380878e5e705ca47d945f9be936d879db1ada7bbdfd738b80b7c0fb4e
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
/series page now displays the auto-classifier's verdict via a new blue pill-auto, fixing the "shows unknown but classified" misread. Migration 7 adds the column. Fixes mangarr #49.

## Test plan
- [ ] Pod rolls to sha-91148a4 (digest sha256:a8ee9403…)
- [ ] Migration 7 logged on startup (sqlite already has prior migrations applied; this one runs once)
- [ ] Visit /series — expect blue pill-auto for the 19 currently-classified series, "unknown" only for The Beginning After the End
- [ ] Hover the pill — tooltip distinguishes manual vs auto
- [ ] Set a manual override on one row → save → it switches to green pill-manual on next render