### PR TITLE
chore(lighthouse): model-serve 0.4.1 (case-insensitive tier match)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -160,7 +160,7 @@ spec:
           model-serve:
             image:
               repository: ghcr.io/gavinmcfall/model-serve
-              tag: 0.4.0@sha256:f7283a545b144784c121ad02de1795d4ced7d7fae89abc114ec3a8c41109c78d
+              tag: 0.4.1@sha256:226aaaaeed4e3f008a91d6f3ce3b266b818202ba9e34a81308034c248326d090
             env:
               MODELSERVE_LISTEN: ":9090"
               MODELSERVE_ROOT: "/models"


### PR DESCRIPTION
Repin `0.4.0@f7283a54` → `0.4.1@226aaaae` (containers#21 — EqualFold tier match). Deliberately held until the fleet's initial pulls finished so the pod roll wouldn't interrupt in-flight downloads; fleet is now steady-state (`0/20/0` everywhere), safe to roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)