### PR TITLE
fix(downloads): drop invalid bindery dependsOn

### DIFF
--- a/kubernetes/apps/downloads/bindery/ks.yaml
+++ b/kubernetes/apps/downloads/bindery/ks.yaml
@@ -10,9 +10,6 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   path: ./kubernetes/apps/downloads/bindery/app
   prune: true
   sourceRef:


### PR DESCRIPTION
rook-ceph-cluster is a HelmRelease, not a Flux Kustomization → the bindery ks errored 'dependency not found' and never deployed. Bindery needs only the cluster-wide ceph-block storage class. Removes the bad dependsOn.