### PR TITLE
feat(lncrawl): web UI for fan-translated web novels → EPUB

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ./heybuilds-downloader/ks.yaml
   - ./heybuilds-viewer/ks.yaml
   - ./kapowarr/ks.yaml
+  - ./lncrawl/ks.yaml
   - ./metube/ks.yaml
   - ./prowlarr/ks.yaml
   - ./qbittorrent/ks.yaml  # Restic restore from Dec 10

--- a/kubernetes/apps/downloads/lncrawl/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lncrawl/app/helmrelease.yaml
@@ -1,0 +1,118 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app lncrawl
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: storage
+  values:
+    controllers:
+      lncrawl:
+        labels:
+          nfsMount: "true"
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            # Lightnovel Crawler — web UI for fetching fan-translated web novels
+            # (NovelUpdates + translator sites) as EPUBs. SQLite in /data.
+            image:
+              repository: ghcr.io/lncrawl/lightnovel-crawler
+              tag: 4.6.0@sha256:445d8da2accd2803125e391773bb927f972c21d05f961ec4d4c9b114d90d84be
+            args: ["-ll", "server", "-p", "8080"]
+            env:
+              LNCRAWL_DATA_PATH: /data
+              PYTHONUNBUFFERED: "1"
+              TZ: ${TIMEZONE}
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 3Gi
+    defaultPodOptions:
+      labels:
+        nfsMount: "true"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Downloads
+          gethomepage.dev/name: Lightnovel Crawler
+          gethomepage.dev/app: *app
+          gethomepage.dev/icon: mdi-book-search
+          gethomepage.dev/description: Fan-translated web novels -> EPUB
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /data
+      # Mount the shared library so EPUBs can be sent to the Calibre inbox
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /media
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/downloads/lncrawl/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/lncrawl/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/keda/nfs-scaler
+  - ../../../../components/volsync-standard
+  - ../../../../components/priority/priority-06

--- a/kubernetes/apps/downloads/lncrawl/ks.yaml
+++ b/kubernetes/apps/downloads/lncrawl/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app lncrawl
+  namespace: &namespace downloads
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: volsync
+      namespace: storage
+  path: ./kubernetes/apps/downloads/lncrawl/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_MINUTE: "37"
+      VOLSYNC_B2_MINUTE: "52"
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-block
+      VOLSYNC_ACCESSMODES: ReadWriteOnce


### PR DESCRIPTION
## What
Deploys **Lightnovel Crawler** (web server mode) to `downloads` — a self-hosted web UI to fetch **English fan translations** of Chinese web novels (NovelUpdates + translator sites) as EPUBs. Fills the gap Anna's Archive can't for the Chinese-only titles on Serina's list.

## Details
- Image `ghcr.io/lncrawl/lightnovel-crawler:4.6.0` (digest-pinned), `-ll server -p 8080`.
- Web UI at `lncrawl.${SECRET_DOMAIN}` (internal); browse/download/**read in-browser**. First-run login `admin/admin` → change in Settings.
- SQLite on a VolSync-backed `/data` PVC; NFS media mounted at `/media` so output can target the Calibre inbox.
- 568/568 + supplementalGroups [10000]; FlareSolverr available in-cluster for Cloudflare-fronted sites.

## Note
Image runs as root by default upstream; deployed non-root (568) per house style — if browser-based crawlers misbehave we adjust. Most translator sites are plain WordPress and work without a browser.

## Validation
`task kubernetes:kubeconform` → `Kustomization lncrawl is valid`.