### PR TITLE
chore(mangarr): bump to sha-c51c7c8 (series tags)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-2089d9a@sha256:272f9ce4836fc1876f066796629d2dd7b3015eef8c46f0f23e790dfb8539f54b
+              tag: sha-c51c7c8@sha256:38d1b1d7afee89b98b6e8f8754311ca85f9e0b344fe334f2ea465763159af29d
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Ships free-form per-series tags (mangarr #10 / PR #53). Tags column on /series with pills, inline comma-separated edit, and a client-side tag filter.

## Test plan
- [ ] Pod rolls to sha-c51c7c8 (digest sha256:38d1b1d7…)
- [ ] /series shows a Tags column; add tags to a row, click "Set selected bindings", reload → pills persist
- [ ] Tag filter box narrows rows by substring