### PR TITLE
chore(mangarr): bump to sha-7aa515a (activity filters/pagination/retention)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-196baa0@sha256:90a5f9f815ef2fb6e68f27cd83f2dbc99e2f118d4949a95c9b5db7472c2b05cb
+              tag: sha-7aa515a@sha256:a8fcda24c95e05a0cc44ca482697143d7fdab3f5a72eb47f3ce6aed20cd907a5
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
## Summary
Activity page #11 — server-side filters (type/series/tag/date), pagination, retention + activity-gc task. Carries the #56 recycle-bin GC timezone fix.

## Test plan
- [ ] Pod rolls to sha-7aa515a (digest sha256:a8fcda24…)
- [ ] /activity filter bar: type/series/tag/date-range filters work + persist; pagination prev/next carries filter
- [ ] /settings activity retention input round-trips; Tasks page has Activity GC (run-now works)