### PR TITLE
fix(rook-ceph): raise RGW memory limit 640Mi->2Gi (large multipart objects)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -220,9 +220,11 @@ spec:
             resources:
               requests:
                 cpu: 1000m
-                memory: 320Mi
+                memory: 512Mi
               limits:
-                memory: 640Mi
+                # 640Mi OOM-killed (exit 137) when finalizing large multipart
+                # objects (e.g. a 3.6GB container-image blob → zot S3 backend).
+                memory: 2Gi
             instances: 2
           healthCheck:
             bucket:


### PR DESCRIPTION
The Ceph RGW (radosgw) gateway **OOM-kills (exit 137)** when finalizing large multipart S3 objects. Surfaced by pushing a 3.6 GB container-image blob (Dune `seabass-server`) into the zot registry, which is backed by Ceph object storage:

> `failed to finish blob … s3aws: … connection refused … dial tcp …(rgw): no route to host`

Both RGW pods restarted; `kubectl describe` confirms `Reason: OOMKilled` at `limits.memory: 640Mi`. The cluster recovered to HEALTH_OK, but the upload couldn't finalize.

Raises the RGW gateway `limits.memory` 640Mi → **2Gi** (requests 320Mi → 512Mi) so it can assemble multi-GB objects. Nodes have ample headroom.

Verified: `kubeconform` passes.