### PR TITLE
feat(lighthouse): pre-stage Nova/Blaze as light-tier workers (disabled)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
@@ -24,6 +24,28 @@
       "cuda_device": 0,
       "extra_args": "",
       "tier": "heavy"
+    },
+    {
+      "id": "gpu-nova",
+      "name": "Nova (3050)",
+      "host": "pc-nova.internal",
+      "port": 8188,
+      "enabled": false,
+      "type": "remote",
+      "cuda_device": 0,
+      "extra_args": "",
+      "tier": "light"
+    },
+    {
+      "id": "gpu-blaze",
+      "name": "Blaze (3050)",
+      "host": "pc-blaze.internal",
+      "port": 8188,
+      "enabled": false,
+      "type": "remote",
+      "cuda_device": 0,
+      "extra_args": "",
+      "tier": "light"
     }
   ],
   "settings": {


### PR DESCRIPTION
## Summary
Pre-stages the kids' PCs in `gpu_config.json` so bringing them online later is a one-line flip:
- `gpu-nova` (pc-nova.internal) + `gpu-blaze` (pc-blaze.internal), `tier: light`, **`enabled: false`** (parked).

They stay out of the pool until their Phase-0 WSL2 + ComfyUI-Distributed install is done (3050 8GB). Once installed, flip `enabled: true` and tier-aware dispatch (v0.1.6) keeps SDXL/Flux off them automatically (SD-1.5 fans to them).

## Safe now
`enabled: false` = ComfyUI-Distributed parks them (no probe, no dispatch). Proxy tier map includes them harmlessly (not in any `enabled_worker_ids` until enabled).

## Test plan
- [ ] flux reconcile → pod restarts; Distributed panel shows Nova/Blaze as disabled (not red-error)
- [ ] Existing 2-worker render still works