### PR TITLE
feat(lighthouse): enable Nova as light-tier worker

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
@@ -30,7 +30,7 @@
       "name": "Nova (3050)",
       "host": "pc-nova.internal",
       "port": 8188,
-      "enabled": false,
+      "enabled": true,
       "type": "remote",
       "cuda_device": 0,
       "extra_args": "",


### PR DESCRIPTION
## Summary
Flip `gpu-nova` `enabled: false → true`. Nova's Phase-0 is done and verified live:
- WSL2 `lighthouse` + CUDA 13.3 + ComfyUI (running as `comfyui-worker.service`)
- ComfyUI-Distributed **v.1.4.0** plugin installed; `/distributed/system_info` → `{"status":"success","hostname":"Nova"}`
- master pod reaches `pc-nova.internal:8188` (probed from the cluster)

Tier-aware dispatch (v0.1.6) tags Nova `tier: light` → SDXL/Flux jobs never land on it (3050 8GB); SD-1.5-class fans to it. Blaze stays `enabled: false` until its plugin install.

## Test plan
- [ ] flux reconcile → master picks up Nova; Distributed panel shows Nova green
- [ ] SD-1.5 fan-out includes Nova; an SDXL job does NOT (tier filter)