### PR TITLE
feat(lighthouse): worker model auto-fetch — sync agent + model-serve 0.4.0

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -160,10 +160,13 @@ spec:
           model-serve:
             image:
               repository: ghcr.io/gavinmcfall/model-serve
-              tag: 0.3.0@sha256:45003e76eb41eea52331483c20646b1907f03fdf1e3099baf4f6a0e88e3e015c
+              tag: 0.4.0@sha256:f7283a545b144784c121ad02de1795d4ced7d7fae89abc114ec3a8c41109c78d
             env:
               MODELSERVE_LISTEN: ":9090"
               MODELSERVE_ROOT: "/models"
+              # Licence registry (mounted below) → tier-filtered /models/manifest:
+              # workers sync aux models + only the checkpoints their tier can run.
+              MODELSERVE_REGISTRY_PATH: "/etc/lighthouse/registry.json"
               MODELSERVE_TOKEN:
                 valueFrom:
                   secretKeyRef:
@@ -274,6 +277,10 @@ spec:
           lighthouse:
             licence-gate:
               - path: /etc/lighthouse
+            # model-serve reads registry.json for tier-filtered /models/manifest.
+            model-serve:
+              - path: /etc/lighthouse
+                readOnly: true
       # Curated App Mode workflows (manifest + JSONs) → role-scoped, read-only
       # overlay served by the gate (LIGHTHOUSE_CURATION_DIR). Separate mount dir
       # so it doesn't shadow the registry/allowlist configMap at /etc/lighthouse.

--- a/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.service
+++ b/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.service
@@ -1,0 +1,23 @@
+# Lighthouse worker model auto-fetch (ADR 018). Install (in the lighthouse WSL
+# distro, alongside comfyui-worker.service):
+#   sudo cp lighthouse-model-sync.{service,timer} /etc/systemd/system/
+#   sudo cp lighthouse-model-sync.sh /usr/local/bin/ && sudo chmod +x /usr/local/bin/lighthouse-model-sync.sh
+#   sudo tee /etc/lighthouse-worker.conf >/dev/null <<EOF
+#   MASTER=10.99.8.215:9090
+#   TOKEN=<LIGHTHOUSE_WORKER_TOKEN from op://Kubernetes/lighthouse>
+#   TIER=heavy        # heavy (Vengeance/Vixen) | light (Nova/Blaze)
+#   MODELS_DIR=/home/<user>/ComfyUI/models
+#   EOF
+#   sudo chmod 600 /etc/lighthouse-worker.conf
+#   sudo systemctl daemon-reload && sudo systemctl enable --now lighthouse-model-sync.timer
+# Manual run: sudo systemctl start lighthouse-model-sync.service
+[Unit]
+Description=Lighthouse model auto-fetch from cluster model-serve
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/lighthouse-model-sync.sh
+# Long downloads are normal on first sync (tens of GB) — no timeout.
+TimeoutStartSec=infinity

--- a/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.sh
+++ b/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Lighthouse worker model auto-fetch (ADR 018, task #40).
+# Pulls the tier-filtered manifest from model-serve, fetches missing/changed
+# files into the local ComfyUI models dir (resumable), and verifies sha256.
+# Config: /etc/lighthouse-worker.conf with MASTER, TOKEN, TIER, MODELS_DIR.
+set -euo pipefail
+
+CONF=/etc/lighthouse-worker.conf
+# shellcheck disable=SC1090
+source "$CONF" # MASTER=10.99.8.215:9090  TOKEN=...  TIER=heavy|light  MODELS_DIR=/home/<u>/ComfyUI/models
+: "${MASTER:?}" "${TOKEN:?}" "${TIER:?}" "${MODELS_DIR:?}"
+
+AUTH=(-H "Authorization: Bearer $TOKEN")
+BASE="http://$MASTER"
+
+log() { echo "[model-sync] $*"; }
+
+manifest=$(curl -fsS "${AUTH[@]}" "$BASE/models/manifest?tier=$TIER")
+count=$(jq length <<<"$manifest")
+log "manifest: $count files for tier=$TIER"
+
+fetched=0 skipped=0 failed=0
+while IFS=$'\t' read -r path size; do
+  dest="$MODELS_DIR/$path"
+  if [[ -f "$dest" && $(stat -c%s "$dest") -eq $size ]]; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+  log "fetch: $path ($size bytes)"
+  mkdir -p "$(dirname "$dest")"
+  # -C - resumes a partial download; --fail-with-body so 404 ≠ success.
+  if ! curl -fsS -C - "${AUTH[@]}" -o "$dest.part" "$BASE/models/$path"; then
+    log "ERROR: download failed: $path"
+    failed=$((failed + 1))
+    continue
+  fi
+  want=$(curl -fsS "${AUTH[@]}" "$BASE/models/sha256/$path" | jq -r .sha256)
+  got=$(sha256sum "$dest.part" | awk '{print $1}')
+  if [[ "$want" != "$got" ]]; then
+    log "ERROR: sha256 mismatch for $path (want $want got $got) — discarding"
+    rm -f "$dest.part"
+    failed=$((failed + 1))
+    continue
+  fi
+  mv "$dest.part" "$dest"
+  fetched=$((fetched + 1))
+done < <(jq -r '.[] | [.path, (.size | tostring)] | @tsv' <<<"$manifest")
+
+log "done: fetched=$fetched skipped=$skipped failed=$failed"
+[[ $failed -eq 0 ]] || exit 1

--- a/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.timer
+++ b/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.timer
@@ -1,0 +1,12 @@
+# Sync on boot + every 30 minutes (Gavin 2026-06-10). New models propagate to
+# every worker within a timer tick of `POST /models/ingest` on the master.
+[Unit]
+Description=Periodic Lighthouse model auto-fetch
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=30min
+RandomizedDelaySec=2min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The **worker half of ADR 018** (task #40), pairing with containers#20: models now propagate to GPU workers automatically — no more hand-`wget` per machine.

## What
- **`worker-setup/lighthouse-model-sync.{sh,service,timer}`** — systemd oneshot + timer (boot + 30min): pulls the **tier-filtered manifest** from model-serve, fetches missing/size-changed files with resumable `curl`, **verifies sha256** (server's cached hash vs local), atomic move into `~/ComfyUI/models`. Config via `/etc/lighthouse-worker.conf` (`MASTER`/`TOKEN`/`TIER`/`MODELS_DIR`) — full install steps in the service-file header. Needs `jq` in the distro.
- **model-serve `0.3.0` → `0.4.0@f7283a54`** (manifest + sha256 endpoints) + licence registry mounted ro (`MODELSERVE_REGISTRY_PATH`) so the manifest tier-filters: light workers (Nova/Blaze) skip heavy-only checkpoints (~100GB saved each); aux models (detectors/upscalers) always sync.

## Rollout after merge
Install the agent on **Vengeance first** (validation: it should skip everything already present), then **Nova/Blaze/Vixen** — which auto-pulls the FaceDetailer models + their tier's checkpoints. That closes the manual-distribution gap blocking fleet replication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)