### PR TITLE
fix(licence-gate): bump to 0.1.5 — gate/scope /api-prefixed routes

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -96,7 +96,7 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              tag: 0.1.4@sha256:772e5b06e19f50aa6cfb50661e601bb29957f1a8732a2681948a07230a1dbbe1
+              tag: 0.1.5@sha256:4564f14a4090e8ab39170d41b5a257f9c34ae730867dffbfefc96f15e25d3d61
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"


### PR DESCRIPTION
## Summary
Bumps `licence-gate` to `0.1.5` (digest `sha256:4564f14a...`, containers#7).

## Why
Browser workflow-save still 405'd after 0.1.4. The HAR revealed the real path is `/api/userdata/...` — ComfyUI's frontend prepends `/api` to **every** native call, and the proxy matched only the bare `/userdata`, `/prompt`, `/view`, `/history`, `/queue`. So every browser request fell through to passthrough, **bypassing the licence gate (`/api/prompt`) and per-user isolation (`/api/view`, `/api/history`, `/api/queue`, `/api/userdata`).** Renders stayed gated only because Lighthouse dispatches via the ComfyUI-Distributed plugin's `/distributed/queue` (no `/api`).

0.1.5 normalises a leading `/api` segment for route matching, so all gated routes apply to both spellings; userdata scoping preserves the `/api` prefix on forward.

**This closes a real native-frontend isolation/gating bypass, not just the save UX.**

## Test plan
- [ ] flux reconcile → lighthouse pod on digest `4564f14a`
- [ ] Workflow save returns 200
- [ ] Two browser sessions: disjoint workflow lists; cannot view each other's outputs