### PR TITLE
fix(zot): raise HTTP read/write timeout to 1h (large blob uploads)

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/config/config.json
+++ b/kubernetes/apps/kube-system/zot/app/config/config.json
@@ -21,6 +21,8 @@
     "address": "0.0.0.0",
     "port": "5000",
     "realm": "zot",
+    "readTimeout": "1h",
+    "writeTimeout": "1h",
     "auth": {
       "htpasswd": {
         "path": "/etc/zot/htpasswd"


### PR DESCRIPTION
**Actual root cause** of the Dune `seabass-server` (~3.6 GB layer) push failing with 503s: zot's default HTTP server **read timeout (~60 s)**. zot's own log:

> `PATCH .../blobs/uploads/...  statusCode:500  latency:"1m0s"  Content-Length:3862709287` then `read tcp …->…(envoy): i/o timeout`

Exactly 60.000 s. The workstation→cluster path can't move 3.6 GB in 60 s (~60 MB/s), so zot's read deadline fires. The gateway `BackendTrafficPolicy` from #2123 (requestTimeout 0s) was confirmed applied but is the wrong layer — this is the real wall.

Sets `http.readTimeout`/`writeTimeout` to `1h` in zot config.json.

Verified: valid JSON, `kustomize build` + `kubeconform` pass (5 resources Valid).