### PR TITLE
fix(lighthouse): persist /app/user + correct Pocket-ID group slugs

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -249,6 +249,15 @@ spec:
             main:
               - path: /app/workflows
                 readOnly: true
+      # ComfyUI user-data (/app/user): each caller's SAVED workflows + settings.
+      # Persisted so they survive pod restarts (previously on ephemeral rootfs →
+      # wiped every roll). RW for the master.
+      userdata:
+        existingClaim: lighthouse-userdata
+        advancedMounts:
+          lighthouse:
+            main:
+              - path: /app/user
       registry:
         type: configMap
         name: lighthouse-registry

--- a/kubernetes/apps/cortex/lighthouse/app/pvc.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/pvc.yaml
@@ -40,3 +40,19 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: ceph-filesystem
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/persistentvolumeclaim_v1.json
+# ComfyUI user-data dir (/app/user → user/default/<user>/workflows/, settings, …).
+# ComfyUI persists each caller's SAVED workflows here; it is on the pod rootfs by
+# default, so every pod restart wiped them (data loss surfaced 2026-06-08). RWX
+# ceph-filesystem so it survives restarts and a future multi-replica/portal reader.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lighthouse-userdata
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/apps/cortex/lighthouse/app/resources/registry.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/registry.json
@@ -171,7 +171,7 @@
   },
   {
     "filename": "pony-diffusion-v6-xl.safetensors",
-    "requires_group": "mature-content",
+    "requires_group": "content-mature",
     "sha256": "TBD-on-acquisition",
     "licence": "Modified Fair AI Public License 1.0-SD (creator addendum: non-commercial without explicit auth)",
     "commercial_ok": false,
@@ -185,7 +185,7 @@
   },
   {
     "filename": "noobai-xl-epsilon-1.1.safetensors",
-    "requires_group": "mature-content",
+    "requires_group": "content-mature",
     "sha256": "TBD-on-acquisition",
     "licence": "Fair AI Public License 1.0-SD + creator non-commercial addendum",
     "commercial_ok": false,
@@ -199,7 +199,7 @@
   },
   {
     "filename": "nova-furry-xl-il-v18.safetensors",
-    "requires_group": "mature-content",
+    "requires_group": "content-mature",
     "sha256": "TBD-on-acquisition",
     "licence": "FAIPL 1.0 (creator rider: unedited generated images not commercial)",
     "commercial_ok": false,
@@ -212,7 +212,7 @@
   },
   {
     "filename": "cyberrealistic-xl-v10.safetensors",
-    "requires_group": "mature-content",
+    "requires_group": "content-mature",
     "sha256": "TBD-on-acquisition",
     "licence": "CreativeML Open RAIL++-M with Addendum",
     "commercial_ok": true,
@@ -226,7 +226,7 @@
   },
   {
     "filename": "cyberrealistic-pony-v18.safetensors",
-    "requires_group": "mature-content",
+    "requires_group": "content-mature",
     "sha256": "TBD-on-acquisition",
     "licence": "CreativeML Open RAIL++-M",
     "commercial_ok": true,

--- a/kubernetes/apps/cortex/lighthouse/workflows/curation.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/curation.json
@@ -4,7 +4,7 @@
     {
       "path": "workflows/lighthouse/portrait-sdxl-hires-facedetailer.json",
       "file": "portrait-sdxl-hires-facedetailer.workflow.json",
-      "role_allowlist": ["family-adult"]
+      "role_allowlist": ["family_adult"]
     }
   ]
 }


### PR DESCRIPTION
Three fixes surfaced while verifying the curated App Mode workflows (#2178).

## 1. Persist ComfyUI user-data (data-loss bug)
`/app/user` — where ComfyUI stores each caller's **saved workflows** + settings — was on the pod's **ephemeral rootfs**. Every pod restart wiped it; saved workflows were never durable (confirmed: a workflow saved yesterday vanished after this morning's deploy restart). Adds a `lighthouse-userdata` PVC (5Gi RWX Ceph) mounted RW at `/app/user`.

## 2. Curated-workflow visibility (group-slug mismatch)
The curated entry's `role_allowlist` used `family-adult`, but the real Pocket-ID group slug is **`family_adult`** (underscore). Zero match → the curated workflow never appeared in App Mode. Fixed.

## 3. Mature-gate slug (pre-existing misconfig)
The model registry gated 5 mature models on `requires_group: "mature-content"`, but the real group is **`content-mature`**. As written, *no one* held the group, so those models were denied to **everyone** (fail-closed). Fixed all 5 → `content-mature` (enables them for `content-mature` holders, blocks everyone else — as designed).

**Pocket-ID's actual gate slugs (verbatim, confirmed):** `family_adult`, `family_minor`, `content-mature`.

⚠️ Applying this restarts the licence-gate pod once. The `/app/user` mount starts empty, so any workflow currently saved in-pod is re-initialised — re-import from a local export after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)