### PR TITLE
feat(downloads): bindery spike (Readarr replacement eval)

### DIFF
--- a/kubernetes/apps/downloads/bindery/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bindery/app/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app bindery
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      bindery:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            # SPIKE: evaluating Bindery (clean Readarr replacement) alongside the
+            # parked bookshelf. Single Go binary + embedded SQLite, no external DB.
+            # Reads the existing Calibre library (configured in the web UI) and
+            # imports to a TEST dir so the real ABS folders are untouched.
+            image:
+              repository: ghcr.io/vavallee/bindery
+              tag: v1.17.0@sha256:1087b3433517e43465b1b59998060e89b235d631a1de58489a0a946663d63435
+            env:
+              TZ: ${TIMEZONE}
+              BINDERY_PORT: &port "8787"
+              BINDERY_DATA_DIR: /config
+              BINDERY_DB_PATH: /config/bindery.db
+              # import targets point at a throwaway test tree (not the real library)
+              BINDERY_LIBRARY_DIR: /media/Library/Books/.calibre/_bindery-test/library
+              BINDERY_AUDIOBOOK_DIR: /media/Library/Books/.calibre/_bindery-test/audiobooks
+              BINDERY_DOWNLOAD_DIR: /media/Library/Books/.calibre/_bindery-test/downloads
+              BINDERY_TELEMETRY_DISABLED: "true"
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    port: 8787
+                    path: /
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness: *probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /config
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /media

--- a/kubernetes/apps/downloads/bindery/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/bindery/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/bindery/ks.yaml
+++ b/kubernetes/apps/downloads/bindery/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bindery
+  namespace: &namespace downloads
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/downloads/bindery/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./bazarr/ks.yaml
   - ./bazarr-foreign/ks.yaml
   - ./bazarr-uhd/ks.yaml
+  - ./bindery/ks.yaml
   - ./bookshelf/ks.yaml
   - ./cross-seed/ks.yaml
   - ./dashbrr/ks.yaml


### PR DESCRIPTION
Spike to evaluate **Bindery** alongside the parked bookshelf. Single Go binary + embedded SQLite (no DB/sidecars), **torrents supported** (qB/MAM via Prowlarr), **dual ebook+audiobook slots**, multi-source metadata (OpenLibrary/Hardcover/Audnex), and can **direct-read the existing Calibre metadata.db**. Imports target a throwaway `_bindery-test/` tree so the real library + Calibre catalog (backed up) are untouched. app-template HR, `ghcr.io/vavallee/bindery:v1.17.0`, internal route `bindery.${SECRET_DOMAIN}`. Validated: kustomize build + kubeconform OK.