### PR TITLE
feat(mempalace): provision pgvector database on postgres18-cluster

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./stanza.yaml
   - ./pluginconfig.yaml
   - ./postgres18-cluster.yaml
+  - ./mempalace-db.yaml
   - ./pooler.yaml
   - ./scheduledbackup.yaml
   - ./scheduledbackup-weekly-full.yaml

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/mempalace-db.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/mempalace-db.yaml
@@ -1,0 +1,43 @@
+---
+# Role password for the mempalace pgvector database.
+# 1Password item `mempalace` must provide fields: username, password.
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mempalace-pg-role
+  namespace: database
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mempalace-pg-role
+    template:
+      engineVersion: v2
+      data:
+        # CNPG managed-role passwordSecret expects username + password keys.
+        username: "{{ .MEMPALACE_POSTGRES_USER }}"
+        password: "{{ .MEMPALACE_POSTGRES_PASS }}"
+  dataFrom:
+    - extract:
+        key: mempalace
+---
+# The mempalace database, owned by the managed `mempalace` role (declared in
+# postgres18-cluster.yaml spec.managed.roles), with the pgvector extension.
+# Created declaratively so it outlives any application pod (Path B retires the
+# mempalace HTTP deployment; the DB must persist independently).
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: mempalace
+  namespace: database
+spec:
+  cluster:
+    name: postgres18-cluster
+  name: mempalace
+  owner: mempalace
+  ensure: present
+  extensions:
+    - name: vector
+      ensure: present

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
@@ -50,6 +50,16 @@ spec:
         stanzaRef: postgres18-cluster-stanza
         pluginConfigRef: postgres18-cluster-pluginconfig
 
+  # Managed roles. `mempalace` owns the mempalace pgvector database
+  # (see mempalace-db.yaml). Password sourced from the mempalace-pg-role secret.
+  managed:
+    roles:
+      - name: mempalace
+        ensure: present
+        login: true
+        passwordSecret:
+          name: mempalace-pg-role
+
   bootstrap:
     initdb:
       database: postgres


### PR DESCRIPTION
## Summary

Provisions the target for the mempalace ChromaDB→pgvector migration (Path B). Creates, declaratively via CNPG:
- **`mempalace` database** on `postgres18-cluster` with the **`vector`** (pgvector 0.8.1) extension
- **`mempalace` managed role** (owner), password from 1Password via ExternalSecret

Created at the cluster level (not as an app initContainer) because the mempalace HTTP deployment is being retired — the DB must persist independently of any app pod.

## ⚠️ Manual prerequisite before merge

Create a 1Password item named **`mempalace`** (same vault the `cloudnative-pg`/`atuin` items live in) with fields:
- `MEMPALACE_POSTGRES_USER` = `mempalace`
- `MEMPALACE_POSTGRES_PASS` = `<a strong generated password>`

The ExternalSecret `mempalace-pg-role` extracts these. Without the item, the secret (and thus the managed role) won't materialize.

## Files
- `mempalace-db.yaml` (new) — ExternalSecret + CNPG `Database` CR
- `postgres18-cluster.yaml` — add `spec.managed.roles` (mempalace)
- `kustomization.yaml` — wire in the new file

## Validation
- `kustomize build` renders all resources; `kubeconform -strict`: 11/11 valid.

## Post-merge verify
```
kubectl -n database get database mempalace
kubectl -n database exec <primary> -- psql -U postgres -d mempalace -tAc "SELECT extversion FROM pg_extension WHERE extname='vector';"
```

Part of the pgvector migration (scope + plan in mempalace repo `docs/superpowers/`).