### PR TITLE
fix(mempalace): raise memory limit to 4Gi for 320k-drawer palace

### DIFF
--- a/kubernetes/apps/cortex/mempalace/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace/app/helmrelease.yaml
@@ -85,10 +85,10 @@ spec:
             resources:
               requests:
                 cpu: 250m
-                memory: 512Mi
+                memory: 1Gi
               limits:
                 cpu: 1500m
-                memory: 1Gi
+                memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Problem

The mempalace pod OOMKills (exit 137) on the first search/status query after startup. The palace grew to 320k drawers after the local→k8s migration; the HNSW index (~350MB) plus embeddings load into memory on query, exceeding the 1Gi limit.

## Change

- requests: memory 512Mi → 1Gi
- limits: memory 1Gi → 4Gi

CPU unchanged.

## Evidence

- Pod idle: 70Mi
- `kubectl describe`: `Last State: Terminated, Reason: Error, Exit Code: 137`
- Restart correlated exactly with an `mempalace_status` MCP call