### PR TITLE
feat(lighthouse): activate role-gating + tier dispatch (T8)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -251,6 +251,11 @@ spec:
             main:
               - path: /app/custom_nodes/ComfyUI-Distributed/gpu_config.json
                 subPath: gpu_config.json
+            # Same gpu_config feeds the proxy's tier-aware dispatch (workers[].tier);
+            # default LIGHTHOUSE_GPU_CONFIG_PATH is /config/gpu_config.json (ADR 019).
+            licence-gate:
+              - path: /config/gpu_config.json
+                subPath: gpu_config.json
       tmp:
         type: emptyDir
         advancedMounts:

--- a/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
@@ -11,7 +11,8 @@
       "enabled": true,
       "type": "remote",
       "cuda_device": 0,
-      "extra_args": ""
+      "extra_args": "",
+      "tier": "heavy"
     },
     {
       "id": "gpu-vixen",
@@ -21,7 +22,8 @@
       "enabled": true,
       "type": "remote",
       "cuda_device": 0,
-      "extra_args": ""
+      "extra_args": "",
+      "tier": "heavy"
     }
   ],
   "settings": {

--- a/kubernetes/apps/cortex/lighthouse/app/resources/registry.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/registry.json
@@ -171,6 +171,7 @@
   },
   {
     "filename": "pony-diffusion-v6-xl.safetensors",
+    "requires_group": "mature-content",
     "sha256": "TBD-on-acquisition",
     "licence": "Modified Fair AI Public License 1.0-SD (creator addendum: non-commercial without explicit auth)",
     "commercial_ok": false,
@@ -184,6 +185,7 @@
   },
   {
     "filename": "noobai-xl-epsilon-1.1.safetensors",
+    "requires_group": "mature-content",
     "sha256": "TBD-on-acquisition",
     "licence": "Fair AI Public License 1.0-SD + creator non-commercial addendum",
     "commercial_ok": false,
@@ -197,6 +199,7 @@
   },
   {
     "filename": "nova-furry-xl-il-v18.safetensors",
+    "requires_group": "mature-content",
     "sha256": "TBD-on-acquisition",
     "licence": "FAIPL 1.0 (creator rider: unedited generated images not commercial)",
     "commercial_ok": false,
@@ -209,6 +212,7 @@
   },
   {
     "filename": "cyberrealistic-xl-v10.safetensors",
+    "requires_group": "mature-content",
     "sha256": "TBD-on-acquisition",
     "licence": "CreativeML Open RAIL++-M with Addendum",
     "commercial_ok": true,
@@ -222,6 +226,7 @@
   },
   {
     "filename": "cyberrealistic-pony-v18.safetensors",
+    "requires_group": "mature-content",
     "sha256": "TBD-on-acquisition",
     "licence": "CreativeML Open RAIL++-M",
     "commercial_ok": true,


### PR DESCRIPTION
## Summary
Activates the licence-gate v0.1.6 enforcement (shipped inert in #2143). **This is the change that makes mature-content models Gavin-only and tier routing live.**

- **registry.json** — tag the 5 NSFW-purpose models `requires_group: mature-content`: `pony-diffusion-v6-xl`, `noobai-xl-epsilon-1.1`, `nova-furry-xl-il-v18`, `cyberrealistic-xl-v10`, `cyberrealistic-pony-v18`. Filenames verified against the models PVC (4/5 present; noobai deferred). Per Gavin's call, the NSFW-*prone-but-not-purpose* photoreal/anime bases (Juggernaut, RealVisXL, epiCRealism, Realistic Vision, Illustrious, WAI) stay **untagged = open to all family incl. kids**.
- **gpu_config.json** — both workers `tier: heavy` (4080S 16 GB).
- **helmrelease** — mount gpu_config into the licence-gate sidecar at `/config/gpu_config.json` so the proxy reads worker tiers for `/distributed/queue` filtering.

Classification sourced from `image-gen-models-final-picks-2026-05-30.md`; rationale in ADR-019.

## Effect after reconcile
- A non-`mature-content` identity (including the kids) **cannot invoke the 5 NSFW models from any client** — 403 by construction (model-tag, not workflow; uncraftable-around).
- Tier filtering active; no-op until Nova/Blaze join as `tier: light` (Phase 3), then SDXL jobs skip them.

## Test plan
- [ ] flux reconcile → pod restarts with new configmaps
- [ ] As Gavin (mature-content): render with `cyberrealistic-xl-v10` → 200
- [ ] As Serina/kid (no mature-content): same model → 403 `requires-group`
- [ ] Untagged model (e.g. juggernaut) as any family member → 200
- [ ] S1/S2 still pass