### PR TITLE
feat(downloads): self-host rreading-glasses (Hardcover) metadata proxy

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
   - ./radarr/ks.yaml
   - ./radarr-uhd/ks.yaml
   - ./recyclarr/ks.yaml
+  - ./rreading-glasses/ks.yaml
   - ./sabnzbd/ks.yaml
   - ./shelfmark/ks.yaml
   - ./sonarr/ks.yaml

--- a/kubernetes/apps/downloads/rreading-glasses/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/rreading-glasses/app/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rreading-glasses
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: rreading-glasses-secret
+    template:
+      engineVersion: v2
+      data:
+        # Hardcover API token lives on the 1Password "bookshelf" item as
+        # BOOKSHELF_HARDCOVER_API_TOKEN (raw JWT). rreading-glasses wants it
+        # prefixed with "Bearer ". Token expires ~2027-06-07 — re-store to rotate.
+        HARDCOVER_AUTH: "Bearer {{ .BOOKSHELF_HARDCOVER_API_TOKEN }}"
+        # postgres-init: create the rreading_glasses DB + user on the CNPG cluster.
+        # The new user's password (INIT_POSTGRES_PASS) comes from the SOPS secret.
+        INIT_POSTGRES_DBNAME: rreading_glasses
+        INIT_POSTGRES_HOST: postgres18-cluster-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: rreading_glasses
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: bookshelf
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/downloads/rreading-glasses/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/rreading-glasses/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app rreading-glasses
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      rreading-glasses:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Creates the rreading_glasses DB + user on the shared CNPG cluster
+          # (same pattern as bookshelf). Super pass from the cloudnative-pg item;
+          # the new user's pass comes from the SOPS secret.
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6.0@sha256:86a1992d46273c58fd4ad95b626081dfaabfe16bd56944675169e406d1a660dd
+              pullPolicy: IfNotPresent
+            envFrom: &envFrom
+              - secretRef:
+                  name: rreading-glasses-secret
+              - secretRef:
+                  name: rreading-glasses-db
+        containers:
+          app:
+            # Self-hosted metadata proxy for the bookshelf (Readarr) stack — own
+            # Hardcover backend + own cache, replacing the flaky public
+            # hardcover.bookinfo.pro. Entrypoint is /main.
+            image:
+              repository: docker.io/blampe/rreading-glasses
+              tag: hardcover@sha256:3489e722a73c9cbab5b9ba530cf8a60c2280367fb03db1fb649261dfb064b52f
+            command: ["/main", "serve"]
+            args: ["--verbose"]
+            env:
+              TZ: ${TIMEZONE}
+              POSTGRES_HOST: postgres18-cluster-rw.database.svc.cluster.local
+              POSTGRES_PORT: "5432"
+              POSTGRES_DATABASE: rreading_glasses
+              POSTGRES_USER: rreading_glasses
+              # HARDCOVER_AUTH (Bearer …) + POSTGRES_PASSWORD come from the secrets
+            envFrom: *envFrom
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8788
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness: *probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/downloads/rreading-glasses/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/rreading-glasses/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/rreading-glasses/app/secret.sops.yaml
+++ b/kubernetes/apps/downloads/rreading-glasses/app/secret.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: rreading-glasses-db
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:v26nYbq08mkyLoOJO+WSiUaWhD8CLowkIK5OMWHdPjjOEGxhEC9+UPlGgDLi/+LoP6SoUW+7z52psUhadg8h5uNNc0zJ3BGD2w==,iv:GkceH41s125nh9yqB1cMwiqlRlfCIrZkUsSb7IADanI=,tag:oujpeuFn0XbGukJq3fRhpA==,type:comment]
+    #ENC[AES256_GCM,data:/EEhbFuhqH7wVJMsDA+gtqr6zl2w5fXDN1JyGPAYXzCyfSHK/HwtcIyI8/sZhebP7vkzFqqBrcNvM/tRY+G5HpxcBig/V58z,iv:E6KLLOuqswCA2wF+LquhWBG8623Wqa+aORlZYOk4S+k=,tag:/cEnf8XcbUSUjjtz7DM/Cg==,type:comment]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:o1BolsBYttQF1yRXrsTDUJBhEZmc3Cp2M2KPUcNlaIw=,iv:X8m/m91m5vMcBR4g2v+kP9img4Sq4OhWcagmvvfMjok=,tag:eVCUHyYObTHxRodyVU44kg==,type:str]
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:XsID5yt/XFlmKZaTP3lbFFau/MSgbl2zjvi1Nh4iA8w=,iv:VUwI8XFCEp7ImNaKo7mXmBSVsWf9RR5dDZUi8rBG30Y=,tag:eAWjGKFAPDbnAKNkgF03yQ==,type:str]
+sops:
+    age:
+        - recipient: age1s3dkl4qn66zsj38zl4nkjdw8c6j4d9v8ddd9vwajcfjrz04s2fgsgg3lxy
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsZWx1WE81WHZ1ZVR1NHVo
+            WCtubDVpYlVyeU5WRC8yNEdjeXcrMXI5WlNVClB5bDhBSWhueTJoY05aZ0tlV28w
+            NHJ5M0sxbHFQSHhUaFh3dkRLN1UreTQKLS0tIFZWVno0ZkgyTEUxZWFrMkNDeFo5
+            eTlSclNMcHNiKzNZTC9RcWMwY0YySGsKaKvo60ErWto8K+arEUaucU6TsLwFfToo
+            GYqIi/NNPlTcXSzbF4YrwEJH+IiaGEh/M4K/I85w12Q7B6eT5vhByg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-07T04:21:14Z"
+    mac: ENC[AES256_GCM,data:gkwJlJrARzL5jHslhKKmP2kAd6uDE4tcYHSA71ZxzGal8LCXwHmz7VfhQ+E8VZGKaK4uqGc4w9HmlkgBCnhirflE8PtnuYn6ygPD8BBxVrTQyBDNhOaXfBxHLqmq+Lj4qBpTL7uH/LQg7nfSqmY3xLD4S9mp5c6h55Iq/N9tG0A=,iv:BshfLFqNiIjceehrGEloyd8XJTL97Dug7X+DOMrn2E0=,tag:o8v2LGtH1g8iW7a+mq1kkw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/downloads/rreading-glasses/ks.yaml
+++ b/kubernetes/apps/downloads/rreading-glasses/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rreading-glasses
+  namespace: &namespace downloads
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-postgres18-cluster
+      namespace: database
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/downloads/rreading-glasses/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Why
The public `hardcover.bookinfo.pro` proxy (baked into the bookshelf `hardcover-` image) **persistently 503s** for a large share of authors — confirmed 3/3 failures for Sarah J. Maas, Frank Herbert, Rick Riordan. This capped the bookshelf Library Import at **21/102 authors / 83/457 books**. Self-hosting our own metadata proxy removes the shared-instance dependency (and underpins any future audiobook arr, which also uses Hardcover).

## What
- **app-template HelmRelease** — `blampe/rreading-glasses:hardcover` (`/main serve --verbose`) on **:8788**, internal-only service.
- **Database** on the shared CNPG cluster (`postgres18-cluster`) via `postgres-init`, mirroring bookshelf. The `rreading_glasses` DB-user password is a **SOPS** secret (no extra 1Password ask).
- **`HARDCOVER_AUTH`** = `"Bearer " + BOOKSHELF_HARDCOVER_API_TOKEN` (1Password `bookshelf` item; the stored token is a raw JWT, so the `Bearer ` prefix is added in the ExternalSecret).

## After merge
Repoint bookshelf at it via the hidden `/settings/development` → **Metadata Provider Source** = `http://rreading-glasses.downloads.svc:8788`, then re-run the import and check the canary authors (Maas/Herbert/Riordan) resolve.

## Validation
`kustomize build` (app + downloads ns) OK; kubeconform clean. Token expires ~2027-06-07 (rotate by re-storing the 1Password field).