### PR TITLE
feat(lighthouse): master image with clipspace shim (SAM editor fix)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           main:
             image:
               repository: ghcr.io/gavinmcfall/lighthouse
-              tag: 0.22.0@sha256:0fccc66977f366bc591f2eb159f0f5cf0bca47a32d95986dbcd209782bba6ee1
+              tag: 0.22.0@sha256:67c7e38e7a0e21d536cd7d8ee7556d6c5de4871b7c62e5d18cf4222ee357cc91
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
Repins lighthouse master 0fccc669→67c7e38e (containers#13). Bakes /extensions/core/clipspace.js so Impact-Pack's SAM mask editor loads. 1-line digest bump.