### PR TITLE
feat(lncrawl): add custom crawlers for 3 translator sites

### DIFF
--- a/kubernetes/apps/downloads/lncrawl/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lncrawl/app/helmrelease.yaml
@@ -105,6 +105,15 @@ spec:
         existingClaim: *app
         globalMounts:
           - path: /data
+      # Custom crawler modules for translator sites lncrawl ships no source for.
+      # lncrawl globs /app/sources/**/*.py and loads any it finds as non-indexed
+      # crawlers; mounting under en/ registers them as English-language sources.
+      custom-sources:
+        type: configMap
+        name: lncrawl-custom-sources
+        globalMounts:
+          - path: /app/sources/en/custom
+            readOnly: true
       # Mount the shared library so EPUBs can be sent to the Calibre inbox
       media:
         type: nfs

--- a/kubernetes/apps/downloads/lncrawl/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/lncrawl/app/kustomization.yaml
@@ -8,3 +8,14 @@ components:
   - ../../../../components/keda/nfs-scaler
   - ../../../../components/volsync-standard
   - ../../../../components/priority/priority-06
+configMapGenerator:
+  # Custom crawler modules for translator sites lncrawl ships no source for.
+  # Mounted into /app/sources/en/custom so lncrawl auto-loads them as
+  # non-indexed crawlers (see helmrelease persistence: custom-sources).
+  - name: lncrawl-custom-sources
+    files:
+      - ./resources/dreamsofjianghu.py
+      - ./resources/bloomingtranslation.py
+      - ./resources/orchidtalestranslations.py
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Crawler for Blooming Translation (bloomingtranslation.home.blog).
+
+WordPress.com-hosted translator site. The novel landing post lists every
+chapter as a dated permalink (``/YYYY/MM/DD/mdd-chapter-N-...``) inside
+``div.entry-content``. Chapter bodies are in ``div.entry-content``.
+"""
+import logging
+import re
+
+from lncrawl.core import Chapter, LegacyCrawler
+
+logger = logging.getLogger(__name__)
+
+
+class BloomingTranslation(LegacyCrawler):
+    base_url = ["https://bloomingtranslation.home.blog/"]
+    language = "en"
+    has_mtl = False
+    has_manga = False
+
+    def read_novel_info(self):
+        soup = self.get_soup(self.novel_url)
+
+        title_tag = soup.select_one("h1.entry-title, .entry-title")
+        raw_title = title_tag.get_text(strip=True) if title_tag else "Blooming Translation Novel"
+        self.novel_title = " ".join(raw_title.split())  # collapse \xa0 / whitespace
+
+        cover = soup.select_one("div.entry-content img, .wp-post-image")
+        if cover and cover.get("src"):
+            self.novel_cover = self.absolute_url(cover.get("src"))
+
+        content = soup.select_one("div.entry-content") or soup
+        self.volumes.append({"id": 1, "title": self.novel_title})
+
+        seen = set()
+        for a in content.select("a[href]"):
+            href = self.absolute_url(a.get("href"))
+            if not href or href in seen:
+                continue
+            if re.search(r"/20\d\d/\d\d/\d\d/", href) and "chapter" in href.lower():
+                seen.add(href)
+                # anchor text is just "Part 1"/"Part 2"; build a real title from
+                # the URL slug, e.g. .../mdd-chapter-211-part-2 -> "Chapter 211 Part 2"
+                m = re.search(r"/20\d\d/\d\d/\d\d/(.+?)/?$", href)
+                slug = (m.group(1) if m else "").replace("mdd-", "")
+                slug_title = " ".join(re.sub(r"[^a-zA-Z0-9]+", " ", slug).split()).title()
+                title = slug_title or a.get_text(strip=True) or "Chapter %d" % (
+                    len(self.chapters) + 1
+                )
+                self.chapters.append(
+                    Chapter(
+                        id=len(self.chapters) + 1,
+                        volume=1,
+                        url=href,
+                        title=title,
+                    )
+                )
+
+    def download_chapter_body(self, chapter):
+        soup = self.get_soup(chapter["url"])
+        content = soup.select_one("div.entry-content")
+        return self.cleaner.extract_contents(content)

--- a/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Crawler for Dreams of Jianghu (dreamsofjianghu.ca).
+
+Standard WordPress translator site. A novel's table-of-contents page holds the
+full chapter list as dated permalinks (``/YYYY/MM/DD/...-chapter-N/``) inside
+``div.entry-content``. Chapter bodies live in ``div.entry-content`` too.
+"""
+import logging
+import re
+import urllib.parse
+
+from lncrawl.core import Chapter, LegacyCrawler
+
+logger = logging.getLogger(__name__)
+
+
+class DreamsOfJianghu(LegacyCrawler):
+    base_url = ["https://dreamsofjianghu.ca/"]
+    language = "en"
+    has_mtl = False
+    has_manga = False
+
+    def read_novel_info(self):
+        soup = self.get_soup(self.novel_url)
+
+        # The TOC page <h1> is just "Table of Contents", so derive the title
+        # from the parent slug of the URL, e.g.
+        # /八宝妆-eight-treasures-trousseau/table-of-contents/ -> Eight Treasures Trousseau
+        slug = ""
+        parts = [p for p in self.novel_url.split("/") if p]
+        for p in parts:
+            if p in ("table-of-contents", "toc"):
+                break
+            slug = p
+        slug = urllib.parse.unquote(slug)  # decode %e5%85.. CJK escapes
+        ascii_slug = re.sub(r"[^a-zA-Z0-9]+", " ", slug).strip()
+        self.novel_title = " ".join(ascii_slug.split()).title() or "Dreams of Jianghu Novel"
+
+        content = soup.select_one("div.entry-content") or soup
+        self.volumes.append({"id": 1, "title": self.novel_title})
+
+        seen = set()
+        for a in content.select("a[href]"):
+            href = self.absolute_url(a.get("href"))
+            if not href or href in seen:
+                continue
+            # chapter permalinks are dated and contain 'chapter'
+            if re.search(r"/20\d\d/\d\d/\d\d/", href) and "chapter" in href.lower():
+                seen.add(href)
+                title = a.get_text(strip=True) or "Chapter %d" % (len(self.chapters) + 1)
+                self.chapters.append(
+                    Chapter(
+                        id=len(self.chapters) + 1,
+                        volume=1,
+                        url=href,
+                        title=title,
+                    )
+                )
+
+    def download_chapter_body(self, chapter):
+        soup = self.get_soup(chapter["url"])
+        content = soup.select_one("div.entry-content")
+        return self.cleaner.extract_contents(content)

--- a/kubernetes/apps/downloads/lncrawl/app/resources/orchidtalestranslations.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/orchidtalestranslations.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Crawler for Orchid Tales Translations (orchidtalestranslations.wordpress.com).
+
+WordPress.com site. Quirk: the table-of-contents links point at the *editor*
+URLs (``https://wordpress.com/post/<site>/<id>``) rather than public permalinks.
+WordPress.com serves any post publicly at ``?p=<id>``, so we rewrite each link.
+Chapter bodies are in ``div.entry-content``.
+"""
+import logging
+import re
+
+from lncrawl.core import Chapter, LegacyCrawler
+
+logger = logging.getLogger(__name__)
+
+
+class OrchidTalesTranslations(LegacyCrawler):
+    base_url = ["https://orchidtalestranslations.wordpress.com/"]
+    language = "en"
+    has_mtl = False
+    has_manga = False
+
+    def read_novel_info(self):
+        soup = self.get_soup(self.novel_url)
+
+        title_tag = soup.select_one("h1.entry-title, .entry-title")
+        raw_title = title_tag.get_text(strip=True) if title_tag else "Orchid Tales Novel"
+        self.novel_title = " ".join(raw_title.split())
+
+        content = soup.select_one("div.entry-content") or soup
+        self.volumes.append({"id": 1, "title": self.novel_title})
+
+        seen = set()
+        for a in content.select("a[href]"):
+            href = a.get("href") or ""
+            text = a.get_text(strip=True)
+            # editor link -> public ?p=<id> permalink
+            m = re.search(r"/post/[^/]+/(\d+)", href)
+            if m:
+                href = self.home_url.rstrip("/") + "/?p=" + m.group(1)
+            else:
+                href = self.absolute_url(href)
+            # only keep this novel's chapter links (skip "Book 1" / external)
+            if not href or href in seen:
+                continue
+            if "chapter" not in text.lower():
+                continue
+            seen.add(href)
+            self.chapters.append(
+                Chapter(
+                    id=len(self.chapters) + 1,
+                    volume=1,
+                    url=href,
+                    title=text or "Chapter %d" % (len(self.chapters) + 1),
+                )
+            )
+
+    def download_chapter_body(self, chapter):
+        soup = self.get_soup(chapter["url"])
+        content = soup.select_one("div.entry-content")
+        return self.cleaner.extract_contents(content)


### PR DESCRIPTION
## What

Adds three custom `LegacyCrawler` modules for WordPress translator sites that lncrawl ships **no source module** for. Without these, the novels they host can't be fetched at all (lncrawl matches crawlers by exact domain — no generic fallback).

The crawler `.py` files are mounted read-only into `/app/sources/en/custom/` via a generated ConfigMap. lncrawl globs `/app/sources/**/*.py` on startup and auto-loads any it finds as non-indexed English sources.

| Crawler | Site | Novel | Verified |
|---|---|---|---|
| `dreamsofjianghu.py` | dreamsofjianghu.ca | Eight Treasures Trousseau | ✅ 108 ch (complete), real body text |
| `bloomingtranslation.py` | bloomingtranslation.home.blog | Marriage of the Di Daughter | ✅ 211 ch / 668 parts |
| `orchidtalestranslations.py` | orchidtalestranslations.wordpress.com | Blazing Sunlight Book 2 | ✅ 13 ch |

## Notes

- Each crawler was run against the live site (chapter-list + chapter-body extraction) before committing.
- **orchidtales quirk:** its TOC links point at editor URLs (`wordpress.com/post/<site>/<id>`) instead of public permalinks; the crawler rewrites them to `?p=<id>`.
- Registration path validated: mounted under `/app/sources/en/custom`, all three resolve in the source registry with `language=en` and the correct domains.
- ConfigMap uses `disableNameSuffixHash: true`; the controller already has `reloader.stakater.com/auto: "true"` so the pod restarts when a crawler changes.

## Usage after merge

Paste the novel's table-of-contents URL into lncrawl:
- `https://dreamsofjianghu.ca/八宝妆-eight-treasures-trousseau/table-of-contents/`
- `https://bloomingtranslation.home.blog/2019/08/26/marriage-of-the-di-daughter/`
- `https://orchidtalestranslations.wordpress.com/blazing-sunlight-ii/`