### PR TITLE
feat(downloads): mount Calibre library into bookshelf at non-dot path

### DIFF
--- a/kubernetes/apps/downloads/bookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bookshelf/app/helmrelease.yaml
@@ -110,3 +110,9 @@ spec:
         path: /mnt/storage0/media
         globalMounts:
           - path: /media
+          # Non-dot view of the Calibre library so Readarr's DiskScanService
+          # will scan it — it ignores hidden/dot-prefixed dirs, and the library
+          # lives under .calibre/ (hidden from AudiobookShelf). Readarr's Calibre
+          # root folder points at /calibre-library.
+          - path: /calibre-library
+            subPath: Library/Books/.calibre/library


### PR DESCRIPTION
## Why
Readarr's `DiskScanService` ignores hidden/dot-prefixed directories. The Calibre library lives under `Library/Books/.calibre/library` (dot-prefixed to hide it from AudiobookShelf), so Readarr scanned it as **empty** ("Scan folder ... is empty" in the log) and couldn't import the 457 existing books.

## Change
Add a second `globalMount` on the existing NFS volume exposing `Library/Books/.calibre/library` at **`/calibre-library`** (a non-dot path). Readarr's Calibre root folder points there; the on-disk directory stays `.calibre` (hidden from ABS). Mirrors how CWA mounts the same library.

## Validation
`kustomize build --load-restrictor LoadRestrictionsNone` of the bookshelf app OK.