### PR TITLE
chore(mangarr): bump to sha-2089d9a (MangaDex fallback)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-db6cc9e@sha256:ecb9b3a3ebab37245173c5d8c52ae6949bc0b0a0e92f41aa7a841446658d000c
+              tag: sha-2089d9a@sha256:272f9ce4836fc1876f066796629d2dd7b3015eef8c46f0f23e790dfb8539f54b
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Classifier step 4b — MangaDex fallback for AniList catalogue gaps. ko/ja/zh → KR/JP/CN; en unmapped (handled by manual override). Both API caches gain singleflight. Fixes mangarr #52.

## Test plan
- [ ] Pod rolls to sha-2089d9a (digest sha256:272f9ce4…)
- [ ] /series still shows 19 blue pill-auto + The Beginning After the End now green pill-manual (override set live last session)
- [ ] Activity log: any AniList-missed CJK title now resolves via mangadex-rule:N
- [ ] Two back-to-back rescans → no AniList/MangaDex network traffic on the second pass (singleflight + cache)