### PR TITLE
fix(lncrawl): rate-limit custom crawlers + restore language tag

### DIFF
--- a/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
@@ -15,8 +15,14 @@ logger = logging.getLogger(__name__)
 
 class BloomingTranslation(LegacyCrawler):
     base_url = ["https://bloomingtranslation.home.blog/"]
+    language = "en"
     has_mtl = False
     has_manga = False
+
+    def initialize(self):
+        # WordPress.com throttles aggressive concurrent scraping: the default
+        # 5 workers fails ~half the chapters with 429/403. Pace the requests.
+        self.init_executor(ratelimit=2)
 
     def read_novel_info(self):
         # lncrawl reuses the cached crawler instance and may call this more than

--- a/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
@@ -16,8 +16,14 @@ logger = logging.getLogger(__name__)
 
 class DreamsOfJianghu(LegacyCrawler):
     base_url = ["https://dreamsofjianghu.ca/"]
+    language = "en"
     has_mtl = False
     has_manga = False
+
+    def initialize(self):
+        # WordPress/Jetpack host throttles concurrent scraping; pace requests
+        # to avoid mass 429/403 failures (default 5 workers is too aggressive).
+        self.init_executor(ratelimit=2)
 
     def read_novel_info(self):
         # lncrawl reuses the cached crawler instance and may call this more than

--- a/kubernetes/apps/downloads/lncrawl/app/resources/orchidtalestranslations.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/orchidtalestranslations.py
@@ -16,8 +16,14 @@ logger = logging.getLogger(__name__)
 
 class OrchidTalesTranslations(LegacyCrawler):
     base_url = ["https://orchidtalestranslations.wordpress.com/"]
+    language = "en"
     has_mtl = False
     has_manga = False
+
+    def initialize(self):
+        # WordPress.com throttles aggressive concurrent scraping: the default
+        # 5 workers fails ~half the chapters with 429/403. Pace the requests.
+        self.init_executor(ratelimit=2)
 
     def read_novel_info(self):
         # lncrawl reuses the cached crawler instance and may call this more than


### PR DESCRIPTION
## Problem

After the dedup fix, *Marriage of the Di Daughter* crawled the correct **672** chapters but **failed 47% (314/672)** — WordPress.com returns 429/403 under lncrawl's default 5 concurrent workers. A sequential test downloads 20/20 chapters cleanly (4–15k chars each), confirming it's rate-limiting, not a crawler bug.

## Fix

Add `initialize()` → `self.init_executor(ratelimit=2)` to all three crawlers (1 worker, 2 req/s) — the same pattern lncrawl's own `daotranslate` (1.1) and `asianovel` (1) sources use for rate-limited hosts. Verified: `workers` drops to 1, chapters still 668, downloads clean.

Also **restores `language = "en"`**, which #2130 inadvertently dropped (it overwrote the resource files from scratch copies that predated that attribute). Cosmetic — affects the UI language tag, not function.

## After merge

Re-crawl (delete + re-add) the affected novels; the paced requests should complete with few/no failures. Any residual → Replay.