### PR TITLE
chore(mangarr): bump to sha-331752c (series detail page #8)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-7aa515a@sha256:a8fcda24c95e05a0cc44ca482697143d7fdab3f5a72eb47f3ce6aed20cd907a5
+              tag: sha-331752c@sha256:68b9dc751834f02c8cffcc41bc76ecdd7a657b40cd66d82c72b08ebb6f87af19
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
Bumps mangarr to `sha-331752c` — the per-series detail page (`GET /series/{id}`) with per-chapter file list, re-run filer, and remove-to-bin actions. Closes mangarr Sonarr-port #8 (gavinmcfall/mangarr#58).

Image: `ghcr.io/gavinmcfall/mangarr:sha-331752c@sha256:68b9dc751834f02c8cffcc41bc76ecdd7a657b40cd66d82c72b08ebb6f87af19`