### PR TITLE
feat(home): enable auth on calibre-server Content Server for Readarr writes

### DIFF
--- a/kubernetes/apps/home/calibre-web-automated/app/externalsecret.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: calibre-web-automated
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: calibre-web-automated-secret
+    template:
+      engineVersion: v2
+      data:
+        # Auth user for the headless calibre-server Content Server (Readarr writes
+        # via /ajax/). 1Password item "calibre-content-server" (vault Kubernetes)
+        # must hold fields: CALIBRE_SERVER_USER, CALIBRE_SERVER_PASSWORD.
+        CALIBRE_SERVER_USER: "{{ .CALIBRE_SERVER_USER }}"
+        CALIBRE_SERVER_PASSWORD: "{{ .CALIBRE_SERVER_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: calibre-content-server

--- a/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
@@ -43,10 +43,26 @@ spec:
             image:
               repository: ghcr.io/crocodilestick/calibre-web-automated
               tag: v4.0.6@sha256:c31a738b6d5ec6982c050063dd3f063b6943eb1051fc81144789f840d9093a8d
+            # Prep the content-server config dir AND (re)create its single auth
+            # user idempotently so a password rotation in 1Password propagates.
+            # password via STDIN (sys.stdin.read() to EOF) → safe for any symbols.
             command:
               - sh
               - -c
-              - mkdir -p /config/calibre-server/tmp && chown -R 568:568 /config/calibre-server
+              - |
+                set -eu
+                DB=/config/calibre-server/users.sqlite
+                mkdir -p /config/calibre-server/tmp
+                /app/calibre/calibre-server --userdb "$DB" --manage-users -- remove "$CALIBRE_SERVER_USER" 2>/dev/null || true
+                printf '%s' "$CALIBRE_SERVER_PASSWORD" | /app/calibre/calibre-server --userdb "$DB" --manage-users -- add "$CALIBRE_SERVER_USER"
+                chown -R 568:568 /config/calibre-server
+            env:
+              HOME: /config/calibre-server
+              CALIBRE_CONFIG_DIRECTORY: /config/calibre-server
+              CALIBRE_TEMP_DIR: /config/calibre-server/tmp
+            envFrom:
+              - secretRef:
+                  name: calibre-web-automated-secret
             securityContext:
               runAsUser: 0
               runAsNonRoot: false
@@ -105,20 +121,28 @@ spec:
               - /calibre-library
               - --listen-on=0.0.0.0
               - --port=8081
-              - --enable-local-write
+              # Auth governs remote writes: --enable-local-write only covers
+              # un-authenticated *localhost*, so it's moot once auth is on and
+              # Readarr connects from another pod. The auth user is read-write by
+              # default. basic auth (over internal HTTP) for Readarr compatibility.
+              - --enable-auth
+              - --auth-mode=basic
+              - --userdb=/config/calibre-server/users.sqlite
+              - --disable-use-bonjour
             env:
               TZ: ${TIMEZONE}
               HOME: /config/calibre-server
               CALIBRE_CONFIG_DIRECTORY: /config/calibre-server
               CALIBRE_TEMP_DIR: /config/calibre-server/tmp
+            # TCP probe, not HTTP: with --enable-auth every path returns 401,
+            # which a k8s httpGet probe scores as failure. Port-open = healthy.
             probes:
               liveness: &csprobes
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
+                  tcpSocket:
                     port: &csport 8081
-                    path: /
                   initialDelaySeconds: 20
                   periodSeconds: 30
                   timeoutSeconds: 5

--- a/kubernetes/apps/home/calibre-web-automated/app/kustomization.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/kustomization.yaml
@@ -3,4 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## What

Turns on authentication for the headless `calibre-server` Content Server sidecar (added in #2164) so **Readarr can write to the Calibre library** over `/ajax/` from another pod.

## Why this is required for writes

Calibre's `--enable-local-write` only governs **un-authenticated _localhost_** connections — it does nothing for a remote client. Readarr runs in a different pod, so under the previous config the Content Server was effectively **read-only to Readarr**. Enabling auth + a read-write user is what actually allows remote writes.

## Changes

- **`--enable-auth --auth-mode=basic --userdb=…`** on the calibre-server command; dropped the now-moot `--enable-local-write`.
  - `basic` (not `auto`/digest) for guaranteed Readarr HTTP-client compatibility over internal cluster HTTP.
- **Init container** creates a single read-write user idempotently (`remove || true` then `add`), password fed via **STDIN** (`sys.stdin.read()` to EOF) so any symbols are safe. Default-added users are read-write — no extra permission step.
- **Probe → `tcpSocket`**: with auth on, every HTTP path returns `401`, which a k8s `httpGet` probe scores as failure. Port-open = healthy.
- **`--disable-use-bonjour`**: silences the harmless mDNS "service name too long" warning.
- **ExternalSecret** `calibre-web-automated` → secret `calibre-web-automated-secret` (1Password, `onepassword-connect`).

## ⚠️ Merge prerequisite

Create 1Password item **`calibre-content-server`** in vault **`Kubernetes`** with fields:
- `CALIBRE_SERVER_USER` (e.g. `readarr`)
- `CALIBRE_SERVER_PASSWORD` (generated)

Until it exists the ExternalSecret stays in `SecretSyncError` and the pod's init container has no creds. The service account is read-only on 1Password, so this is a manual one-time step.

## Validation

- `kubeconform`: `externalsecret.yaml` **Valid**; `kustomize build` of the app composes cleanly (ExternalSecret + HelmRelease).
- The only `kubeconform` failure in the repo is the pre-existing `network/.../unifi` HTTPRoute `${SECRET_DOMAIN}` substitution artifact — unrelated to this PR (fails identically on `main`).