### PR TITLE
feat(home): calibre-web-automated eval instance

### DIFF
--- a/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
@@ -1,0 +1,127 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app calibre-web-automated
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  values:
+    defaultPodOptions:
+      # CWA is an s6-overlay image: it must start as root then drop to PUID/PGID.
+      # s6 is contained via the env flags + minimal caps below (rafaribe pattern).
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        seccompProfile: { type: RuntimeDefault }
+    controllers:
+      calibre-web-automated:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/crocodilestick/calibre-web-automated
+              tag: v4.0.6@sha256:c31a738b6d5ec6982c050063dd3f063b6943eb1051fc81144789f840d9093a8d
+            env:
+              TZ: ${TIMEZONE}
+              PUID: "568"
+              PGID: "568"
+              CACHE_DIR: /cache
+              # Library + ingest live on NFS — disables SQLite WAL + uses polling watcher
+              NETWORK_SHARE_MODE: "true"
+              # Let s6-overlay work under a read-only-ish, non-privileged k8s sandbox
+              S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES: "1"
+              S6_READ_ONLY_ROOT: "1"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    port: &port 8083
+                    path: /login
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+                add: ["CHOWN", "SETUID", "SETGID", "FOWNER", "DAC_OVERRIDE"]
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "calibre.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /config
+      # Single NFS export (proven by audiobookshelf), sub-pathed to the eval-only
+      # folders so the real 459G Books library is never touched.
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /cwa-book-ingest
+            subPath: Library/Books/_cwa-eval/ingest
+          - path: /calibre-library
+            subPath: Library/Books/_cwa-eval/library
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /cache
+            subPath: cache
+          - path: /tmp
+            subPath: tmp
+          - path: /run
+            subPath: run

--- a/kubernetes/apps/home/calibre-web-automated/app/kustomization.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/calibre-web-automated/ks.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app calibre-web-automated
+  namespace: &namespace home
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/home/calibre-web-automated/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./atuin/ks.yaml
   - ./bentopdf/ks.yaml
   - ./bookstack/ks.yaml
+  - ./calibre-web-automated/ks.yaml
   - ./cdn-sync/ks.yaml
   - ./homepage/ks.yaml
   - ./filebrowser/ks.yaml


### PR DESCRIPTION
Deploys CWA (s6 contained, rafaribe pattern) to the **home** namespace at `calibre.${SECRET_DOMAIN}` (internal gateway) to evaluate its ebook reading experience vs AudiobookShelf.

- Library + ingest on NFS `_cwa-eval` subfolder → real 459G Books library untouched
- config on ceph-block PVC; PUID/PGID 568
- Disposable: remove the dir + kustomization line after the eval if not kept

Note: there is already a rootless `entertainment/calibre-web` (bjw-s) at `ebooks.${SECRET_DOMAIN}`; this CWA instance is for comparison only.