### PR TITLE
feat(lighthouse): curated restyle-canny workflow + ControlNet union (Phase-2a #3)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/kustomization.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/kustomization.yaml
@@ -34,5 +34,6 @@ configMapGenerator:
       - ../workflows/portrait-sdxl-hires-facedetailer.workflow.json
       - ../workflows/standard-sdxl-hires.workflow.json
       - ../workflows/illustrious-booru.workflow.json
+      - ../workflows/restyle-canny.workflow.json
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/cortex/lighthouse/app/resources/allowlist.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/allowlist.json
@@ -1,14 +1,73 @@
 {
-  "CheckpointLoaderSimple": { "model_fields": [{ "field": "ckpt_name", "folder": "checkpoints" }] },
-  "UNETLoader": { "model_fields": [{ "field": "unet_name", "folder": "diffusion_models" }] },
-  "VAELoader": { "model_fields": [{ "field": "vae_name", "folder": "vae" }] },
-  "LoraLoader": { "model_fields": [{ "field": "lora_name", "folder": "loras" }] },
-  "CLIPLoader": { "model_fields": [{ "field": "clip_name", "folder": "text_encoders" }] },
-  "DualCLIPLoader": { "model_fields": [{ "field": "clip_name1", "folder": "text_encoders" }, { "field": "clip_name2", "folder": "text_encoders" }] },
-  "ControlNetLoader": { "model_fields": [{ "field": "control_net_name", "folder": "controlnet" }] },
-  "SaveImage": { "output_field": "filename_prefix" },
-  "SaveAnimatedWEBP": { "output_field": "filename_prefix" },
-  "SaveAnimatedPNG": { "output_field": "filename_prefix" },
+  "CheckpointLoaderSimple": {
+    "model_fields": [
+      {
+        "field": "ckpt_name",
+        "folder": "checkpoints"
+      }
+    ]
+  },
+  "UNETLoader": {
+    "model_fields": [
+      {
+        "field": "unet_name",
+        "folder": "diffusion_models"
+      }
+    ]
+  },
+  "VAELoader": {
+    "model_fields": [
+      {
+        "field": "vae_name",
+        "folder": "vae"
+      }
+    ]
+  },
+  "LoraLoader": {
+    "model_fields": [
+      {
+        "field": "lora_name",
+        "folder": "loras"
+      }
+    ]
+  },
+  "CLIPLoader": {
+    "model_fields": [
+      {
+        "field": "clip_name",
+        "folder": "text_encoders"
+      }
+    ]
+  },
+  "DualCLIPLoader": {
+    "model_fields": [
+      {
+        "field": "clip_name1",
+        "folder": "text_encoders"
+      },
+      {
+        "field": "clip_name2",
+        "folder": "text_encoders"
+      }
+    ]
+  },
+  "ControlNetLoader": {
+    "model_fields": [
+      {
+        "field": "control_net_name",
+        "folder": "controlnet"
+      }
+    ]
+  },
+  "SaveImage": {
+    "output_field": "filename_prefix"
+  },
+  "SaveAnimatedWEBP": {
+    "output_field": "filename_prefix"
+  },
+  "SaveAnimatedPNG": {
+    "output_field": "filename_prefix"
+  },
   "CLIPTextEncode": {},
   "KSampler": {},
   "EmptyLatentImage": {},
@@ -18,5 +77,9 @@
   "DistributedSeed": {},
   "UltralyticsDetectorProvider": {},
   "SAMLoader": {},
-  "FaceDetailer": {}
+  "FaceDetailer": {},
+  "LoadImage": {},
+  "VAEEncode": {},
+  "CannyEdgePreprocessor": {},
+  "ControlNetApplyAdvanced": {}
 }

--- a/kubernetes/apps/cortex/lighthouse/app/resources/registry.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/registry.json
@@ -237,5 +237,16 @@
       "realvisxl-v5.0.safetensors",
       "cyberrealistic-xl-v10.safetensors"
     ]
+  },
+  {
+    "filename": "controlnet-union-sdxl-promax.safetensors",
+    "sha256": "9fae2e50cb431bfcbe05822b59ec2228df545ef27f711dea8949e9f4ed9f7cdc",
+    "licence": "Apache-2.0 (xinsir/controlnet-union-sdxl-1.0)",
+    "commercial_ok": true,
+    "tier_fit": [
+      "heavy",
+      "light"
+    ],
+    "substitutes": []
   }
 ]

--- a/kubernetes/apps/cortex/lighthouse/workflows/curation.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/curation.json
@@ -17,6 +17,11 @@
       "path": "workflows/lighthouse/illustrious-booru.json",
       "file": "illustrious-booru.workflow.json",
       "role_allowlist": []
+    },
+    {
+      "path": "workflows/lighthouse/restyle-canny.json",
+      "file": "restyle-canny.workflow.json",
+      "role_allowlist": []
     }
   ]
 }

--- a/kubernetes/apps/cortex/lighthouse/workflows/restyle-canny.workflow.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/restyle-canny.workflow.json
@@ -1,0 +1,673 @@
+{
+  "id": "d4e5f6a7-2222-4000-8000-restylecanny",
+  "revision": 0,
+  "last_node_id": 13,
+  "last_link_id": 17,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "LoadImage",
+      "pos": [
+        -700,
+        200
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1,
+            2
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "example.png",
+        "image"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "CannyEdgePreprocessor",
+      "pos": [
+        -330,
+        120
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            3
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CannyEdgePreprocessor"
+      },
+      "widgets_values": [
+        100,
+        200,
+        1024
+      ]
+    },
+    {
+      "id": 3,
+      "type": "ControlNetLoader",
+      "pos": [
+        -330,
+        320
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONTROL_NET",
+          "type": "CONTROL_NET",
+          "links": [
+            4
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ControlNetLoader"
+      },
+      "widgets_values": [
+        "controlnet-union-sdxl-promax.safetensors"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -700,
+        500
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            5
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            6,
+            7
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            8,
+            9
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "sd_xl_base_1.0.safetensors"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -330,
+        500
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 6
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            10
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "cyberpunk neon drift car livery, glossy, studio lighting, ultra detailed"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -330,
+        700
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            11
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "text, watermark, blurry, low quality"
+      ]
+    },
+    {
+      "id": 10,
+      "type": "ControlNetApplyAdvanced",
+      "pos": [
+        60,
+        300
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 10
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 11
+        },
+        {
+          "name": "control_net",
+          "type": "CONTROL_NET",
+          "link": 4
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            12
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "links": [
+            13
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ControlNetApplyAdvanced"
+      },
+      "widgets_values": [
+        0.8,
+        0.0,
+        0.8
+      ]
+    },
+    {
+      "id": 11,
+      "type": "VAEEncode",
+      "pos": [
+        60,
+        560
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 2
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 8
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            14
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEEncode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 12,
+      "type": "KSampler",
+      "pos": [
+        420,
+        300
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 5
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 12
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 13
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 14
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            15
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        42,
+        "randomize",
+        25,
+        7,
+        "euler",
+        "normal",
+        0.6
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        760,
+        300
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 15
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 9
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            16
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 13,
+      "type": "DistributedCollector",
+      "pos": [
+        1000,
+        300
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 16
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": null,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            17
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DistributedCollector"
+      },
+      "widgets_values": [
+        false
+      ]
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        1260,
+        300
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 17
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "restyle"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      2,
+      0,
+      "IMAGE"
+    ],
+    [
+      2,
+      1,
+      0,
+      11,
+      0,
+      "IMAGE"
+    ],
+    [
+      3,
+      2,
+      0,
+      10,
+      3,
+      "IMAGE"
+    ],
+    [
+      4,
+      3,
+      0,
+      10,
+      2,
+      "CONTROL_NET"
+    ],
+    [
+      5,
+      4,
+      0,
+      12,
+      0,
+      "MODEL"
+    ],
+    [
+      6,
+      4,
+      1,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      7,
+      4,
+      1,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      8,
+      4,
+      2,
+      11,
+      1,
+      "VAE"
+    ],
+    [
+      9,
+      4,
+      2,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      10,
+      6,
+      0,
+      10,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      11,
+      7,
+      0,
+      10,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      12,
+      10,
+      0,
+      12,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      13,
+      10,
+      1,
+      12,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      14,
+      11,
+      0,
+      12,
+      3,
+      "LATENT"
+    ],
+    [
+      15,
+      12,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      16,
+      8,
+      0,
+      13,
+      0,
+      "IMAGE"
+    ],
+    [
+      17,
+      13,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.43.18"
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Third Phase-2a base: **restyle-canny** — the drift-livery / fan-art workflow. `LoadImage → CannyEdgePreprocessor` (algorithmic, zero weights) `→ ControlNetApplyAdvanced` (strength 0.8, end 0.8) + img2img (`VAEEncode`, denoise 0.6): holds the reference's structure, restyles per prompt.

- **Model:** `xinsir/controlnet-union-sdxl-1.0` (promax) — Apache-2.0, **already ingested** to the PVC (`sha256:9fae2e50…`, 2.5GB); auto-fetch distributes to the fleet within 30 min.
- **Allowlist:** + `LoadImage`, `VAEEncode`, `CannyEdgePreprocessor`, `ControlNetApplyAdvanced` (execution-only).
- **Registry:** row for the controlnet (commercial-OK, both tiers).
- Empty `role_allowlist` (all authenticated).
- Depth variant deferred until the DepthAnythingV2-**Base** (Apache, not the NC Large) ckpts-path plumbing is sorted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)