### PR TITLE
feat(home): ebook-reconcile CronJob (suspended)

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app ebook-reconcile
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  values:
+    controllers:
+      ebook-reconcile:
+        type: cronjob
+        cronjob:
+          # SUSPENDED until the controlled first run is validated.
+          suspend: true
+          schedule: "*/15 * * * *"
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          backoffLimit: 1
+        pod:
+          # calibredb is a plain binary here (command override, no s6 init) → run rootless,
+          # UID 568 to match the NFS file ownership the CWA workbench writes.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile: { type: RuntimeDefault }
+        containers:
+          app:
+            image:
+              repository: ghcr.io/crocodilestick/calibre-web-automated
+              tag: v4.0.6@sha256:c31a738b6d5ec6982c050063dd3f063b6943eb1051fc81144789f840d9093a8d
+            command: ["python3", "/scripts/reconcile.py"]
+            env:
+              TZ: ${TIMEZONE}
+              HOME: /tmp
+              CALIBRE_CONFIG_DIRECTORY: /tmp/calibre
+              LIB: /media/Library/Books/_cwa-eval/library      # staging Calibre library (CWA workbench)
+              DEST: /media/Library/Books/Books                 # AudiobookShelf books root
+              STATE: /state/abs_paths.json
+              TAG: "→abs"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    persistence:
+      scripts:
+        type: configMap
+        name: ebook-reconcile-scripts
+        defaultMode: 0555
+        globalMounts:
+          - path: /scripts
+      # Single NFS mount so LIB (library) and DEST (Books) share one device → hardlinks work.
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /media
+      state:
+        accessMode: ReadWriteOnce
+        size: 128Mi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /state
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/home/ebook-reconcile/app/kustomization.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: ebook-reconcile-scripts
+    files:
+      - reconcile.py=./resources/reconcile.py
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Reconcile curated ebooks from a Calibre library into the AudiobookShelf
+folder structure via HARDLINKS — idempotent.
+
+For every book tagged `→abs` (the review gate), compute its ABS path
+(`<Genre>/<Author>/<Series>/<NN - Title>/<Title>.epub`) and hardlink Calibre's
+epub there. Same dataset → nlink=2, one physical copy, zero extra bytes, and
+Calibre retains the book.
+
+- New book          -> link
+- File replaced     -> inode mismatch -> re-link  (re-convert/re-embed in Calibre)
+- In-place edit     -> same inode -> ABS already current, no action
+- Metadata path move-> state says old path -> remove old hardlink, link new
+- Unchanged         -> skip
+
+Reads metadata via `calibredb` (handles locking + custom columns + format
+paths). Keeps its own state file (book id -> last dst) so it never writes to
+Calibre's metadata.db.
+
+Env: LIB, DEST, STATE (default /state/abs_paths.json), TAG (default →abs).
+"""
+import json
+import os
+import re
+import subprocess
+
+LIB = os.environ["LIB"]
+DEST = os.environ["DEST"]
+STATE = os.environ.get("STATE", "/state/abs_paths.json")
+TAG = os.environ.get("TAG", "→abs")
+GENRE_FIELD = os.environ.get("GENRE_FIELD", "*genre")
+FIELDS = f"id,title,authors,series,series_index,{GENRE_FIELD},formats"
+
+
+def calibredb(*args):
+    return subprocess.run(
+        ["calibredb", "--with-library", LIB, *args],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def sanitize(s):
+    """Filesystem-safe, matching how the existing folders are named."""
+    s = re.sub(r'[/:*?"<>|]', "_", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def load_state():
+    try:
+        with open(STATE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(st):
+    os.makedirs(os.path.dirname(STATE) or ".", exist_ok=True)
+    tmp = STATE + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(st, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, STATE)
+
+
+def rel_path(b):
+    genre = sanitize(b.get(GENRE_FIELD) or "")
+    author = sanitize(b.get("authors") or "")
+    title = sanitize(b.get("title") or "")
+    series = (b.get("series") or "").strip()
+    if not (genre and author and title):
+        return None
+    if series:
+        s = sanitize(series)
+        nn = f'{int(float(b.get("series_index") or 0)):02d}'
+        return os.path.join(genre, author, s, f"{nn} - {title}", f"{title}.epub")
+    return os.path.join(genre, author, title, f"{title}.epub")
+
+
+def epub_of(b):
+    for p in (b.get("formats") or []):
+        if p.lower().endswith(".epub"):
+            return p
+    return None
+
+
+def main():
+    books = json.loads(calibredb(
+        "list", "--search", f'tag:"{TAG}"', "--fields", FIELDS, "--for-machine") or "[]")
+    state = load_state()
+    linked = relinked = moved = skipped = ok = 0
+
+    for b in books:
+        bid, rp, src = str(b["id"]), rel_path(b), epub_of(b)
+        if not rp or not src or not os.path.exists(src):
+            print(f"SKIP id={bid} '{b.get('title')}' (missing genre/author/title/epub) -> review")
+            skipped += 1
+            continue
+        dst = os.path.join(DEST, rp)
+        prev = state.get(bid)
+
+        if prev and prev != dst and os.path.lexists(prev):       # metadata moved the path
+            os.remove(prev)
+            try:
+                os.removedirs(os.path.dirname(prev))
+            except OSError:
+                pass
+            moved += 1
+            print(f"MOVED id={bid}: removed stale {prev}")
+
+        if not os.path.lexists(dst):
+            colocated = os.path.isdir(os.path.dirname(dst))
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            os.link(src, dst)
+            linked += 1
+            print(f"LINK   id={bid} -> {rp}  [{'colocated' if colocated else 'new folder'}]")
+        elif os.stat(dst).st_ino != os.stat(src).st_ino:
+            os.remove(dst)
+            os.link(src, dst)
+            relinked += 1
+            print(f"RELINK id={bid} (file changed) -> {rp}")
+        else:
+            ok += 1
+            print(f"OK     id={bid} (current)")
+        state[bid] = dst
+
+    save_state(state)
+    print(f"\ndone: {len(books)} {TAG} book(s) | "
+          f"linked={linked} relinked={relinked} moved={moved} ok={ok} skipped={skipped}")
+
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/apps/home/ebook-reconcile/ks.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ebook-reconcile
+  namespace: &namespace home
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: calibre-web-automated
+      namespace: home
+  path: ./kubernetes/apps/home/ebook-reconcile/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./bookstack/ks.yaml
   - ./calibre-web-automated/ks.yaml
   - ./cdn-sync/ks.yaml
+  - ./ebook-reconcile/ks.yaml
   - ./homepage/ks.yaml
   - ./filebrowser/ks.yaml
   - ./linkwarden/ks.yaml


### PR DESCRIPTION
Idempotent reconciler that hardlinks `→abs`-tagged ebooks from the Calibre staging library into the ABS Books folders (nlink=2, no dup, Calibre retains). **Suspended**; validated against the eval library. First real run = controlled manual Job vs a test DEST before enabling. Design: nerdz-reading/docs/ebook-curation-pipeline.md.