### PR TITLE
chore(mangarr): bump to sha-6d8046a (poller s.ID backfill)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-91148a4@sha256:a8ee940380878e5e705ca47d945f9be936d879db1ada7bbdfd738b80b7c0fb4e
+              tag: sha-6d8046a@sha256:0cef8068c01941773a373cded3b5fa0ac3acefb338b5631c9dc216c6f5d49a59
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
One-line poller fix so PR #49's pill-auto feature actually works. The classifier was resolving bindings correctly but s.ID=0 (scanner-built rows) meant SetSeriesCurrentBinding wrote nothing. Fixes mangarr #50.

## Test plan
- [ ] Pod rolls to sha-6d8046a (digest sha256:0cef8068…)
- [ ] Hit Rescan
- [ ] /series shows blue pill-auto for the 19 classified series; "unknown" only for The Beginning After the End
- [ ] DB: `SELECT COUNT(*) FROM series WHERE current_binding_id IS NOT NULL` returns 19