### PR TITLE
fix(lighthouse): lowercase TIER in model-sync script

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.sh
+++ b/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.sh
@@ -9,6 +9,7 @@ CONF=/etc/lighthouse-worker.conf
 # shellcheck disable=SC1090
 source "$CONF" # MASTER=10.99.8.215:9090  TOKEN=...  TIER=heavy|light  MODELS_DIR=/home/<u>/ComfyUI/models
 : "${MASTER:?}" "${TOKEN:?}" "${TIER:?}" "${MODELS_DIR:?}"
+TIER=${TIER,,} # registry tier_fit slugs are lowercase; TIER=HEAVY must not silently match nothing
 
 AUTH=(-H "Authorization: Bearer $TOKEN")
 BASE="http://$MASTER"


### PR DESCRIPTION
TIER=HEAVY in a worker conf matched no (lowercase) `tier_fit` slugs → aux-only manifest on all three fleet installs (2026-06-12). Normalise `TIER=${TIER,,}` after sourcing. Pairs with containers#21 (server-side EqualFold). Script-only — no pod roll; already-installed workers were fixed by correcting their confs, this protects future installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)