### PR TITLE
feat(lighthouse): curated standard-sdxl base workflow (Phase-2a #1)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/kustomization.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/kustomization.yaml
@@ -32,5 +32,6 @@ configMapGenerator:
     files:
       - ../workflows/curation.json
       - ../workflows/portrait-sdxl-hires-facedetailer.workflow.json
+      - ../workflows/standard-sdxl-hires.workflow.json
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/cortex/lighthouse/workflows/curation.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/curation.json
@@ -1,10 +1,17 @@
 {
-  "_comment": "Curated App Mode workflow registry (licence-gate LIGHTHOUSE_CURATION_DIR). Each entry is overlaid, role-filtered, into every caller's ComfyUI workflow sidebar and served read-only from this configMap. 'path' is the logical userdata path (workflows/lighthouse/... groups curated graphs); 'file' is the configMap key holding the workflow JSON; 'role_allowlist' is the VISIBILITY layer (empty = all authenticated callers) — enforcement is by model tag at the gate. See app-mode-curation.md.",
+  "_comment": "Curated App Mode workflow registry (licence-gate LIGHTHOUSE_CURATION_DIR). Each entry is overlaid, role-filtered, into every caller's ComfyUI workflow sidebar and served read-only from this configMap. 'path' is the logical userdata path (workflows/lighthouse/... groups curated graphs); 'file' is the configMap key holding the workflow JSON; 'role_allowlist' is the VISIBILITY layer (empty = all authenticated callers) \u2014 enforcement is by model tag at the gate. See app-mode-curation.md.",
   "entries": [
     {
       "path": "workflows/lighthouse/portrait-sdxl-hires-facedetailer.json",
       "file": "portrait-sdxl-hires-facedetailer.workflow.json",
-      "role_allowlist": ["family_adult"]
+      "role_allowlist": [
+        "family_adult"
+      ]
+    },
+    {
+      "path": "workflows/lighthouse/standard-sdxl-hires.json",
+      "file": "standard-sdxl-hires.workflow.json",
+      "role_allowlist": []
     }
   ]
 }

--- a/kubernetes/apps/cortex/lighthouse/workflows/standard-sdxl-hires.workflow.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/standard-sdxl-hires.workflow.json
@@ -1,0 +1,576 @@
+{
+  "id": "b2f1c9d0-0000-4000-8000-standardsdxl",
+  "revision": 0,
+  "last_node_id": 16,
+  "last_link_id": 25,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -94.84745390075693,
+        416.1639386099241
+      ],
+      "size": [
+        425.27801513671875,
+        180.6060791015625
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 5
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            6,
+            23
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "text, watermark, blurry, low quality"
+      ]
+    },
+    {
+      "id": 13,
+      "type": "DistributedCollector",
+      "pos": [
+        2022.1290608184836,
+        196.20550674133307
+      ],
+      "size": [
+        270,
+        78
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 18
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            19
+          ]
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DistributedCollector"
+      },
+      "widgets_values": [
+        false
+      ]
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        2411.5768151342727,
+        195.44205340423568
+      ],
+      "size": [
+        210,
+        270
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 19
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -92.84745390075696,
+        213.16393860992432
+      ],
+      "size": [
+        422.84503173828125,
+        164.31304931640625
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            4,
+            22
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "a cozy mountain village at golden hour, ultra detailed, cinematic lighting"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -481.8474539007569,
+        501.1639386099241
+      ],
+      "size": [
+        315,
+        98
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            1,
+            21
+          ]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": [
+            3,
+            5
+          ]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 2,
+          "links": [
+            8
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "sd_xl_base_1.0.safetensors"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        355.1525460992429,
+        213.16393860992432
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 4
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 6
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 2
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            20
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        1040474753904256,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 15,
+      "type": "LatentUpscaleBy",
+      "pos": [
+        630.2182176083068,
+        -257.5635040920633
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 20
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            24
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LatentUpscaleBy"
+      },
+      "widgets_values": [
+        "nearest-exact",
+        1.5
+      ]
+    },
+    {
+      "id": 16,
+      "type": "KSampler",
+      "pos": [
+        833.3571598495189,
+        -70.95906319492279
+      ],
+      "size": [
+        270,
+        262
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 21
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 22
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 23
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 24
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            25
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        511521651465881,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "simple",
+        0.45
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1209,
+        188
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 25
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 8
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            18
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [
+        -34.847453900756946,
+        636.1639386099246
+      ],
+      "size": [
+        315,
+        106
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            2
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        1024,
+        1024,
+        1
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      4,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      2,
+      5,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      3,
+      4,
+      1,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      4,
+      6,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      5,
+      4,
+      1,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      6,
+      7,
+      0,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      8,
+      4,
+      2,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      19,
+      13,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ],
+    [
+      20,
+      3,
+      0,
+      15,
+      0,
+      "LATENT"
+    ],
+    [
+      21,
+      4,
+      0,
+      16,
+      0,
+      "MODEL"
+    ],
+    [
+      22,
+      6,
+      0,
+      16,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      23,
+      7,
+      0,
+      16,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      24,
+      15,
+      0,
+      16,
+      3,
+      "LATENT"
+    ],
+    [
+      25,
+      16,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      18,
+      8,
+      0,
+      13,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.620921323059155,
+      "offset": [
+        297.71828409396375,
+        403.383135705604
+      ]
+    },
+    "frontendVersion": "1.43.18"
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
First of the remaining Phase-2a curated bases: **standard-sdxl** — SDXL + HiRes-fix (1024² → ×1.5 latent → 0.45-denoise second pass), derived programmatically from the proven portrait graph minus the FaceDetailer chain (nodes 10/11/12 dropped, VAEDecode rewired to the DistributedCollector). Registered in `curation.json` with an **empty role_allowlist** (visible to all authenticated users — it's the default base; mature/model enforcement stays at the gate via model tags). configMap wiring updated; renders clean.

After merge + reconcile: everyone sees `lighthouse/standard-sdxl-hires` in the workflow sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)