### PR TITLE
fix(zot): BackendTrafficPolicy for large image-blob uploads

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/backendtrafficpolicy.yaml
+++ b/kubernetes/apps/kube-system/zot/app/backendtrafficpolicy.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: zot-backend
+spec:
+  # Large container-image blobs (the Dune seabass-server layer is ~3.6GB) take
+  # minutes to upload; the default request timeout cuts them off (zot logs an
+  # i/o timeout reading from Envoy → 503). Same pattern as audiobookshelf/truenas.
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot
+  connection:
+    bufferLimit: 16Mi
+  timeout:
+    http:
+      requestTimeout: 0s
+      connectionIdleTimeout: 3600s
+  tcpKeepalive:
+    probes: 3
+    idleTime: 60s
+    interval: 60s

--- a/kubernetes/apps/kube-system/zot/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/zot/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./objectbucketclaim.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./backendtrafficpolicy.yaml
 configMapGenerator:
   - name: zot-config
     files:


### PR DESCRIPTION
Pushing the Dune Awakening `seabass-server` image (one ~3.6 GB layer) into zot through the internal Envoy gateway fails with repeated **503**s. zot logs the cause:

> `unexpected error, removing .uploads/ files … read tcp …->…(envoy): i/o timeout … PatchBlobUpload`

The default request timeout cuts off the multi-minute blob upload (~60 s in). Same class of problem the **audiobookshelf** and **truenas** backends already solve with a per-route `BackendTrafficPolicy`.

Adds `zot-backend` targeting the `zot` HTTPRoute: `requestTimeout: 0s`, `connectionIdleTimeout: 3600s`, `bufferLimit: 16Mi`, tcpKeepalive. Scoped to zot only — no change to other routes.

Verified: `kustomize build` + `kubeconform` pass (5 resources Valid).