### PR TITLE
feat(dune): operator-free Dune Awakening server (first deploy)

### DIFF
--- a/kubernetes/apps/games/dune-awakening/app/externalsecret.yaml
+++ b/kubernetes/apps/games/dune-awakening/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dune-awakening
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dune-awakening-secret
+    template:
+      engineVersion: v2
+      data:
+        # Funcom Live Services self-host token — from https://account.duneawakening.com/
+        FLS_SECRET: "{{ .DUNE_FLS_SECRET }}"
+        # Postgres
+        POSTGRES_DUNE_PASSWORD: "{{ .DUNE_POSTGRES_DUNE_PASSWORD }}"
+        POSTGRES_SUPER_PASSWORD: "{{ .DUNE_POSTGRES_SUPER_PASSWORD }}"
+        # RabbitMQ HTTP token-auth shared secret
+        RMQ_HTTP_TOKEN_AUTH_SECRET: "{{ .DUNE_RMQ_HTTP_TOKEN_AUTH_SECRET }}"
+  dataFrom:
+    - extract:
+        key: dune-awakening

--- a/kubernetes/apps/games/dune-awakening/app/helmrelease.yaml
+++ b/kubernetes/apps/games/dune-awakening/app/helmrelease.yaml
@@ -1,16 +1,24 @@
 # =============================================================================
-# DRAFT — grounded in snapetech/DuneAwakeningSelfHost compose.yaml, but NOT
-# deployable yet and NOT wired into Flux. See ../PORT-NOTES.md for the blockers
-# (wrapper scripts run_server_safe.sh/bootstrap_db.py, vendor userland, game-rmq
-# TLS, the full -ini: arg list). ${DUNE_REGISTRY}=zot, ${DUNE_TAG}=<build>-0-shipping.
-# This is a faithful SKELETON of the topology, not a finished release.
+# DRAFT first-cut — operator-free transplant of the Funcom Dune server, grounded
+# in the extracted image (run.sh, Config INIs) + snapetech compose env wiring.
+# NOT wired into Flux. Needs before going live (see ../PORT-NOTES.md + TODOs):
+#   1. 1Password item "dune-awakening" (FLS token + pg/rmq secrets)
+#   2. EXTERNAL ADDRESS: Talos nodes have no ExternalIP → run.sh can't derive a
+#      routable -ExternalAddress. Must set node ExternalIP or inject public IP.
+#   3. SECRET-IN-ARGS: the game server's FLS token / DB password are passed here
+#      via ENV (FuncomLiveServices__* / DuneDatabaseInterfacePSQL_*). If the UE5
+#      binary ONLY honours -ini: CLI args (not env), a wrapper/initContainer must
+#      build args from env so secrets don't sit in the pod spec. VALIDATE on first run.
+#   4. DB bootstrap mechanism (db-init) — native image db setup, unconfirmed.
+#   5. game-rmq TLS cert (cert-manager).
+# Substitution vars (${DUNE_*}) come from ks.yaml postBuild.
 # =============================================================================
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: &app dune-awakening
+  name: dune-awakening
 spec:
   interval: 30m
   chart:
@@ -22,8 +30,11 @@ spec:
         name: bjw-s
         namespace: flux-system
   values:
+    defaultPodOptions:
+      # run.sh needs the SA token to read its node + patch its pod (see rbac.yaml)
+      serviceAccountName: dune-awakening
     controllers:
-      # --- data plane ------------------------------------------------------
+      # ---------------- data plane -------------------------------------------
       postgres:
         type: statefulset
         containers:
@@ -35,7 +46,7 @@ spec:
               POSTGRES_DB: dune
               POSTGRES_USER: dune
             envFrom:
-              - secretRef: { name: dune-awakening-secret }  # POSTGRES_PASSWORD / _SUPER_PASSWORD
+              - secretRef: { name: dune-awakening-secret }   # POSTGRES_PASSWORD / _SUPER_PASSWORD
 
       admin-rmq:
         type: statefulset
@@ -48,7 +59,7 @@ spec:
               RMQ_AUTH_BACKEND_1: cache
               FuncomLiveServices__RmqTlsEnabled: "false"
             envFrom:
-              - secretRef: { name: dune-awakening-secret }  # RMQ_HTTP_TOKEN_AUTH_SECRET
+              - secretRef: { name: dune-awakening-secret }   # RMQ_HTTP_TOKEN_AUTH_SECRET
 
       game-rmq:
         type: statefulset
@@ -59,11 +70,11 @@ spec:
               tag: "${DUNE_TAG}"
             env:
               RMQ_AUTH_BACKEND_1: cache
-              FuncomLiveServices__RmqTlsEnabled: "true"     # mounts ca/cert/key — see persistence.rmq-tls
+              FuncomLiveServices__RmqTlsEnabled: "true"       # mounts ca/cert/key (persistence.rmq-tls)
             envFrom:
               - secretRef: { name: dune-awakening-secret }
 
-      # --- one-shot DB bootstrap ------------------------------------------
+      # ---------------- one-shot DB bootstrap (TODO: confirm native invocation) --
       db-init:
         type: job
         containers:
@@ -71,60 +82,153 @@ spec:
             image:
               repository: "${DUNE_REGISTRY}/funcom/self-hosting/seabass-server-db-utils"
               tag: "${DUNE_TAG}"
-            # command: bootstrap_db.py — TODO: provide via scripts ConfigMap (PORT-NOTES blocker #1)
-            envFrom:
-              - secretRef: { name: dune-awakening-secret }
+            # TODO: native image ships home/dune/server/PSQL/ToolsDB/setupdb.py — confirm
+            #   the correct invocation (snapetech used its own /workspace bootstrap_db.py).
+            env:
+              POSTGRES_DUNE_PASSWORD:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: POSTGRES_DUNE_PASSWORD } }
 
-      # --- control plane ---------------------------------------------------
-      text-router:
-        containers:
-          app:
-            image:
-              repository: "${DUNE_REGISTRY}/funcom/self-hosting/seabass-server-text-router"
-              tag: "${DUNE_TAG}"
+      # ---------------- control plane ----------------------------------------
       director:
         containers:
           app:
             image:
               repository: "${DUNE_REGISTRY}/funcom/self-hosting/seabass-server-bg-director"
               tag: "${DUNE_TAG}"
-            envFrom:
-              - secretRef: { name: dune-awakening-secret }  # FLS_SECRET
+            args:
+              - --RMQGameHostname
+              - game-rmq
+              - --RMQGamePort
+              - "5672"
+              - --RMQAdminHostname
+              - admin-rmq
+              - --RMQAdminPort
+              - "5672"
+            env:
+              Database__address: postgres
+              Database__port: "5432"
+              Database__user: dune
+              BATTLEGROUP_DISPLAY_NAME: "${DUNE_WORLD_UNIQUE_NAME}"
+              WORLD_NAME: "${DUNE_WORLD_NAME}"
+              OPT_SERVERNAME: "${DUNE_WORLD_UNIQUE_NAME}"
+              OPT_DISPLAY_NAME: "${DUNE_WORLD_NAME}"
+              BATTLEGROUP_REGION_NAME: "${DUNE_WORLD_REGION}"
+              HOST_DATACENTER_ID: "${DUNE_WORLD_DATACENTER_ID}"
+              HOST_DATACENTER_IP_ADDRESS: "${DUNE_EXTERNAL_ADDRESS}"   # TODO #2
+              FuncomLiveServices__RmqTlsEnabled: "true"
+              FuncomLiveServices__DefaultFlsEnvironment: retail
+              Database__password:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: POSTGRES_DUNE_PASSWORD } }
+              FuncomLiveServices__ServiceAuthToken:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: FLS_SECRET } }
+              RMQ_HTTP_TOKEN_AUTH_SECRET:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: RMQ_HTTP_TOKEN_AUTH_SECRET } }
+
+      text-router:
+        containers:
+          app:
+            image:
+              repository: "${DUNE_REGISTRY}/funcom/self-hosting/seabass-server-text-router"
+              tag: "${DUNE_TAG}"
+            args: ["--RMQGameHostname", "game-rmq", "--RMQGamePort", "5672", "--RMQAdminHostname", "admin-rmq", "--RMQAdminPort", "5672"]
+            env:
+              DuneDatabaseInterfacePSQL_DatabaseHost: postgres
+              DuneDatabaseInterfacePSQL_DatabasePort: "5432"
+              DuneDatabaseInterfacePSQL_DatabaseUser: dune
+              DuneDatabaseInterfacePSQL_DatabaseName: "${DUNE_DB_NAME}"   # e.g. dune_sb_1_4_0_0
+              Database__address: postgres
+              Database__port: "5432"
+              Database__user: dune
+              WORLD_NAME: "${DUNE_WORLD_NAME}"
+              OPT_SERVERNAME: "${DUNE_WORLD_UNIQUE_NAME}"
+              BATTLEGROUP_REGION_NAME: "${DUNE_WORLD_REGION}"
+              BATTLEGROUP_LANGUAGE: en-US
+              FuncomLiveServices__RmqTlsEnabled: "true"
+              FuncomLiveServices__DefaultFlsEnvironment: retail
+              HOST_DATACENTER_ID: "${DUNE_WORLD_DATACENTER_ID}"
+              HOST_DATACENTER_IP_ADDRESS: "${DUNE_EXTERNAL_ADDRESS}"
+              DuneDatabaseInterfacePSQL_DatabasePassword:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: POSTGRES_DUNE_PASSWORD } }
+              Database__password:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: POSTGRES_DUNE_PASSWORD } }
+              FuncomLiveServices__ServiceAuthToken:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: FLS_SECRET } }
+              RMQ_HTTP_TOKEN_AUTH_SECRET:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: RMQ_HTTP_TOKEN_AUTH_SECRET } }
+
       gateway:
         containers:
           app:
             image:
               repository: "${DUNE_REGISTRY}/funcom/self-hosting/seabass-server-gateway"
               tag: "${DUNE_TAG}"
-            envFrom:
-              - secretRef: { name: dune-awakening-secret }
+            # gateway is the client-facing piece; advertises game-rmq public endpoint
+            command: ["sh", "-lc"]
+            args:
+              - >-
+                sleep 30;
+                exec python -m service
+                -c /Tools/Battlegroups/GatewayService/service/configs/service.conf
+                --RMQGameHostname ${DUNE_EXTERNAL_ADDRESS}
+                --RMQGamePort 31982
+                --RMQGameHttpPort 15673
+            env:
+              DuneDatabaseInterfacePSQL_DatabaseHost: postgres
+              DuneDatabaseInterfacePSQL_DatabasePort: "5432"
+              DuneDatabaseInterfacePSQL_DatabaseUser: dune
+              DuneDatabaseInterfacePSQL_DatabaseName: "${DUNE_DB_NAME}"
+              FuncomLiveServices__RmqTlsEnabled: "true"
+              FuncomLiveServices__BattlegroupAuthorizationPreset: BattlegroupInternal
+              FuncomLiveServices__DefaultFlsEnvironment: retail
+              BATTLEGROUP_DISPLAY_NAME: "${DUNE_WORLD_NAME}"
+              OPT_SERVERNAME: "${DUNE_WORLD_UNIQUE_NAME}"
+              OPT_DISPLAY_NAME: "${DUNE_WORLD_NAME}"
+              HOST_DATACENTER_ID: "${DUNE_WORLD_DATACENTER_ID}"
+              HOST_DATACENTER_IP_ADDRESS: "${DUNE_EXTERNAL_ADDRESS}"
+              DuneDatabaseInterfacePSQL_DatabasePassword:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: POSTGRES_DUNE_PASSWORD } }
+              FuncomLiveServices__ServiceAuthToken:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: FLS_SECRET } }
+              gateway_farm_api_key:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: FLS_SECRET } }
+              RMQ_HTTP_TOKEN_AUTH_SECRET:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: RMQ_HTTP_TOKEN_AUTH_SECRET } }
 
-      # --- game server: one controller per map (start: survival = Hagga Basin) ---
+      # ---------------- game server: one controller per map (start: survival) ----
       game-survival:
         containers:
           app:
             image:
               repository: "${DUNE_REGISTRY}/funcom/self-hosting/seabass-server"
               tag: "${DUNE_TAG}"
-            # TODO: command is snapetech's wrapper + the full -ini: arg list (PORT-NOTES blocker #1/#4).
-            # Shape (from compose anchors):
-            #   /workspace/scripts/run_server_safe.sh
-            #   -FarmRegion=$WORLD_REGION
-            #   -ini:engine:[FuncomLiveServices]:ServiceAuthToken=$FLS_SECRET
-            #   -ini:game:[DuneDatabaseInterfacePSQL]:DatabaseHost=postgres:5432 (user=dune, pw=$POSTGRES_DUNE_PASSWORD)
-            #   --RMQGameHostname=game-rmq --RMQGamePort=5672 --RMQAdminHostname=admin-rmq --RMQAdminPort=5672
-            #   -RMQGameTlsEnabled=true  -ExternalAddress=$EXTERNAL_ADDRESS  -MultiHome=$POD_IP
+            # NOTE: do NOT override command — image Cmd is /home/dune/run.sh, which
+            # does the k8s external-address/pod-patch dance then execs the UE5 binary
+            # with these args. Secrets passed via env (TODO #3: confirm UE5 honours
+            # FuncomLiveServices__ServiceAuthToken env; else inject via -ini: in a wrapper).
+            args:
+              - -FarmRegion=${DUNE_WORLD_REGION}
+              - -ini:engine:[OnlineSubsystem]:ServerName=${DUNE_WORLD_UNIQUE_NAME}
+              - -ini:engine:[OnlineSubsystem]:DatacenterId=${DUNE_WORLD_DATACENTER_ID}
+              - -ini:engine:[FuncomLiveServices]:DefaultFlsEnvironment=retail
+              - -ini:game:[DuneDatabaseInterfacePSQL]:DatabaseHost=postgres:5432
+              - -ini:game:[DuneDatabaseInterfacePSQL]:DatabaseUser=dune
+              - -RMQGameTlsEnabled=true
+              - --RMQGameHostname=game-rmq
+              - --RMQGamePort=5672
+              - --RMQAdminHostname=admin-rmq
+              - --RMQAdminPort=5672
+              - -MultiHome=$POD_IP          # run.sh rewrites with node ExternalIP if available
             env:
-              WORLD_NAME: "${DUNE_WORLD_NAME}"
-              WORLD_UNIQUE_NAME: "${DUNE_WORLD_UNIQUE_NAME}"
-              WORLD_REGION: "${DUNE_WORLD_REGION}"
-              WORLD_DATACENTER_ID: "${DUNE_WORLD_REGION}"
+              FuncomLiveServices__ServiceAuthToken:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: FLS_SECRET } }
+              POSTGRES_DUNE_PASSWORD:
+                valueFrom: { secretKeyRef: { name: dune-awakening-secret, key: POSTGRES_DUNE_PASSWORD } }
               POD_IP:
-                valueFrom:
-                  fieldRef:
-                    fieldPath: status.podIP        # -> -MultiHome
-            envFrom:
-              - secretRef: { name: dune-awakening-secret }  # FLS_SECRET, EXTERNAL_ADDRESS, POSTGRES_DUNE_PASSWORD
+                valueFrom: { fieldRef: { fieldPath: status.podIP } }
+              POD_NAME:
+                valueFrom: { fieldRef: { fieldPath: metadata.name } }
+              NODE_NAME:
+                valueFrom: { fieldRef: { fieldPath: spec.nodeName } }
             resources:
               requests: { cpu: 2, memory: 12Gi }
               limits: { memory: 20Gi }
@@ -132,16 +236,19 @@ spec:
     service:
       game-survival:
         controller: game-survival
-        type: LoadBalancer            # Cilium L2, UDP
+        type: LoadBalancer            # Cilium L2, UDP game traffic (7xxx/8xxx per run.sh)
         annotations:
-          io.cilium/lb-ipam-pool: PLACEHOLDER
+          io.cilium/lb-ipam-pool: PLACEHOLDER   # TODO: pool + spare IP
         ports:
           game:
-            port: 27015               # Funcom default base; configurable
+            port: 7777
+            protocol: UDP
+          igw:
+            port: 8888
             protocol: UDP
       game-rmq:
         controller: game-rmq
-        type: LoadBalancer            # AMQPS, WAN-reachable
+        type: LoadBalancer            # AMQPS, client-reachable
         ports:
           amqps:
             port: 31982
@@ -157,14 +264,16 @@ spec:
             app:
               - path: /var/lib/postgresql/data
       saved:
-        existingClaim: dune-awakening-saved   # ceph-filesystem RWX, shared Saved/ across maps
+        accessMode: ReadWriteMany
+        size: 20Gi
+        storageClass: ceph-filesystem      # shared Saved/ across map servers
         advancedMounts:
           game-survival:
             app:
               - path: /home/dune/server/DuneSandbox/Saved
       rmq-tls:
         type: secret
-        name: dune-game-rmq-tls               # cert-manager Certificate (TODO)
+        name: dune-game-rmq-tls             # TODO #5: cert-manager Certificate
         advancedMounts:
           game-rmq:
             app:

--- a/kubernetes/apps/games/dune-awakening/app/helmrelease.yaml
+++ b/kubernetes/apps/games/dune-awakening/app/helmrelease.yaml
@@ -30,9 +30,10 @@ spec:
         name: bjw-s
         namespace: flux-system
   values:
-    defaultPodOptions:
-      # run.sh needs the SA token to read its node + patch its pod (see rbac.yaml)
-      serviceAccountName: dune-awakening
+    # SA the chart creates; rbac.yaml binds it (get nodes + patch pods). Only the
+    # game server (run.sh) needs it — attached per-controller below.
+    serviceAccount:
+      dune-awakening: {}
     controllers:
       # ---------------- data plane -------------------------------------------
       postgres:
@@ -196,6 +197,8 @@ spec:
 
       # ---------------- game server: one controller per map (start: survival) ----
       game-survival:
+        serviceAccount:
+          identifier: dune-awakening
         containers:
           app:
             image:

--- a/kubernetes/apps/games/dune-awakening/app/helmrelease.yaml
+++ b/kubernetes/apps/games/dune-awakening/app/helmrelease.yaml
@@ -206,6 +206,7 @@ spec:
             # with these args. Secrets passed via env (TODO #3: confirm UE5 honours
             # FuncomLiveServices__ServiceAuthToken env; else inject via -ini: in a wrapper).
             args:
+              - -Port=7777                  # pin game UDP port (UE5 default; [URL] empty)
               - -FarmRegion=${DUNE_WORLD_REGION}
               - -ini:engine:[OnlineSubsystem]:ServerName=${DUNE_WORLD_UNIQUE_NAME}
               - -ini:engine:[OnlineSubsystem]:DatacenterId=${DUNE_WORLD_DATACENTER_ID}
@@ -238,8 +239,10 @@ spec:
         controller: game-survival
         type: LoadBalancer            # Cilium L2, UDP game traffic (7xxx/8xxx per run.sh)
         annotations:
-          io.cilium/lb-ipam-pool: PLACEHOLDER   # TODO: pool + spare IP
+          io.cilium/lb-ipam-ips: ${DUNE_GAME_LBIP}
         ports:
+          # TODO: pin the game/igw UDP ports (run.sh currently discovers them via
+          # lsof). These must be deterministic to match the LB + router forward.
           game:
             port: 7777
             protocol: UDP
@@ -248,7 +251,9 @@ spec:
             protocol: UDP
       game-rmq:
         controller: game-rmq
-        type: LoadBalancer            # AMQPS, client-reachable
+        type: LoadBalancer            # AMQPS, client-reachable at ${DUNE_EXTERNAL_ADDRESS}:31982
+        annotations:
+          io.cilium/lb-ipam-ips: ${DUNE_RMQ_LBIP}
         ports:
           amqps:
             port: 31982

--- a/kubernetes/apps/games/dune-awakening/app/kustomization.yaml
+++ b/kubernetes/apps/games/dune-awakening/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+# NOTE: image-sync/ (the SteamCMD→zot pull tooling) is intentionally NOT included
+# here — it's separate operational tooling, not part of the server deployment.

--- a/kubernetes/apps/games/dune-awakening/app/rbac.yaml
+++ b/kubernetes/apps/games/dune-awakening/app/rbac.yaml
@@ -5,11 +5,8 @@
 #   - PATCH its own pod/status → writes gamePid/gamePort/igwPort/sshPort annotations
 # Operator-free: we provide what Funcom's Server operator normally would.
 # =============================================================================
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: dune-awakening
+# NOTE: the ServiceAccount "dune-awakening" is created by the app-template chart
+# (values.serviceAccount). These bind to it.
 ---
 # nodes are cluster-scoped → ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubernetes/apps/games/dune-awakening/app/rbac.yaml
+++ b/kubernetes/apps/games/dune-awakening/app/rbac.yaml
@@ -1,0 +1,58 @@
+# =============================================================================
+# RBAC the game server needs. /home/dune/run.sh (the image's native entrypoint)
+# uses the pod ServiceAccount token to:
+#   - GET its node           → reads status.addresses[ExternalIP] for -ExternalAddress
+#   - PATCH its own pod/status → writes gamePid/gamePort/igwPort/sshPort annotations
+# Operator-free: we provide what Funcom's Server operator normally would.
+# =============================================================================
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dune-awakening
+---
+# nodes are cluster-scoped → ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dune-awakening-node-reader
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dune-awakening-node-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dune-awakening-node-reader
+subjects:
+  - kind: ServiceAccount
+    name: dune-awakening
+    namespace: games
+---
+# patch own pod annotations/status → namespaced Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dune-awakening-pod-patcher
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/status"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dune-awakening-pod-patcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dune-awakening-pod-patcher
+subjects:
+  - kind: ServiceAccount
+    name: dune-awakening
+    namespace: games

--- a/kubernetes/apps/games/dune-awakening/ks.yaml
+++ b/kubernetes/apps/games/dune-awakening/ks.yaml
@@ -36,5 +36,7 @@ spec:
       DUNE_WORLD_REGION: "Oceania"
       DUNE_WORLD_DATACENTER_ID: "Oceania"
       DUNE_DB_NAME: "dune_sb_1_4_0_0"          # TODO: confirm branch-specific DB name
-      # --- TODO #2: real routable public/LAN IP players connect to ---
-      DUNE_EXTERNAL_ADDRESS: "PLACEHOLDER_PUBLIC_IPV4"
+      # --- networking (Cilium lb-pool 10.99.8.0/24; play.nerdz.cloud → 210.54.38.155) ---
+      DUNE_GAME_LBIP: "10.99.8.217"            # next free in lb-pool (UDP game/igw)
+      DUNE_RMQ_LBIP: "10.99.8.218"             # game-rmq AMQPS 31982
+      DUNE_EXTERNAL_ADDRESS: "play.nerdz.cloud"  # public; router forwards to the LB IPs above

--- a/kubernetes/apps/games/dune-awakening/ks.yaml
+++ b/kubernetes/apps/games/dune-awakening/ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dune-awakening
+  namespace: &namespace games
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cluster-apps-rook-ceph-cluster
+      namespace: rook-ceph
+    - name: external-secrets-stores
+      namespace: external-secrets
+  prune: true
+  interval: 30m
+  path: "./kubernetes/apps/games/dune-awakening/app"
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      # --- image source (zot) ---
+      DUNE_REGISTRY: "zot.nerdz.cloud"
+      DUNE_TAG: "1979201-0-shipping"
+      # --- world config (edit to taste) ---
+      DUNE_WORLD_NAME: "Nerdz Dune Awakening Server"
+      DUNE_WORLD_UNIQUE_NAME: "sh-nerdz-dune"
+      DUNE_WORLD_REGION: "Oceania"
+      DUNE_WORLD_DATACENTER_ID: "Oceania"
+      DUNE_DB_NAME: "dune_sb_1_4_0_0"          # TODO: confirm branch-specific DB name
+      # --- TODO #2: real routable public/LAN IP players connect to ---
+      DUNE_EXTERNAL_ADDRESS: "PLACEHOLDER_PUBLIC_IPV4"

--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 
 resources:
   # Applications
+  - ./dune-awakening/ks.yaml
   - ./pelican/ks.yaml
   - ./pelican-dev/ks.yaml
   - ./romm/ks.yaml


### PR DESCRIPTION
Deploys the self-hosted Dune Awakening server operator-free, images from the self-hosted zot registry.

**Stack:** postgres, admin-rmq, game-rmq, db-init, director, text-router, gateway, game-survival (per-map) via bjw-s/app-template. Native run.sh entrypoint. RBAC: SA + get-nodes + patch-pods. Secrets via onepassword-connect (item dune-awakening). Cilium LB: game 10.99.8.217, game-rmq 10.99.8.218; external address play.nerdz.cloud; game port pinned -Port=7777.

**First deploy — expect iteration.** Three things only confirmable from runtime logs: the IGW UDP port, whether the game binary reads FLS/DB from env vs needing -ini: CLI args, and DB bootstrap. Router forwards after ports confirmed.

Verified: kustomize build + kubeconform (7 resources Valid).