### PR TITLE
feat(lighthouse): role-scoped curated workflows in App Mode (licence-gate 0.1.10)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -96,7 +96,7 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              tag: 0.1.9@sha256:3aa750210bc1f47ae9807982c1048a1ea97335daf752e3eaee8a9f74380e5191
+              tag: 0.1.10@sha256:2a644e24d00676b880ae790b8aa9d4da76c0d7acf1f36d8e0252a75cae55d99e
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"
@@ -109,6 +109,10 @@ spec:
               # completed-jobs gallery synthesized from /output/<user>/, surviving
               # master restarts that wipe ComfyUI's in-memory /api/jobs history.
               LIGHTHOUSE_OUTPUT_DIR: "/output"
+              # Curated-workflow dir (configMap below): role-scoped App Mode
+              # curation overlaid onto each caller's workflow sidebar, served
+              # read-only from this gate. Empty would disable curation.
+              LIGHTHOUSE_CURATION_DIR: "/etc/lighthouse/curation"
               LIGHTHOUSE_DR_TOKEN:
                 valueFrom:
                   secretKeyRef:
@@ -252,6 +256,16 @@ spec:
           lighthouse:
             licence-gate:
               - path: /etc/lighthouse
+      # Curated App Mode workflows (manifest + JSONs) → role-scoped, read-only
+      # overlay served by the gate (LIGHTHOUSE_CURATION_DIR). Separate mount dir
+      # so it doesn't shadow the registry/allowlist configMap at /etc/lighthouse.
+      curation:
+        type: configMap
+        name: lighthouse-curation
+        advancedMounts:
+          lighthouse:
+            licence-gate:
+              - path: /etc/lighthouse/curation
       gpu-config:
         type: configMap
         name: lighthouse-comfyui-distributed

--- a/kubernetes/apps/cortex/lighthouse/app/kustomization.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/kustomization.yaml
@@ -23,5 +23,14 @@ configMapGenerator:
   - name: lighthouse-comfyui-distributed
     files:
       - ./resources/gpu_config.json
+  # Curated App Mode workflows (licence-gate LIGHTHOUSE_CURATION_DIR): the manifest
+  # + each vetted workflow JSON, served role-filtered + read-only into every
+  # caller's workflow sidebar. Canonical source is ../workflows/ (sibling to
+  # smoke/). The cross-dir ref relies on Flux kustomize-controller's default
+  # LoadRestrictionsNone; a local `kustomize build` needs --load-restrictor=none.
+  - name: lighthouse-curation
+    files:
+      - ../workflows/curation.json
+      - ../workflows/portrait-sdxl-hires-facedetailer.workflow.json
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/cortex/lighthouse/workflows/curation.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/curation.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Curated App Mode workflow registry (licence-gate LIGHTHOUSE_CURATION_DIR). Each entry is overlaid, role-filtered, into every caller's ComfyUI workflow sidebar and served read-only from this configMap. 'path' is the logical userdata path (workflows/lighthouse/... groups curated graphs); 'file' is the configMap key holding the workflow JSON; 'role_allowlist' is the VISIBILITY layer (empty = all authenticated callers) — enforcement is by model tag at the gate. See app-mode-curation.md.",
+  "entries": [
+    {
+      "path": "workflows/lighthouse/portrait-sdxl-hires-facedetailer.json",
+      "file": "portrait-sdxl-hires-facedetailer.workflow.json",
+      "role_allowlist": ["family-adult"]
+    }
+  ]
+}

--- a/kubernetes/apps/cortex/lighthouse/workflows/portrait-sdxl-hires-facedetailer.workflow.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/portrait-sdxl-hires-facedetailer.workflow.json
@@ -1,0 +1,860 @@
+{
+  "id": "9e591f94-5b26-4c69-a9ea-6c2f9ddd3955",
+  "revision": 0,
+  "last_node_id": 16,
+  "last_link_id": 25,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -94.84745390075693,
+        416.1639386099241
+      ],
+      "size": [
+        425.27801513671875,
+        180.6060791015625
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 5
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            6,
+            15,
+            23
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "text, watermark"
+      ]
+    },
+    {
+      "id": 10,
+      "type": "FaceDetailer",
+      "pos": [
+        1514.3192236785872,
+        191.9792270645139
+      ],
+      "size": [
+        400,
+        960
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 10
+        },
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 11
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 12
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 13
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 14
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 15
+        },
+        {
+          "name": "bbox_detector",
+          "type": "BBOX_DETECTOR",
+          "link": 16
+        },
+        {
+          "name": "sam_model_opt",
+          "shape": 7,
+          "type": "SAM_MODEL",
+          "link": 17
+        },
+        {
+          "name": "segm_detector_opt",
+          "shape": 7,
+          "type": "SEGM_DETECTOR",
+          "link": null
+        },
+        {
+          "name": "detailer_hook",
+          "shape": 7,
+          "type": "DETAILER_HOOK",
+          "link": null
+        },
+        {
+          "name": "scheduler_func_opt",
+          "shape": 7,
+          "type": "SCHEDULER_FUNC",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "links": [
+            18
+          ]
+        },
+        {
+          "name": "cropped_refined",
+          "shape": 6,
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "name": "cropped_enhanced_alpha",
+          "shape": 6,
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "name": "mask",
+          "type": "MASK",
+          "links": null
+        },
+        {
+          "name": "detailer_pipe",
+          "type": "DETAILER_PIPE",
+          "links": null
+        },
+        {
+          "name": "cnet_images",
+          "shape": 6,
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "FaceDetailer"
+      },
+      "widgets_values": [
+        512,
+        true,
+        1024,
+        1036400902182605,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "simple",
+        0.5,
+        5,
+        true,
+        true,
+        0.5,
+        10,
+        3,
+        "center-1",
+        0,
+        0.93,
+        0,
+        0.7,
+        "False",
+        10,
+        "",
+        1,
+        false,
+        20,
+        false,
+        false
+      ]
+    },
+    {
+      "id": 13,
+      "type": "DistributedCollector",
+      "pos": [
+        2022.1290608184836,
+        196.20550674133307
+      ],
+      "size": [
+        270,
+        78
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 18
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            19
+          ]
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DistributedCollector"
+      },
+      "widgets_values": [
+        false
+      ]
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        2411.5768151342727,
+        195.44205340423568
+      ],
+      "size": [
+        210,
+        270
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 19
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 11,
+      "type": "UltralyticsDetectorProvider",
+      "pos": [
+        1036.3647255218496,
+        565.5488817062378
+      ],
+      "size": [
+        278.8545440673828,
+        78
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "BBOX_DETECTOR",
+          "type": "BBOX_DETECTOR",
+          "links": [
+            16
+          ]
+        },
+        {
+          "name": "SEGM_DETECTOR",
+          "type": "SEGM_DETECTOR",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UltralyticsDetectorProvider"
+      },
+      "widgets_values": [
+        "bbox/face_yolov8m.pt"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "SAMLoader",
+      "pos": [
+        1064.7640882507305,
+        757.736469436646
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAM_MODEL",
+          "type": "SAM_MODEL",
+          "links": [
+            17
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SAMLoader"
+      },
+      "widgets_values": [
+        "sam_vit_b_01ec64.pth",
+        "AUTO"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -92.84745390075696,
+        213.16393860992432
+      ],
+      "size": [
+        422.84503173828125,
+        164.31304931640625
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            4,
+            14,
+            22
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "close-up portrait photo of a caucasian woman, detailed face, freckles, red hair in twin ponytails, natural lighting, sharp focus"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -481.8474539007569,
+        501.1639386099241
+      ],
+      "size": [
+        315,
+        98
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            1,
+            11,
+            21
+          ]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": [
+            3,
+            5,
+            12
+          ]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 2,
+          "links": [
+            8,
+            13
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "sd_xl_base_1.0.safetensors"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        355.1525460992429,
+        213.16393860992432
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 4
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 6
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 2
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            20
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        1040474753904256,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 15,
+      "type": "LatentUpscaleBy",
+      "pos": [
+        630.2182176083068,
+        -257.5635040920633
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 20
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            24
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LatentUpscaleBy"
+      },
+      "widgets_values": [
+        "nearest-exact",
+        1.5
+      ]
+    },
+    {
+      "id": 16,
+      "type": "KSampler",
+      "pos": [
+        833.3571598495189,
+        -70.95906319492279
+      ],
+      "size": [
+        270,
+        262
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 21
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 22
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 23
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 24
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            25
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        511521651465881,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "simple",
+        0.45
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1209,
+        188
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 25
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 8
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            10
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [
+        -34.847453900756946,
+        636.1639386099246
+      ],
+      "size": [
+        315,
+        106
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            2
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        1024,
+        1024,
+        1
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      4,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      2,
+      5,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      3,
+      4,
+      1,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      4,
+      6,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      5,
+      4,
+      1,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      6,
+      7,
+      0,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      8,
+      4,
+      2,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      10,
+      8,
+      0,
+      10,
+      0,
+      "IMAGE"
+    ],
+    [
+      11,
+      4,
+      0,
+      10,
+      1,
+      "MODEL"
+    ],
+    [
+      12,
+      4,
+      1,
+      10,
+      2,
+      "CLIP"
+    ],
+    [
+      13,
+      4,
+      2,
+      10,
+      3,
+      "VAE"
+    ],
+    [
+      14,
+      6,
+      0,
+      10,
+      4,
+      "CONDITIONING"
+    ],
+    [
+      15,
+      7,
+      0,
+      10,
+      5,
+      "CONDITIONING"
+    ],
+    [
+      16,
+      11,
+      0,
+      10,
+      6,
+      "BBOX_DETECTOR"
+    ],
+    [
+      17,
+      12,
+      0,
+      10,
+      7,
+      "SAM_MODEL"
+    ],
+    [
+      18,
+      10,
+      0,
+      13,
+      0,
+      "IMAGE"
+    ],
+    [
+      19,
+      13,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ],
+    [
+      20,
+      3,
+      0,
+      15,
+      0,
+      "LATENT"
+    ],
+    [
+      21,
+      4,
+      0,
+      16,
+      0,
+      "MODEL"
+    ],
+    [
+      22,
+      6,
+      0,
+      16,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      23,
+      7,
+      0,
+      16,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      24,
+      15,
+      0,
+      16,
+      3,
+      "LATENT"
+    ],
+    [
+      25,
+      16,
+      0,
+      8,
+      0,
+      "LATENT"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.620921323059155,
+      "offset": [
+        297.71828409396375,
+        403.383135705604
+      ]
+    },
+    "frontendVersion": "1.43.18"
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## What

Wires up the **curated-workflow delivery** built in licence-gate `v0.1.10` (containers#16) so a small, vetted, role-scoped set of ComfyUI workflows appears in every family member's **App Mode**.

- `lighthouse-curation` configMap — `curation.json` manifest + the first vetted workflow (`portrait-sdxl-hires-facedetailer`), generated from `../workflows/`.
- Mounted **read-only** at `/etc/lighthouse/curation` on the licence-gate sidecar.
- `LIGHTHOUSE_CURATION_DIR` env enables the role-scoped overlay.
- Repin licence-gate `0.1.9` → `0.1.10@sha256:2a644e24…`.

## How it works

The proxy overlays these workflows (role-filtered via `role_allowlist`, read-only) into each caller's ComfyUI workflow sidebar **without touching their per-user `/userdata` bucket** — listing merge + serve-from-configMap on read + 403 on write. Visibility only; model-tag remains the enforcement boundary.

## Notes

- Canonical source lives in `../workflows/` (sibling to `smoke/`). The cross-dir `configMapGenerator` ref relies on kustomize-controller's `LoadRestrictionsNone` (already used repo-wide, incl. file-level `resources:` refs). A local `kustomize build` needs `--load-restrictor=LoadRestrictionsNone`.
- This entry is scoped `role_allowlist: [family-adult]` (Phase-1 family-minor curation is deferred per the design).
- **Follow-up (not blocking):** the workflow JSON is the raw graph; an App Builder pass gives it the App-Mode *form* view. The plumbing (listed, role-scoped, read-only, runnable) is delivered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)