### PR TITLE
feat(lighthouse): restyle-depth curated workflow (DepthAnythingV2-Small) + annotator path plumbing

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -47,6 +47,19 @@ spec:
               repository: ghcr.io/gavinmcfall/lighthouse
               # Bakes the lighthouse-identity sidebar tab (Phase 5; sidebar-icon rework).
               tag: 0.22.0@sha256:25fd91ae0cba5dd8c753463577e82e1dfe506d87ac540a54849447e5d696b158
+            env:
+              # comfyui_controlnet_aux annotator weights (DepthAnythingV2 etc.) live
+              # on the models PVC under annotators/ — the env var wins over the
+              # pack's config.yaml, so the pack finds them there and never attempts
+              # a runtime HuggingFace download. Workers get the same weights via
+              # lighthouse-model-sync + the matching env in comfyui-worker.service.
+              AUX_ANNOTATOR_CKPTS_PATH: /app/models/annotators
+              # Belt-and-braces for the Phase-2a pack vetting: the master image
+              # docs promise "HF_HUB_OFFLINE at runtime" (auto-download paths fail
+              # safe); these make that promise real. All weights are pre-staged on
+              # the PVC / worker model dirs.
+              HF_HUB_OFFLINE: "1"
+              TRANSFORMERS_OFFLINE: "1"
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/cortex/lighthouse/app/kustomization.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/kustomization.yaml
@@ -35,6 +35,7 @@ configMapGenerator:
       - ../workflows/standard-sdxl-hires.workflow.json
       - ../workflows/illustrious-booru.workflow.json
       - ../workflows/restyle-canny.workflow.json
+      - ../workflows/restyle-depth.workflow.json
       - ../workflows/mature-booru.workflow.json
       - ../workflows/mature-photoreal.workflow.json
       - ../workflows/mature-restyle.workflow.json

--- a/kubernetes/apps/cortex/lighthouse/app/resources/allowlist.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/allowlist.json
@@ -81,5 +81,6 @@
   "LoadImage": {},
   "VAEEncode": {},
   "CannyEdgePreprocessor": {},
+  "DepthAnythingV2Preprocessor": {},
   "ControlNetApplyAdvanced": {}
 }

--- a/kubernetes/apps/cortex/lighthouse/worker-setup/README.md
+++ b/kubernetes/apps/cortex/lighthouse/worker-setup/README.md
@@ -195,7 +195,19 @@ curl -sf http://localhost:8188/ >/dev/null && echo "ComfyUI up"
 > Re-run the `sed` + `daemon-reload` + `restart`.
 
 The unit launches ComfyUI with `--listen 0.0.0.0 --enable-cors-header` (both
-**required** for a ComfyUI-Distributed remote worker) and `Restart=always`.
+**required** for a ComfyUI-Distributed remote worker) and `Restart=always`. It
+also sets `AUX_ANNOTATOR_CKPTS_PATH=~/ComfyUI/models/annotators` so the
+controlnet_aux preprocessor weights (DepthAnythingV2 etc.) land inside the
+model-sync scope instead of the pack's own `ckpts/` dir.
+
+**Already-installed workers (units predating 2026-06-13) need the env line added
+once** — run inside the distro (no placeholders; `$USER` auto-fills):
+
+```bash
+sudo sed -i "\|^WorkingDirectory=|a Environment=AUX_ANNOTATOR_CKPTS_PATH=/home/$USER/ComfyUI/models/annotators" /etc/systemd/system/comfyui-worker.service
+grep Environment= /etc/systemd/system/comfyui-worker.service   # verify: one line, your real username in the path
+sudo systemctl daemon-reload && sudo systemctl restart comfyui-worker.service
+```
 
 ### 3c. Worker autostart — hidden VBS launcher in Startup (no window)
 

--- a/kubernetes/apps/cortex/lighthouse/worker-setup/comfyui-worker.service
+++ b/kubernetes/apps/cortex/lighthouse/worker-setup/comfyui-worker.service
@@ -19,6 +19,11 @@ Wants=network-online.target
 Type=simple
 User=<WSL_USER>
 WorkingDirectory=/home/<WSL_USER>/ComfyUI
+# Point comfyui_controlnet_aux annotator weights (DepthAnythingV2 etc.) into the
+# models tree so lighthouse-model-sync distributes them (annotators/...) and the
+# pack never tries a runtime HuggingFace download. The env var wins over the
+# pack's config.yaml (utils.py reads it via os.getenv).
+Environment=AUX_ANNOTATOR_CKPTS_PATH=/home/<WSL_USER>/ComfyUI/models/annotators
 ExecStart=/home/<WSL_USER>/ComfyUI/.venv/bin/python /home/<WSL_USER>/ComfyUI/main.py --listen 0.0.0.0 --enable-cors-header
 Restart=always
 RestartSec=5

--- a/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.service
+++ b/kubernetes/apps/cortex/lighthouse/worker-setup/lighthouse-model-sync.service
@@ -2,15 +2,25 @@
 # distro, alongside comfyui-worker.service):
 #   sudo cp lighthouse-model-sync.{service,timer} /etc/systemd/system/
 #   sudo cp lighthouse-model-sync.sh /usr/local/bin/ && sudo chmod +x /usr/local/bin/lighthouse-model-sync.sh
+#
+#   ⚠️ The heredoc below has TWO placeholders to replace — line 2 (TOKEN) and
+#   line 4 (MODELS_DIR <user>). Leaving `<...>` in the file breaks the service
+#   (angle brackets are shell redirects). TIER must be LOWERCASE (heavy|light) —
+#   the manifest filter matches exact lowercase slugs; an uppercase TIER silently
+#   strips every checkpoint (aux-only sync, bit the first fleet install).
+#
 #   sudo tee /etc/lighthouse-worker.conf >/dev/null <<EOF
 #   MASTER=10.99.8.215:9090
-#   TOKEN=<LIGHTHOUSE_WORKER_TOKEN from op://Kubernetes/lighthouse>
-#   TIER=heavy        # heavy (Vengeance/Vixen) | light (Nova/Blaze)
-#   MODELS_DIR=/home/<user>/ComfyUI/models
+#   TOKEN=<LIGHTHOUSE_WORKER_TOKEN from op://Kubernetes/lighthouse>   # ← REPLACE, keep no angle brackets
+#   TIER=heavy        # lowercase! heavy (Vengeance/Vixen) | light (Nova/Blaze)
+#   MODELS_DIR=/home/<user>/ComfyUI/models                            # ← REPLACE <user>
 #   EOF
 #   sudo chmod 600 /etc/lighthouse-worker.conf
 #   sudo systemctl daemon-reload && sudo systemctl enable --now lighthouse-model-sync.timer
-# Manual run: sudo systemctl start lighthouse-model-sync.service
+# Manual run (oneshot BLOCKS until the sync finishes — first sync can be tens of
+# GB, so don't wait on it):
+#   sudo systemctl start --no-block lighthouse-model-sync.service
+#   journalctl -fu lighthouse-model-sync.service   # watch progress; done line = "done: fetched=N skipped=M failed=0"
 [Unit]
 Description=Lighthouse model auto-fetch from cluster model-serve
 Wants=network-online.target

--- a/kubernetes/apps/cortex/lighthouse/workflows/curation.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/curation.json
@@ -24,6 +24,11 @@
       "role_allowlist": []
     },
     {
+      "path": "workflows/lighthouse/restyle-depth.json",
+      "file": "restyle-depth.workflow.json",
+      "role_allowlist": []
+    },
+    {
       "path": "workflows/lighthouse/mature-booru.json",
       "file": "mature-booru.workflow.json",
       "role_allowlist": [

--- a/kubernetes/apps/cortex/lighthouse/workflows/restyle-depth.workflow.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/restyle-depth.workflow.json
@@ -1,0 +1,672 @@
+{
+ "id": "d4e5f6a7-2222-4000-8000-restylecanny",
+ "revision": 0,
+ "last_node_id": 13,
+ "last_link_id": 17,
+ "nodes": [
+  {
+   "id": 1,
+   "type": "LoadImage",
+   "pos": [
+    -700,
+    200
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 0,
+   "mode": 0,
+   "inputs": [],
+   "outputs": [
+    {
+     "name": "IMAGE",
+     "type": "IMAGE",
+     "links": [
+      1,
+      2
+     ],
+     "slot_index": 0
+    },
+    {
+     "name": "MASK",
+     "type": "MASK",
+     "links": null,
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "LoadImage"
+   },
+   "widgets_values": [
+    "example.png",
+    "image"
+   ]
+  },
+  {
+   "id": 2,
+   "type": "DepthAnythingV2Preprocessor",
+   "pos": [
+    -330,
+    120
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 1,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "image",
+     "type": "IMAGE",
+     "link": 1
+    }
+   ],
+   "outputs": [
+    {
+     "name": "IMAGE",
+     "type": "IMAGE",
+     "links": [
+      3
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "DepthAnythingV2Preprocessor"
+   },
+   "widgets_values": [
+    "depth_anything_v2_vits.pth",
+    1024
+   ]
+  },
+  {
+   "id": 3,
+   "type": "ControlNetLoader",
+   "pos": [
+    -330,
+    320
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 2,
+   "mode": 0,
+   "inputs": [],
+   "outputs": [
+    {
+     "name": "CONTROL_NET",
+     "type": "CONTROL_NET",
+     "links": [
+      4
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "ControlNetLoader"
+   },
+   "widgets_values": [
+    "controlnet-union-sdxl-promax.safetensors"
+   ]
+  },
+  {
+   "id": 4,
+   "type": "CheckpointLoaderSimple",
+   "pos": [
+    -700,
+    500
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 3,
+   "mode": 0,
+   "inputs": [],
+   "outputs": [
+    {
+     "name": "MODEL",
+     "type": "MODEL",
+     "links": [
+      5
+     ],
+     "slot_index": 0
+    },
+    {
+     "name": "CLIP",
+     "type": "CLIP",
+     "links": [
+      6,
+      7
+     ],
+     "slot_index": 0
+    },
+    {
+     "name": "VAE",
+     "type": "VAE",
+     "links": [
+      8,
+      9
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "CheckpointLoaderSimple"
+   },
+   "widgets_values": [
+    "sd_xl_base_1.0.safetensors"
+   ]
+  },
+  {
+   "id": 6,
+   "type": "CLIPTextEncode",
+   "pos": [
+    -330,
+    500
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 4,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "clip",
+     "type": "CLIP",
+     "link": 6
+    }
+   ],
+   "outputs": [
+    {
+     "name": "CONDITIONING",
+     "type": "CONDITIONING",
+     "links": [
+      10
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "CLIPTextEncode"
+   },
+   "widgets_values": [
+    "cyberpunk neon drift car livery, glossy, studio lighting, ultra detailed"
+   ]
+  },
+  {
+   "id": 7,
+   "type": "CLIPTextEncode",
+   "pos": [
+    -330,
+    700
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 5,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "clip",
+     "type": "CLIP",
+     "link": 7
+    }
+   ],
+   "outputs": [
+    {
+     "name": "CONDITIONING",
+     "type": "CONDITIONING",
+     "links": [
+      11
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "CLIPTextEncode"
+   },
+   "widgets_values": [
+    "text, watermark, blurry, low quality"
+   ]
+  },
+  {
+   "id": 10,
+   "type": "ControlNetApplyAdvanced",
+   "pos": [
+    60,
+    300
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 6,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "positive",
+     "type": "CONDITIONING",
+     "link": 10
+    },
+    {
+     "name": "negative",
+     "type": "CONDITIONING",
+     "link": 11
+    },
+    {
+     "name": "control_net",
+     "type": "CONTROL_NET",
+     "link": 4
+    },
+    {
+     "name": "image",
+     "type": "IMAGE",
+     "link": 3
+    }
+   ],
+   "outputs": [
+    {
+     "name": "positive",
+     "type": "CONDITIONING",
+     "links": [
+      12
+     ],
+     "slot_index": 0
+    },
+    {
+     "name": "negative",
+     "type": "CONDITIONING",
+     "links": [
+      13
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "ControlNetApplyAdvanced"
+   },
+   "widgets_values": [
+    0.8,
+    0.0,
+    0.8
+   ]
+  },
+  {
+   "id": 11,
+   "type": "VAEEncode",
+   "pos": [
+    60,
+    560
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 7,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "pixels",
+     "type": "IMAGE",
+     "link": 2
+    },
+    {
+     "name": "vae",
+     "type": "VAE",
+     "link": 8
+    }
+   ],
+   "outputs": [
+    {
+     "name": "LATENT",
+     "type": "LATENT",
+     "links": [
+      14
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "VAEEncode"
+   },
+   "widgets_values": []
+  },
+  {
+   "id": 12,
+   "type": "KSampler",
+   "pos": [
+    420,
+    300
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 8,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "model",
+     "type": "MODEL",
+     "link": 5
+    },
+    {
+     "name": "positive",
+     "type": "CONDITIONING",
+     "link": 12
+    },
+    {
+     "name": "negative",
+     "type": "CONDITIONING",
+     "link": 13
+    },
+    {
+     "name": "latent_image",
+     "type": "LATENT",
+     "link": 14
+    }
+   ],
+   "outputs": [
+    {
+     "name": "LATENT",
+     "type": "LATENT",
+     "links": [
+      15
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "KSampler"
+   },
+   "widgets_values": [
+    42,
+    "randomize",
+    25,
+    7,
+    "euler",
+    "normal",
+    0.6
+   ]
+  },
+  {
+   "id": 8,
+   "type": "VAEDecode",
+   "pos": [
+    760,
+    300
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 9,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "samples",
+     "type": "LATENT",
+     "link": 15
+    },
+    {
+     "name": "vae",
+     "type": "VAE",
+     "link": 9
+    }
+   ],
+   "outputs": [
+    {
+     "name": "IMAGE",
+     "type": "IMAGE",
+     "links": [
+      16
+     ],
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "VAEDecode"
+   },
+   "widgets_values": []
+  },
+  {
+   "id": 13,
+   "type": "DistributedCollector",
+   "pos": [
+    1000,
+    300
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 10,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "images",
+     "type": "IMAGE",
+     "link": 16
+    },
+    {
+     "name": "audio",
+     "type": "AUDIO",
+     "link": null,
+     "shape": 7
+    }
+   ],
+   "outputs": [
+    {
+     "name": "images",
+     "type": "IMAGE",
+     "links": [
+      17
+     ],
+     "slot_index": 0
+    },
+    {
+     "name": "audio",
+     "type": "AUDIO",
+     "links": null,
+     "slot_index": 0
+    }
+   ],
+   "properties": {
+    "Node name for S&R": "DistributedCollector"
+   },
+   "widgets_values": [
+    false
+   ]
+  },
+  {
+   "id": 9,
+   "type": "SaveImage",
+   "pos": [
+    1260,
+    300
+   ],
+   "size": [
+    315,
+    130
+   ],
+   "flags": {},
+   "order": 11,
+   "mode": 0,
+   "inputs": [
+    {
+     "name": "images",
+     "type": "IMAGE",
+     "link": 17
+    }
+   ],
+   "outputs": [],
+   "properties": {
+    "Node name for S&R": "SaveImage"
+   },
+   "widgets_values": [
+    "restyle"
+   ]
+  }
+ ],
+ "links": [
+  [
+   1,
+   1,
+   0,
+   2,
+   0,
+   "IMAGE"
+  ],
+  [
+   2,
+   1,
+   0,
+   11,
+   0,
+   "IMAGE"
+  ],
+  [
+   3,
+   2,
+   0,
+   10,
+   3,
+   "IMAGE"
+  ],
+  [
+   4,
+   3,
+   0,
+   10,
+   2,
+   "CONTROL_NET"
+  ],
+  [
+   5,
+   4,
+   0,
+   12,
+   0,
+   "MODEL"
+  ],
+  [
+   6,
+   4,
+   1,
+   6,
+   0,
+   "CLIP"
+  ],
+  [
+   7,
+   4,
+   1,
+   7,
+   0,
+   "CLIP"
+  ],
+  [
+   8,
+   4,
+   2,
+   11,
+   1,
+   "VAE"
+  ],
+  [
+   9,
+   4,
+   2,
+   8,
+   1,
+   "VAE"
+  ],
+  [
+   10,
+   6,
+   0,
+   10,
+   0,
+   "CONDITIONING"
+  ],
+  [
+   11,
+   7,
+   0,
+   10,
+   1,
+   "CONDITIONING"
+  ],
+  [
+   12,
+   10,
+   0,
+   12,
+   1,
+   "CONDITIONING"
+  ],
+  [
+   13,
+   10,
+   1,
+   12,
+   2,
+   "CONDITIONING"
+  ],
+  [
+   14,
+   11,
+   0,
+   12,
+   3,
+   "LATENT"
+  ],
+  [
+   15,
+   12,
+   0,
+   8,
+   0,
+   "LATENT"
+  ],
+  [
+   16,
+   8,
+   0,
+   13,
+   0,
+   "IMAGE"
+  ],
+  [
+   17,
+   13,
+   0,
+   9,
+   0,
+   "IMAGE"
+  ]
+ ],
+ "groups": [],
+ "config": {},
+ "extra": {
+  "frontendVersion": "1.43.18"
+ },
+ "version": 0.4
+}


### PR DESCRIPTION
## What

The depth-guided restyle variant joins restyle-canny in the curated App Mode set (entry #8), plus the annotator-weights plumbing that previously blocked it.

### Workflow
- `workflows/lighthouse/restyle-depth.workflow.json` — derived programmatically from restyle-canny: same LoadImage → preprocessor → ControlNetApplyAdvanced(0.8/0/0.8) + img2img denoise-0.6 graph on `sd_xl_base_1.0` + `controlnet-union-sdxl-promax`, with `DepthAnythingV2Preprocessor` (`depth_anything_v2_vits.pth`, resolution 1024) in place of Canny.
- **Licence check (HF API verified):** only DepthAnythingV2-**Small** (vits) is Apache-2.0 — Base/Large/Giant are CC-BY-NC-4.0, so they stay out. (Earlier notes claiming Base was Apache were wrong.)
- `curation.json` entry, `role_allowlist: []` (all authenticated); allowlist += `DepthAnythingV2Preprocessor` (execution-only `{}`).

### Annotator path plumbing (the blocker)
`comfyui_controlnet_aux` (pinned e8b689a5) resolves its ckpts dir from `AUX_ANNOTATOR_CKPTS_PATH` — the env var wins over the pack's config.yaml, and the loader skips its HuggingFace download when `<ckpts>/depth-anything/Depth-Anything-V2-Small/depth_anything_v2_vits.pth` exists. So:
- master: `AUX_ANNOTATOR_CKPTS_PATH=/app/models/annotators` (+ `HF_HUB_OFFLINE=1`/`TRANSFORMERS_OFFLINE=1`, which the master image docs promised but the helmrelease never set)
- workers: same env in `comfyui-worker.service` (new installs); README §3b has a one-line `sed` for the four existing workers
- weights: **already ingested** to the PVC at `annotators/depth-anything/Depth-Anything-V2-Small/depth_anything_v2_vits.pth` (99,218,434 bytes, sha256 `715fade1…` = HF LFS oid, verified) and **already visible in the tier manifest** — the fleet timer mirrors it to every worker within ~30 min, both tiers (non-registry aux path).

### Runbook touch-ups (folded in)
- manual sync runs: `systemctl start --no-block` + `journalctl -fu` (oneshot blocks for tens of GB otherwise)
- TIER must be lowercase — uppercase silently strips every checkpoint (bit the first fleet install)
- the two `/etc/lighthouse-worker.conf` placeholders are now loudly called out

## Validation

`kustomize build --load-restrictor=LoadRestrictionsNone` renders clean; all JSON valid; allowlist/curation diffs are single-entry.

## After merge

1. Flux reconcile → master pod rolls (new env + configMap).
2. One-time on each of the 4 workers: README §3b env line + service restart.
3. Gavin: hard refresh → `lighthouse/restyle-depth` appears; App Builder pass still pending for all bases.