### PR TITLE
chore(dune): shelve deployment (keep manifests + zot + images)

### DIFF
--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -8,7 +8,9 @@ components:
 
 resources:
   # Applications
-  - ./dune-awakening/ks.yaml
+  # - ./dune-awakening/ks.yaml   # SHELVED — manifests kept under ./dune-awakening/;
+  #   re-add this line to redeploy. Operator-free hit the FLS battlegroup-registration
+  #   wall; images remain in zot. See dune-awakening/PORT-NOTES.md + memory.
   - ./pelican/ks.yaml
   - ./pelican-dev/ks.yaml
   - ./romm/ks.yaml


### PR DESCRIPTION
Shelves the Dune Awakening deployment. Unwires it from the games namespace → Flux prunes the deployed pods/services/secret/rbac/PVCs. Manifests stay in-repo (redeploy = re-add the line); zot registry + images stay. Operator-free hit the FLS battlegroup-registration wall — see PORT-NOTES + memory.