### PR TITLE
fix(lncrawl): repair malformed off-host chapter links

### DIFF
--- a/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/bloomingtranslation.py
@@ -9,6 +9,7 @@ import logging
 import re
 import threading
 import time
+import urllib.parse
 
 from lncrawl.core import Chapter, LegacyCrawler
 
@@ -57,10 +58,19 @@ class BloomingTranslation(LegacyCrawler):
         content = soup.select_one("div.entry-content") or soup
         self.volumes.append({"id": 1, "title": self.novel_title})
 
+        home_host = urllib.parse.urlparse(self.home_url).netloc
         seen = set()
         for a in content.select("a[href]"):
             href = self.absolute_url(a.get("href"))
-            if not href or href in seen:
+            if not href:
+                continue
+            # Some TOC links have a malformed host (a source typo, e.g.
+            # http://g/2026/05/21/mdd-chapter-209-part-4); rebuild from the path
+            # against the real site host so the chapter is still reachable.
+            parsed = urllib.parse.urlparse(href)
+            if parsed.netloc and parsed.netloc != home_host:
+                href = self.home_url.rstrip("/") + parsed.path
+            if href in seen:
                 continue
             if re.search(r"/20\d\d/\d\d/\d\d/", href) and "chapter" in href.lower():
                 seen.add(href)

--- a/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
+++ b/kubernetes/apps/downloads/lncrawl/app/resources/dreamsofjianghu.py
@@ -62,10 +62,17 @@ class DreamsOfJianghu(LegacyCrawler):
         content = soup.select_one("div.entry-content") or soup
         self.volumes.append({"id": 1, "title": self.novel_title})
 
+        home_host = urllib.parse.urlparse(self.home_url).netloc
         seen = set()
         for a in content.select("a[href]"):
             href = self.absolute_url(a.get("href"))
-            if not href or href in seen:
+            if not href:
+                continue
+            # repair malformed off-host links (source typos) from the path
+            parsed = urllib.parse.urlparse(href)
+            if parsed.netloc and parsed.netloc != home_host:
+                href = self.home_url.rstrip("/") + parsed.path
+            if href in seen:
                 continue
             # chapter permalinks are dated and contain 'chapter'
             if re.search(r"/20\d\d/\d\d/\d\d/", href) and "chapter" in href.lower():


### PR DESCRIPTION
Marriage of the Di Daughter finished **667/668** after the image-strip fix. The one miss (Chapter 209 Part 4) is a typo'd link on the source TOC — host `g` instead of the domain (`http://g/2026/05/21/mdd-chapter-209-part-4`), so it 404'd.

**Fix:** normalize chapter links — if a link's host isn't the site's host, rebuild from the path against the site host. Verified: the broken chapter now resolves to the real URL and downloads; total stays 668, 0 malformed.

Applied to `bloomingtranslation` (the bug) + `dreamsofjianghu` (same link structure, cheap robustness). `orchidtales` left alone — it has bespoke `?p=` link handling.

After merge: delete + re-add to pick up the corrected chapter URL (the existing chapter row still holds the bad `http://g/` URL, so Replay alone won't fix it).