### PR TITLE
fix(home): ebook-reconcile calibredb absolute path

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
@@ -57,6 +57,8 @@ spec:
               TZ: ${TIMEZONE}
               HOME: /tmp
               CALIBRE_CONFIG_DIRECTORY: /tmp/calibre
+              # /usr/bin/calibredb is an s6-created runtime symlink; command-override skips s6
+              CALIBREDB: /app/calibre/calibredb
               LIB: /media/Library/Books/_cwa-eval/library      # staging Calibre library (CWA workbench)
               DEST: /media/Library/Books/Books                 # AudiobookShelf books root
               STATE: /state/abs_paths.json

--- a/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
@@ -29,12 +29,15 @@ DEST = os.environ["DEST"]
 STATE = os.environ.get("STATE", "/state/abs_paths.json")
 TAG = os.environ.get("TAG", "→abs")
 GENRE_FIELD = os.environ.get("GENRE_FIELD", "*genre")
+# In the CWA image `/usr/bin/calibredb` is a symlink created by s6 at runtime; a
+# command-override container (no s6 init) won't have it, so point at the real binary.
+CALIBREDB = os.environ.get("CALIBREDB", "calibredb")
 FIELDS = f"id,title,authors,series,series_index,{GENRE_FIELD},formats"
 
 
 def calibredb(*args):
     return subprocess.run(
-        ["calibredb", "--with-library", LIB, *args],
+        [CALIBREDB, "--with-library", LIB, *args],
         capture_output=True, text=True, check=True,
     ).stdout
 


### PR DESCRIPTION
Command-override container skips s6, so the runtime `/usr/bin/calibredb` symlink is absent → FileNotFoundError. Use `CALIBREDB=/app/calibre/calibredb` (verified runs standalone). Follow-up to #2159.