### PR TITLE
feat(lighthouse): repin master to Phase-2a node-pack image

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           main:
             image:
               repository: ghcr.io/gavinmcfall/lighthouse
-              tag: 0.22.0@sha256:a1c492ecb450eeac4196d288e96f3bec6f8f8dbfc60ef25c7b761aaed791d106
+              tag: 0.22.0@sha256:f17070987e2397878df92485f13fe5fc01a5b048efdb98c1841717d3dd42cb31
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
Repins the `lighthouse` orchestrator master image to the Phase-2a build (containers#10).

- `ghcr.io/gavinmcfall/lighthouse:0.22.0` digest `a1c492ec` → `f1707098`
- Master now bakes the 4 vetted Phase-2a custom-node packs (Impact-Pack + Subpack, Ultimate SD Upscale, ControlNet-aux canny+depth, IPAdapter), each pinned by commit SHA — matching the install proven across all 4 GPU workers (Vengeance/Vixen/Nova/Blaze, torch 2.12, all target nodes register clean).

ComfyUI version is unchanged (still 0.22.0) — only the node set / digest changes. Reloader will roll the pod on apply.

Note: this only puts the nodes *present* on the master so it can validate graphs. The §7 licence-gate allowlist for the new class_types is a **separate follow-up** (derived from the authored workflows) — so no new node is actually renderable through the gate until that lands.