### PR TITLE
fix(lncrawl): throttle chapter requests in download_chapter_body

### DIFF
--- a/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
@@ -7,6 +7,8 @@ chapter as a dated permalink (``/YYYY/MM/DD/mdd-chapter-N-...``) inside
 """
 import logging
 import re
+import threading
+import time
 
 from lncrawl.core import Chapter, LegacyCrawler
 
@@ -19,10 +21,23 @@ class BloomingTranslation(LegacyCrawler):
     has_mtl = False
     has_manga = False
 
-    def initialize(self):
-        # WordPress.com throttles aggressive concurrent scraping: the default
-        # 5 workers fails ~half the chapters with 429/403. Pace the requests.
-        self.init_executor(ratelimit=2)
+    # lncrawl downloads chapters as parallel child-jobs (runner_concurrency,
+    # default 5) that call the crawler directly, bypassing its taskman — so a
+    # crawler-level executor/ratelimit has no effect. WordPress.com 429s under
+    # that concurrency (~47% failures). A shared lock + min-interval caps the
+    # request rate across all concurrent job threads.
+    _rate_lock = threading.Lock()
+    _next_request = 0.0
+    _min_interval = 0.5  # seconds between requests (~2/s)
+
+    def _pace(self):
+        cls = type(self)
+        with cls._rate_lock:
+            now = time.monotonic()
+            if now < cls._next_request:
+                time.sleep(cls._next_request - now)
+                now = time.monotonic()
+            cls._next_request = now + cls._min_interval
 
     def read_novel_info(self):
         # lncrawl reuses the cached crawler instance and may call this more than
@@ -67,6 +82,7 @@ class BloomingTranslation(LegacyCrawler):
                 )
 
     def download_chapter_body(self, chapter):
+        self._pace()
         soup = self.get_soup(chapter["url"])
         content = soup.select_one("div.entry-content")
         return self.cleaner.extract_contents(content)

--- a/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
@@ -7,6 +7,8 @@ full chapter list as dated permalinks (``/YYYY/MM/DD/...-chapter-N/``) inside
 """
 import logging
 import re
+import threading
+import time
 import urllib.parse
 
 from lncrawl.core import Chapter, LegacyCrawler
@@ -20,10 +22,22 @@ class DreamsOfJianghu(LegacyCrawler):
     has_mtl = False
     has_manga = False
 
-    def initialize(self):
-        # WordPress/Jetpack host throttles concurrent scraping; pace requests
-        # to avoid mass 429/403 failures (default 5 workers is too aggressive).
-        self.init_executor(ratelimit=2)
+    # lncrawl downloads chapters as parallel child-jobs (runner_concurrency,
+    # default 5) that bypass the crawler taskman, so a crawler-level ratelimit
+    # has no effect. Cap the request rate across all job threads with a shared
+    # lock + min-interval to avoid mass 429/403 failures.
+    _rate_lock = threading.Lock()
+    _next_request = 0.0
+    _min_interval = 0.5  # seconds between requests (~2/s)
+
+    def _pace(self):
+        cls = type(self)
+        with cls._rate_lock:
+            now = time.monotonic()
+            if now < cls._next_request:
+                time.sleep(cls._next_request - now)
+                now = time.monotonic()
+            cls._next_request = now + cls._min_interval
 
     def read_novel_info(self):
         # lncrawl reuses the cached crawler instance and may call this more than
@@ -67,6 +81,7 @@ class DreamsOfJianghu(LegacyCrawler):
                 )
 
     def download_chapter_body(self, chapter):
+        self._pace()
         soup = self.get_soup(chapter["url"])
         content = soup.select_one("div.entry-content")
         return self.cleaner.extract_contents(content)

--- a/kubernetes/apps/downloads/lncrawl/app/resources/orchidtalestranslations.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/orchidtalestranslations.py
@@ -8,6 +8,8 @@ Chapter bodies are in ``div.entry-content``.
 """
 import logging
 import re
+import threading
+import time
 
 from lncrawl.core import Chapter, LegacyCrawler
 
@@ -20,10 +22,22 @@ class OrchidTalesTranslations(LegacyCrawler):
     has_mtl = False
     has_manga = False
 
-    def initialize(self):
-        # WordPress.com throttles aggressive concurrent scraping: the default
-        # 5 workers fails ~half the chapters with 429/403. Pace the requests.
-        self.init_executor(ratelimit=2)
+    # lncrawl downloads chapters as parallel child-jobs (runner_concurrency,
+    # default 5) that bypass the crawler taskman, so a crawler-level ratelimit
+    # has no effect. Cap the request rate across all job threads with a shared
+    # lock + min-interval to avoid mass 429/403 failures.
+    _rate_lock = threading.Lock()
+    _next_request = 0.0
+    _min_interval = 0.5  # seconds between requests (~2/s)
+
+    def _pace(self):
+        cls = type(self)
+        with cls._rate_lock:
+            now = time.monotonic()
+            if now < cls._next_request:
+                time.sleep(cls._next_request - now)
+                now = time.monotonic()
+            cls._next_request = now + cls._min_interval
 
     def read_novel_info(self):
         # lncrawl reuses the cached crawler instance and may call this more than
@@ -65,6 +79,7 @@ class OrchidTalesTranslations(LegacyCrawler):
             )
 
     def download_chapter_body(self, chapter):
+        self._pace()
         soup = self.get_soup(chapter["url"])
         content = soup.select_one("div.entry-content")
         return self.cleaner.extract_contents(content)


### PR DESCRIPTION
## Problem

After #2132, *Marriage of the Di Daughter* **still failed 47% (314/672)** — twice, including a genuine Replay that ran *after* the rate-limited pod was live.

## Root cause

`init_executor(ratelimit=2)` throttles the crawler's **taskman** executor, but lncrawl's server **doesn't use it for downloads**. Each chapter is a separate child-job; the scheduler runs `runner_concurrency` (default **5**) jobs at once, each calling `crawler.fetch_chapter` directly. So 5 chapters hit WordPress.com concurrently → 429s → ~half fail. The crawler-level ratelimit was throttling the wrong path.

## Fix

A class-level throttle (`threading.Lock` + `_next_request` timestamp + `_min_interval=0.5`) called at the top of `download_chapter_body`. Because the crawler instance is shared across all job threads, the shared lock paces every request to ~2/s regardless of how many child-jobs run.

**Verified under 5-way concurrency** (mimicking the runner): 40/40 chapters succeed, 0 failures, steady 2.02 req/s — vs. 47% failures before.

Trade: a full ~672-chapter novel takes ~5–6 min (paced), but completes clean in one pass. Applied to all three crawlers.