### PR TITLE
feat(lighthouse): enable Blaze as light-tier worker — full 4-worker pool

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/gpu_config.json
@@ -41,7 +41,7 @@
       "name": "Blaze (3050)",
       "host": "pc-blaze.internal",
       "port": 8188,
-      "enabled": false,
+      "enabled": true,
       "type": "remote",
       "cuda_device": 0,
       "extra_args": "",


### PR DESCRIPTION
## Summary
Flip `gpu-blaze` `enabled: false → true`. Blaze Phase-0 verified live (user `ariana`): WSL2 lighthouse + CUDA 13.3 + ComfyUI + ComfyUI-Distributed **v.1.4.0**; `/distributed/system_info` → `{"status":"success","hostname":"Blaze"}`; master reaches `pc-blaze.internal:8188`.

**Both kids' 3050s are now live light-tier workers.** Pool: Vengeance + Vixen (heavy) + Nova + Blaze (light) = 4 GPU workers. Tier-aware dispatch (v0.1.6) keeps SDXL/Flux off the 3050s.

## Test plan
- [ ] flux reconcile → master loads gpu-blaze enabled; Distributed panel shows all 4 green
- [ ] SD-1.5 fan-out spreads across light + heavy; SDXL skips the 3050s