### PR TITLE
fix(licence-gate): bump to 0.1.4 — scope /userdata when Envoy decodes %2F

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -96,7 +96,7 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              tag: 0.1.3@sha256:a981888c261bd10aa99cf2e06753b1b8ec110a337239858129465232f7e81951
+              tag: 0.1.4@sha256:772e5b06e19f50aa6cfb50661e601bb29957f1a8732a2681948a07230a1dbbe1
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"


### PR DESCRIPTION
## Summary
Bumps `licence-gate` to `0.1.4` (digest `sha256:772e5b06...`, containers#5).

## Why
v0.1.3 scoped `/userdata` correctly only when the inbound `%2F` survived to the proxy. **It doesn't** — Envoy Gateway runs `path_with_escaped_slashes_action=UNESCAPE_AND_REDIRECT` (its default), so the browser's `POST /userdata/workflows%2F...` reached the proxy already decoded to a literal slash → master saw a multi-segment path against its single-segment `/userdata/{file}` route → **every workflow save 405'd.** In-pod `curl` (encoded, bypasses Envoy) returned 200, which masked it during the v0.1.3 smoke.

v0.1.4 normalizes on the fully-decoded logical path and re-encodes the whole `<user>/<path>` as one `%2F` segment, so encoded and Envoy-decoded inputs converge to the identical master path. **Verified live**: master accepts the emitted write + move shapes (both 200).

## Test plan
- [ ] flux reconcile → lighthouse Kustomization READY, pod on new digest `772e5b06`
- [ ] Workflow save in https://lighthouse.nerdz.cloud returns 200 (not 405)
- [ ] Two browser sessions (Gavin + Serina) see disjoint workflow lists