### PR TITLE
fix(mempalace): correct image digest to develop build with fixes

### DIFF
--- a/kubernetes/apps/cortex/mempalace/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace
-              tag: http-transport@sha256:ef6aba6425790676888cc0ee7e536007c14e5d7505a4bde7a434414a5a15852a
+              tag: develop@sha256:4618970ec02530986fca73ae1041d21fc1bb62b6dc08dea00fa1a0249d30874a
             args:
               - --serve-http
               - --host=0.0.0.0


### PR DESCRIPTION
## Problem

PR #2187 bumped the image to `http-transport@sha256:ef6aba64`, but that tag only updates on `feat/http-transport` branch builds. The threadpool + status-perf fixes are on `develop`, which CI tags as `develop`. So the deployed image had neither fix — `mempalace_status` was still ~50s (verified: old paginated `_fetch_all_metadata`, TTL=5 in the running container).

## Fix

Point at `develop@sha256:4618970e`, verified to contain both:
- `run_in_threadpool` in transport/http.py (3 refs)
- `_METADATA_CACHE_TTL = 300.0` + single-call metadata fetch in mcp_server.py

## Test plan
- [ ] After deploy: `mempalace_status` < 30s; warm search sub-second