### PR TITLE
fix(mempalace): deploy threadpool + status perf image

### DIFF
--- a/kubernetes/apps/cortex/mempalace/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace
-              tag: http-transport@sha256:6622f057a1624ebf4f504b329a667b6665e4c158ddd62f11300c3ae2fc362eac
+              tag: http-transport@sha256:ef6aba6425790676888cc0ee7e536007c14e5d7505a4bde7a434414a5a15852a
             args:
               - --serve-http
               - --host=0.0.0.0


### PR DESCRIPTION
## Summary

Bumps the mempalace image digest to deploy two fixes from `develop`:

1. **Threadpool** (`2609956`) — `handle_request` runs in a threadpool so the asyncio event loop stays responsive during heavy queries. Removes the liveness-kill risk during cold index loads (complements the relaxed probe in #2186).
2. **Status perf** (`c4a18f5`) — fetch all metadata in a single `get()` call instead of O(n²) offset pagination. `mempalace_status` drops from ~51s to ~6s on the 320k-drawer palace, back under the MCP client timeout.

Digest: `sha256:ef6aba64…` (was `6622f057…`)

## Test plan
- [x] mempalace unit tests pass locally (mcp_server, http transport, searcher, layers)
- [ ] After deploy: `mempalace_status` returns < 30s; pod stays Ready during a cold query