### PR TITLE
chore(mangarr): bump to sha-0273a98 (tags save feedback fix)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-c51c7c8@sha256:38d1b1d7afee89b98b6e8f8754311ca85f9e0b344fe334f2ea465763159af29d
+              tag: sha-0273a98@sha256:8294575b4de5f8dcdc893e1b8d593f9d0b3db10b41fb73b9160f63a8c9263c29
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Fixes the tags "can't save / filter broken" reports (mangarr #54). Root cause was the missing reload after save; tags always persisted. Now counts tag changes, reloads on save, button reads "Save changes".

## Test plan
- [ ] Pod rolls to sha-0273a98 (digest sha256:8294575b…)
- [ ] Hard-refresh /series → the 4 System/Leveling tags show as pills
- [ ] Add a tag + Save → "Saved 1 change(s)", page reloads, pill appears
- [ ] Filter by tag → matching rows show (no longer empties the table)