### PR TITLE
fix(lighthouse): repin master to headless-opencv build

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           main:
             image:
               repository: ghcr.io/gavinmcfall/lighthouse
-              tag: 0.22.0@sha256:f17070987e2397878df92485f13fe5fc01a5b048efdb98c1841717d3dd42cb31
+              tag: 0.22.0@sha256:0fccc66977f366bc591f2eb159f0f5cf0bca47a32d95986dbcd209782bba6ee1
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
Repins `lighthouse:0.22.0` digest `f1707098` → `0fccc669` (containers#11).

Fixes Impact-Pack + controlnet_aux failing `import cv2` on the CPU master (GUI `opencv-python` needs libGL/libxcb absent from the slim base) — now `opencv-python-headless`, so `FaceDetailer` + `DepthAnythingV2Preprocessor` register. Verified by the build-time `import cv2` gate (CI green). Only the lighthouse helmrelease digest changes.