### PR TITLE
fix(lncrawl): strip images from chapter bodies (fixes ~47% chapter failures)

### DIFF
--- a/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
@@ -85,4 +85,12 @@ class BloomingTranslation(LegacyCrawler):
         self._pace()
         soup = self.get_soup(chapter["url"])
         content = soup.select_one("div.entry-content")
+        if content:
+            # Strip images. These are text novels; the only <img> is the
+            # translator's ko-fi/support badge, repeated in most chapters. lncrawl
+            # derives chapter_images.id from the image URL, so that one shared
+            # image collides on the UNIQUE id and fails ~half the chapters with
+            # "Failed to fetch chapter" (sqlite3.IntegrityError).
+            for img in content.select("img"):
+                img.decompose()
         return self.cleaner.extract_contents(content)

--- a/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
@@ -84,4 +84,11 @@ class DreamsOfJianghu(LegacyCrawler):
         self._pace()
         soup = self.get_soup(chapter["url"])
         content = soup.select_one("div.entry-content")
+        if content:
+            # Strip images. These are text novels; embedded <img> are ko-fi/
+            # support badges or dividers repeated across chapters. lncrawl derives
+            # chapter_images.id from the image URL, so a shared image collides on
+            # the UNIQUE id and fails chapters with sqlite3.IntegrityError.
+            for img in content.select("img"):
+                img.decompose()
         return self.cleaner.extract_contents(content)

--- a/kubernetes/apps/downloads/lncrawl/app/resources/orchidtalestranslations.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/orchidtalestranslations.py
@@ -82,4 +82,11 @@ class OrchidTalesTranslations(LegacyCrawler):
         self._pace()
         soup = self.get_soup(chapter["url"])
         content = soup.select_one("div.entry-content")
+        if content:
+            # Strip images. These are text novels; embedded <img> are ko-fi/
+            # support badges or dividers repeated across chapters. lncrawl derives
+            # chapter_images.id from the image URL, so a shared image collides on
+            # the UNIQUE id and fails chapters with sqlite3.IntegrityError.
+            for img in content.select("img"):
+                img.decompose()
         return self.cleaner.extract_contents(content)


### PR DESCRIPTION
## The actual root cause (found via the job's stored error tracebacks)

*Marriage of the Di Daughter* failed **314/672** three times. The download always succeeded — the failures happen **after** download, on the DB write:

```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError)
UNIQUE constraint failed: chapter_images.id
INSERT INTO chapter_images ... url '.../support_me_on_kofi_blue.png'
```

The translators embed a **ko-fi "support me" badge** in most chapters. lncrawl derives `chapter_images.id` from the image URL, so that one shared image gets the **same id across every chapter**. The first insert wins; every subsequent chapter containing the badge collides on the UNIQUE id → the runner catches it as `"Failed to fetch chapter"`. The ~47% that fail are exactly the chapters with the badge.

This is why earlier "fixes" missed: it's not rate-limiting (all HTTP 200), not concurrency of downloads (a 668-chapter download via the real method got 667/668), not the crawler logic.

## Fix

`decompose()` all `<img>` in the chapter body before `extract_contents`. These are text novels; the only images are ko-fi badges / dividers. **Verified:** chapter text unchanged (6159 chars), and lncrawl now extracts **0 images** per chapter → no `chapter_images` insert → no collision.

Applied to all three crawlers (all three sites use the same badge pattern).

## After merge

Delete + re-add the novel — should complete a clean 668 with no IntegrityError failures.