### PR TITLE
feat(lighthouse): deploy master with identity badge (Phase 5)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -45,7 +45,8 @@ spec:
           main:
             image:
               repository: ghcr.io/gavinmcfall/lighthouse
-              tag: 0.22.0@sha256:67c7e38e7a0e21d536cd7d8ee7556d6c5de4871b7c62e5d18cf4222ee357cc91
+              # Rebuild bakes the lighthouse-identity badge web extension (Phase 5).
+              tag: 0.22.0@sha256:40a49d75112db4b43bad88a10c45877c873aa4639e1d31f3b279a15e3f70a814
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
Repins the ComfyUI master to the rebuild that bakes the **lighthouse-identity** badge web extension (containers#18).

`0.22.0@67c7e38e` → `0.22.0@40a49d75`

After reconcile: App Mode shows **"👤 Signed in as `<you>` · Sign out"** bottom-left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)