### PR TITLE
fix(mempalace): relax liveness probe for HNSW index load

### DIFF
--- a/kubernetes/apps/cortex/mempalace/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace/app/helmrelease.yaml
@@ -62,8 +62,12 @@ spec:
                   httpGet: { path: /healthz, port: 8080 }
                   initialDelaySeconds: 20
                   periodSeconds: 30
-                  timeoutSeconds: 5
-                  failureThreshold: 3
+                  timeoutSeconds: 10
+                  # Tolerant of a blocked event loop while the 320k-drawer HNSW
+                  # index loads on the first query (~minutes). 6×30s = 3min
+                  # before a restart. The threadpool fix in the app keeps the
+                  # loop responsive; this is the safety margin.
+                  failureThreshold: 6
               readiness:
                 enabled: true
                 custom: true


### PR DESCRIPTION
## Problem

After raising memory to 4Gi (#2185), the OOM is gone but a new failure surfaced: the pod crash-loops on liveness. The 320k-drawer HNSW index loads synchronously on the first query and blocks the FastAPI event loop, so `/healthz` can't respond. The 3-failure liveness probe (~90s) kills the pod before the load finishes.

## Change

- liveness `timeoutSeconds` 5 → 10
- liveness `failureThreshold` 3 → 6 (~3min tolerance)

## Pairs with

App-side fix (mempalace `develop` @ 2609956) that runs `handle_request` in a threadpool so the event loop stays responsive during heavy queries. This probe change is the safety margin; once the new image is deployed the loop won't block at all.