### PR TITLE
fix(mangarr): remove noisy filing-gap line (sha-471e1f8)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-4f106ed@sha256:d5e71c1031c3f86b35f562c33d470ceaab90bdd29fc9091b06a82fed606aa63f
+              tag: sha-471e1f8@sha256:91f477eb934ee90bdad14938efe0c1e3f7a8bfdd671563ae8c4c737cb40f89c6
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
Cleans up the Library page — removes the false 'not filed to Kavita' warning that showed on every row (gavinmcfall/mangarr#62). Keeps honest status + dud/not-downloaded breakdown. Image: `ghcr.io/gavinmcfall/mangarr:sha-471e1f8@sha256:91f477eb934ee90bdad14938efe0c1e3f7a8bfdd671563ae8c4c737cb40f89c6`