### PR TITLE
fix(mangarr): stop progress bar flashing (sha-3593ce4)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-471e1f8@sha256:91f477eb934ee90bdad14938efe0c1e3f7a8bfdd671563ae8c4c737cb40f89c6
+              tag: sha-3593ce4@sha256:a63d56a323f7ae1391f12700d2e8c26a0366e684c805815104f9fb21b579b809
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
Fixes the global progress bar flashing every ~5s from the downloads-badge poll (gavinmcfall/mangarr#63). Image: `ghcr.io/gavinmcfall/mangarr:sha-3593ce4@sha256:a63d56a323f7ae1391f12700d2e8c26a0366e684c805815104f9fb21b579b809`