### PR TITLE
fix(home): drop invalid dependsOn on calibre-web-automated ks

### DIFF
--- a/kubernetes/apps/home/calibre-web-automated/ks.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/ks.yaml
@@ -10,9 +10,6 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   path: ./kubernetes/apps/home/calibre-web-automated/app
   prune: true
   sourceRef:


### PR DESCRIPTION
Follow-up to #2153. The Flux Kustomization `dependsOn rook-ceph/rook-ceph-cluster` references a name that exists only as a HelmRelease, so Flux blocked the app ("dependency not found"). The HelmRelease already dependsOn rook-ceph-cluster, so this ks-level dep is removed.