### PR TITLE
feat(downloads): bump bookshelf to hardcover-v0.4.20.129

### DIFF
--- a/kubernetes/apps/downloads/bookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bookshelf/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
             # metadata baked in. Uses the standard Servarr READARR__* env schema.
             image:
               repository: ghcr.io/pennydreadful/bookshelf
-              tag: hardcover-v0.4.19.45@sha256:8e32af474bd3b8af6fd6fe1d988db580f6dc2c8700deec298fb658ac1266c1ed
+              tag: hardcover-v0.4.20.129@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359
             env:
               READARR__APP__INSTANCENAME: Bookshelf
               READARR__APP__THEME: dark


### PR DESCRIPTION
Bumps the pennydreadful bookshelf (Readarr fork) from `hardcover-v0.4.19.45` to `hardcover-v0.4.20.129` (latest). The current build's web UI throws React error #152 on the System/Status page; updating to the much-newer 0.4.20 line in hopes it's fixed. Done now while the instance is near-empty (root folder + profiles, pre-import) so DB forward-migration is low-risk. Renovate hasn't been bumping it (the `hardcover-vX.Y.Z` tag scheme isn't matched by its versioning).