### PR TITLE
feat(security): add oauth2-proxy for Lighthouse forward-auth (dormant)

### DIFF
--- a/kubernetes/apps/security/oauth2-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# oauth2-proxy reuses the EXISTING Pocket-ID "lighthouse" client (same redirect
+# URI https://lighthouse.${SECRET_DOMAIN}/oauth2/callback = oauth2-proxy's default
+# callback path). Only the cookie secret is new. Pulls from the same 1Password
+# `lighthouse` item; ClusterSecretStore is cluster-scoped so a security-namespace
+# ExternalSecret can read it.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oauth2-proxy
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: oauth2-proxy-secret
+    template:
+      engineVersion: v2
+      data:
+        OAUTH2_PROXY_CLIENT_ID: "{{ .LIGHTHOUSE_OIDC_CLIENT_ID }}"
+        OAUTH2_PROXY_CLIENT_SECRET: "{{ .LIGHTHOUSE_OIDC_CLIENT_SECRET }}"
+        OAUTH2_PROXY_COOKIE_SECRET: "{{ .LIGHTHOUSE_OAUTH2_COOKIE_SECRET }}"
+  dataFrom:
+    - extract:
+        key: lighthouse

--- a/kubernetes/apps/security/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/helmrelease.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app oauth2-proxy
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      oauth2-proxy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: quay.io/oauth2-proxy/oauth2-proxy
+              tag: v7.15.2@sha256:aa0bd8dd5ab0c78e4c91c92755ad573a5f92241f88138b4141b8ec803463b4fd
+            env:
+              # ── Provider: Pocket-ID (OIDC) ──
+              OAUTH2_PROXY_PROVIDER: oidc
+              OAUTH2_PROXY_OIDC_ISSUER_URL: https://id.${SECRET_DOMAIN}
+              OAUTH2_PROXY_REDIRECT_URL: https://lighthouse.${SECRET_DOMAIN}/oauth2/callback
+              OAUTH2_PROXY_SCOPE: "openid profile email groups"
+              OAUTH2_PROXY_OIDC_GROUPS_CLAIM: groups
+              OAUTH2_PROXY_EMAIL_DOMAINS: "*" # gate by groups downstream, not email
+              # ── Reverse-proxy mode: forward to the licence-gate, inject identity ──
+              # Upstream pre-set for Phase 3; nothing routes to oauth2-proxy yet
+              # (dormant), so no traffic flows until the lighthouse HTTPRoute is
+              # repointed here.
+              OAUTH2_PROXY_UPSTREAMS: http://lighthouse-app.cortex.svc.cluster.local:8000
+              OAUTH2_PROXY_HTTP_ADDRESS: 0.0.0.0:4180
+              OAUTH2_PROXY_REVERSE_PROXY: "true" # behind Envoy; trust X-Forwarded-*
+              OAUTH2_PROXY_PASS_USER_HEADERS: "true" # X-Forwarded-User/Email/Groups → upstream
+              OAUTH2_PROXY_SET_XAUTHREQUEST: "true" # also X-Auth-Request-* (belt + braces)
+              OAUTH2_PROXY_PASS_ACCESS_TOKEN: "true" # keep token available during transition
+              OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true" # straight to Pocket-ID, no landing page
+              # ── Cookie/session (stateless; no redis at family scale) ──
+              OAUTH2_PROXY_COOKIE_SECURE: "true"
+              OAUTH2_PROXY_COOKIE_DOMAINS: ".${SECRET_DOMAIN}"
+              OAUTH2_PROXY_WHITELIST_DOMAINS: ".${SECRET_DOMAIN}"
+              OAUTH2_PROXY_COOKIE_CSRF_PER_REQUEST: "true"
+              OAUTH2_PROXY_COOKIE_CSRF_EXPIRE: "5m"
+            envFrom:
+              - secretRef:
+                  name: oauth2-proxy-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: &port 4180
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+        supplementalGroups: [10000]
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/security/oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/kustomization.yaml
@@ -2,12 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: security
-
-components:
-  - ../../components/common
-
 resources:
-  # Applications
-  - ./oauth2-proxy/ks.yaml
-  - ./pocket-id/ks.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/security/oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app oauth2-proxy
+  namespace: &namespace security
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/security/oauth2-proxy/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app


### PR DESCRIPTION
**Phase 1** of the edge-auth + native-multi-user plan (`lighthouse/docs/declaration/plans/2026-06-09-edge-auth-and-multiuser.md`).

## What
oauth2-proxy `v7.15.2` (pinned) in the shared **security** namespace, reverse-proxy mode, OIDC against Pocket-ID.

- **Reuses the existing Pocket-ID `lighthouse` client** — its redirect URI `https://lighthouse.${SECRET_DOMAIN}/oauth2/callback` is already oauth2-proxy's default callback path. No new client.
- Only new secret: `LIGHTHOUSE_OAUTH2_COOKIE_SECRET` (added to the `lighthouse` 1Password item).
- Emits `X-Forwarded-User`/`X-Forwarded-Groups` (`--oidc-groups-claim=groups`) to the upstream licence-gate.

## Why
The current Envoy `forwardAccessToken` sends the **access** token, which lacks `groups` (they live in the ID token) — so curation + mature gating silently fail. oauth2-proxy injects the groups as headers, fixing that whole class of bug, and is the foundation for native multi-user.

## Dormant
**No inbound route points here yet** — deploying this changes nothing for current users. Phase 3 repoints the lighthouse HTTPRoute through it (and removes Envoy's `oidc:` block).

## Verify after merge
oauth2-proxy pod starts, `/ping` healthy, logs show successful Pocket-ID OIDC discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)