### PR TITLE
fix(oauth2-proxy): server-side Redis session store (fixes 8190-byte cookie overflow)

### DIFF
--- a/kubernetes/apps/security/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/helmrelease.yaml
@@ -57,7 +57,16 @@ spec:
               OAUTH2_PROXY_PASS_ACCESS_TOKEN: "true" # keep token available during transition
               OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true" # straight to Pocket-ID, no landing page
               OAUTH2_PROXY_CODE_CHALLENGE_METHOD: S256 # PKCE (Pocket-ID supports it)
-              # ── Cookie/session (stateless; no redis at family scale) ──
+              # ── Session: server-side (Redis/Dragonfly) ──
+              # Pocket-ID's tokens (ID + refresh, fat with the groups claim) overflow
+              # a cookie-store: the chunked RefreshToken cookie exceeds ComfyUI's
+              # aiohttp 8190-byte header limit on the upstream hop ("Got more than
+              # 8190 bytes" on first authed request, 2026-06-09). A Redis session
+              # store keeps the full session server-side; the browser cookie becomes
+              # a small ticket. Dragonfly is shared + unauthed (like plane/immich).
+              OAUTH2_PROXY_SESSION_STORE_TYPE: redis
+              OAUTH2_PROXY_REDIS_CONNECTION_URL: redis://dragonfly.database.svc.cluster.local:6379
+              # ── Cookie ──
               OAUTH2_PROXY_COOKIE_SECURE: "true"
               OAUTH2_PROXY_COOKIE_DOMAINS: ".${SECRET_DOMAIN}"
               OAUTH2_PROXY_WHITELIST_DOMAINS: ".${SECRET_DOMAIN}"


### PR DESCRIPTION
## Bug
After a successful Pocket-ID login, the first authenticated request errored:
> `Got more than 8190 bytes when reading: b'RefreshToken-…'`

oauth2-proxy's cookie session store packs the full session (ID + **refresh** token, fat with the `groups` claim) into chunked cookies. On the upstream hop those cookies exceed **ComfyUI's aiohttp 8190-byte header-field limit**, so the request is rejected.

## Fix
Move the session **server-side** to **Dragonfly** (Redis-compatible, already shared + unauthed by plane/immich/pelican): `OAUTH2_PROXY_SESSION_STORE_TYPE=redis` + `REDIS_CONNECTION_URL=redis://dragonfly.database.svc.cluster.local:6379`. The browser cookie becomes a small session ticket; the big tokens never hit the upstream header.

## Verify
Re-login at `lighthouse.nerdz.cloud` → no header error → land in App Mode with the curated `lighthouse/` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)