### PR TITLE
chore(mangarr): bump to sha-db6cc9e (UpsertSeries id fix)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-6d8046a@sha256:0cef8068c01941773a373cded3b5fa0ac3acefb338b5631c9dc216c6f5d49a59
+              tag: sha-db6cc9e@sha256:ecb9b3a3ebab37245173c5d8c52ae6949bc0b0a0e92f41aa7a841446658d000c
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Root-cause fix for the pill-auto display: UpsertSeries now returns the correct series id (was trusting stale LastInsertId on SQLite's UPSERT-update path). Fixes mangarr #51. Completes the chain #49 → #50 → #51.

## Test plan
- [ ] Pod rolls to sha-db6cc9e (digest sha256:ecb9b3a3…)
- [ ] Hit Rescan
- [ ] `SELECT COUNT(*) FROM series WHERE current_binding_id IS NOT NULL` returns 19
- [ ] /series shows blue pill-auto for all 19 classified series; "unknown" only for The Beginning After the End