### PR TITLE
feat(lighthouse): licence-gate 0.1.7 (scope /api/jobs + create_time)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -96,7 +96,7 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              tag: 0.1.6@sha256:5527aa31c6029bf0d1f8dc06de871fe7ab009428016a693096ef4e536a6b749c
+              tag: 0.1.7@sha256:aad5aeaac403832ea117cf1dcccc35bc3cd10b987886ef9d1bc0ce123c0fedeb
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"


### PR DESCRIPTION
Repins licence-gate 0.1.6→0.1.7 (digest 5527aa31→aad5aeaa, containers#12). Fixes the render-history panel rendering empty (ZodError on missing create_time) + scopes /api/jobs per-user. 1-file digest bump.