### PR TITLE
feat(lncrawl): sidecar to sync built EPUBs into the Calibre inbox

### DIFF
--- a/kubernetes/apps/downloads/lncrawl/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lncrawl/app/helmrelease.yaml
@@ -67,6 +67,33 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 3Gi
+          # lncrawl stores built EPUBs in /data/novels/<uuid>/artifacts/ and has
+          # no setting to write elsewhere. This sidecar copies each newly-built
+          # EPUB into the Calibre inbox on the NFS share. The -newer marker means
+          # each artifact syncs once (and again only if lncrawl rebuilds it), so
+          # processed books removed from the inbox are not re-copied.
+          inbox-sync:
+            image:
+              repository: docker.io/library/busybox
+              tag: "1.36"
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                [ -f /data/.inbox-marker ] || touch /data/.inbox-marker
+                while true; do
+                  find /data/novels -name '*.epub' -type f -newer /data/.inbox-marker -exec cp {} /media/Library/Books/_inbox/ \;
+                  touch /data/.inbox-marker
+                  sleep 120
+                done
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
     defaultPodOptions:
       labels:
         nfsMount: "true"


### PR DESCRIPTION
## Why

lncrawl stores built EPUBs in `/data/novels/<uuid>/artifacts/` (a managed store keyed by novel UUID) and has **no config to write elsewhere** — finished crawls only surface via the UI download button, never reaching the Calibre inbox.

## What

A small `busybox:1.36` sidecar in the lncrawl pod (which already mounts both `/data` and the `/media` NFS share) copies each newly-built EPUB into `/media/Library/Books/_inbox`.

```sh
[ -f /data/.inbox-marker ] || touch /data/.inbox-marker
while true; do
  find /data/novels -name '*.epub' -type f -newer /data/.inbox-marker -exec cp {} /media/Library/Books/_inbox/ \;
  touch /data/.inbox-marker
  sleep 120
done
```

- **`-newer` marker** (not a state list) so the script has **no shell vars** → Flux variable substitution leaves it untouched.
- Each artifact syncs **once**; re-syncs only if lncrawl **rebuilds** it (newer mtime). Books processed and removed from the inbox are **not** re-copied.
- Marker pre-seeded at deploy time, so the 5 already-built artifacts (copied manually) won't re-sync.

## Notes

- Runs as the pod's non-root 568 with caps dropped; tiny resource ask (10m/16Mi).
- Copies **all** completed crawls including MTL/ongoing builds — fine for a personal inbox; can be gated to a naming convention later if wanted.
- KEDA nfs-scaler caveat: if the pod scales to 0 right after a build, that artifact syncs on the next scale-up (marker persists) — eventually consistent.