### PR TITLE
feat(lighthouse): licence-gate 0.1.6 — role-gating + tier-aware dispatch

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -96,7 +96,7 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              tag: 0.1.5@sha256:4564f14a4090e8ab39170d41b5a257f9c34ae730867dffbfefc96f15e25d3d61
+              tag: 0.1.6@sha256:5527aa31c6029bf0d1f8dc06de871fe7ab009428016a693096ef4e536a6b749c
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"


### PR DESCRIPTION
## Summary
Bumps `licence-gate` to `0.1.6` (digest `sha256:5527aa31...`, containers#9).

Adds **role-gating by model tag** (`requires_group`) and **tier-aware dispatch** (filter `/distributed/queue` `enabled_worker_ids` by `tier_fit`). See ADR-019.

## Ship-inert
**This deploy changes nothing behaviorally.** v0.1.6 is backward-compatible — untagged model = no role restriction; no worker `tier` field / no gpu_config mount = no tier filtering. Enforcement activates in a follow-up PR that tags mature-content models, sets `tier_fit`, adds `tier` to gpu_config workers, and mounts gpu_config into the proxy sidecar (needs Gavin's mature-content model list).

## Test plan
- [ ] flux reconcile → lighthouse pod on digest `5527aa31`
- [ ] S1/S2 smoke still pass (no behavior change expected)