### PR TITLE
refactor(home): relocate Calibre library from _cwa-eval to .calibre

### DIFF
--- a/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
@@ -191,16 +191,17 @@ spec:
         globalMounts:
           - path: /config
       # Single NFS export (proven by audiobookshelf), sub-pathed to the eval-only
-      # folders so the real 459G Books library is never touched.
+      # Production Calibre lib + ingest under a dot-prefixed sibling of Books/
+      # (hidden from AudiobookShelf scans), same dataset → hardlinks work.
       media:
         type: nfs
         server: citadel.internal
         path: /mnt/storage0/media
         globalMounts:
           - path: /cwa-book-ingest
-            subPath: Library/Books/_cwa-eval/ingest
+            subPath: Library/Books/.calibre/ingest
           - path: /calibre-library
-            subPath: Library/Books/_cwa-eval/library
+            subPath: Library/Books/.calibre/library
       tmpfs:
         type: emptyDir
         globalMounts:

--- a/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
               CALIBRE_CONFIG_DIRECTORY: /tmp/calibre
               # /usr/bin/calibredb is an s6-created runtime symlink; command-override skips s6
               CALIBREDB: /app/calibre/calibredb
-              LIB: /media/Library/Books/_cwa-eval/library      # staging Calibre library (CWA workbench)
+              LIB: /media/Library/Books/.calibre/library       # staging Calibre library (CWA workbench)
               DEST: /media/Library/Books/Books                 # AudiobookShelf books root
               STATE: /state/abs_paths.json
               TAG: "→abs"


### PR DESCRIPTION
Promotes the eval Calibre library to its production home **before** the bulk import of 459 existing ebooks.

- Repoints CWA mount subPaths: `Library/Books/_cwa-eval/{ingest,library}` → `Library/Books/.calibre/{ingest,library}`.
- Repoints `ebook-reconcile` `LIB` to `.calibre/library`.
- Dot-prefixed sibling of `Books/` → AudiobookShelf scans ignore it; same `storage0/media` dataset → hardlinks into the Books tree keep working.

Paired with an on-NAS `mv` of the directory, done in a quiesced window (Flux suspend → scale CWA to 0 → mv → merge this → resume). Reversible.

Validated: `kustomize build` of both apps OK.