### PR TITLE
feat(lighthouse): restyle-depth ships as an App Mode form

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/workflows/restyle-depth.workflow.json
+++ b/kubernetes/apps/cortex/lighthouse/workflows/restyle-depth.workflow.json
@@ -1,672 +1,733 @@
 {
- "id": "d4e5f6a7-2222-4000-8000-restylecanny",
- "revision": 0,
- "last_node_id": 13,
- "last_link_id": 17,
- "nodes": [
-  {
-   "id": 1,
-   "type": "LoadImage",
-   "pos": [
-    -700,
-    200
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 0,
-   "mode": 0,
-   "inputs": [],
-   "outputs": [
+  "id": "64f38174-8bfc-48c1-b707-b51bfe72d67a",
+  "revision": 0,
+  "last_node_id": 13,
+  "last_link_id": 17,
+  "nodes": [
     {
-     "name": "IMAGE",
-     "type": "IMAGE",
-     "links": [
+      "id": 2,
+      "type": "DepthAnythingV2Preprocessor",
+      "pos": [
+        -330,
+        120
+      ],
+      "size": [
+        315,
+        138.13333129882812
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            3
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DepthAnythingV2Preprocessor"
+      },
+      "widgets_values": [
+        "depth_anything_v2_vits.pth",
+        1024
+      ]
+    },
+    {
+      "id": 3,
+      "type": "ControlNetLoader",
+      "pos": [
+        -330,
+        320
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONTROL_NET",
+          "type": "CONTROL_NET",
+          "slot_index": 0,
+          "links": [
+            4
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ControlNetLoader"
+      },
+      "widgets_values": [
+        "controlnet-union-sdxl-promax.safetensors"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -700,
+        500
+      ],
+      "size": [
+        315,
+        130.13333129882812
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            5
+          ]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            6,
+            7
+          ]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            8,
+            9
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "sd_xl_base_1.0.safetensors"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -330,
+        500
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 6
+        },
+        {
+          "label": "Positive Prompt",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            10
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "oil painting portrait, painterly brushstrokes, warm Rembrandt lighting, rich earthy palette, textured canvas, soft chiaroscuro, fine art, masterpiece, highly detailed"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -330,
+        700
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 7
+        },
+        {
+          "label": "Negative Prompt",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            11
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "photograph, photorealistic, 3d render, cgi, plastic skin, lowres, blurry, deformed, distorted face, extra fingers, bad anatomy, watermark, text, signature, jpeg artifacts, oversaturated"
+      ]
+    },
+    {
+      "id": 10,
+      "type": "ControlNetApplyAdvanced",
+      "pos": [
+        60,
+        300
+      ],
+      "size": [
+        315,
+        239.4666748046875
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 10
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 11
+        },
+        {
+          "name": "control_net",
+          "type": "CONTROL_NET",
+          "link": 4
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 3
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            12
+          ]
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            13
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ControlNetApplyAdvanced"
+      },
+      "widgets_values": [
+        0.8,
+        0,
+        0.8
+      ]
+    },
+    {
+      "id": 11,
+      "type": "VAEEncode",
+      "pos": [
+        60,
+        560
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 2
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 8
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            14
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEEncode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        760,
+        300
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 15
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 9
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            16
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 13,
+      "type": "DistributedCollector",
+      "pos": [
+        1000,
+        300
+      ],
+      "size": [
+        315,
+        130
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 16
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            17
+          ]
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "slot_index": 0,
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DistributedCollector"
+      },
+      "widgets_values": [
+        false
+      ]
+    },
+    {
+      "id": 12,
+      "type": "KSampler",
+      "pos": [
+        420,
+        300
+      ],
+      "size": [
+        315,
+        316.79998779296875
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 5
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 12
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 13
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 14
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            15
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        97597479239564,
+        "randomize",
+        25,
+        7,
+        "euler",
+        "normal",
+        0.6
+      ]
+    },
+    {
+      "id": 1,
+      "type": "LoadImage",
+      "pos": [
+        -700,
+        200
+      ],
+      "size": [
+        315,
+        343.4666748046875
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "Input Image",
+          "name": "image",
+          "type": "COMBO",
+          "widget": {
+            "name": "image"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 0,
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "example.png",
+        "image"
+      ]
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        1445.417444487132,
+        307.3675660239544
+      ],
+      "size": [
+        315,
+        315.4666748046875
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 17
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "restyle"
+      ]
+    }
+  ],
+  "links": [
+    [
       1,
-      2
-     ],
-     "slot_index": 0
-    },
-    {
-     "name": "MASK",
-     "type": "MASK",
-     "links": null,
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "LoadImage"
-   },
-   "widgets_values": [
-    "example.png",
-    "image"
-   ]
-  },
-  {
-   "id": 2,
-   "type": "DepthAnythingV2Preprocessor",
-   "pos": [
-    -330,
-    120
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 1,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "image",
-     "type": "IMAGE",
-     "link": 1
-    }
-   ],
-   "outputs": [
-    {
-     "name": "IMAGE",
-     "type": "IMAGE",
-     "links": [
-      3
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "DepthAnythingV2Preprocessor"
-   },
-   "widgets_values": [
-    "depth_anything_v2_vits.pth",
-    1024
-   ]
-  },
-  {
-   "id": 3,
-   "type": "ControlNetLoader",
-   "pos": [
-    -330,
-    320
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 2,
-   "mode": 0,
-   "inputs": [],
-   "outputs": [
-    {
-     "name": "CONTROL_NET",
-     "type": "CONTROL_NET",
-     "links": [
-      4
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "ControlNetLoader"
-   },
-   "widgets_values": [
-    "controlnet-union-sdxl-promax.safetensors"
-   ]
-  },
-  {
-   "id": 4,
-   "type": "CheckpointLoaderSimple",
-   "pos": [
-    -700,
-    500
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 3,
-   "mode": 0,
-   "inputs": [],
-   "outputs": [
-    {
-     "name": "MODEL",
-     "type": "MODEL",
-     "links": [
-      5
-     ],
-     "slot_index": 0
-    },
-    {
-     "name": "CLIP",
-     "type": "CLIP",
-     "links": [
+      1,
+      0,
+      2,
+      0,
+      "IMAGE"
+    ],
+    [
+      2,
+      1,
+      0,
+      11,
+      0,
+      "IMAGE"
+    ],
+    [
+      3,
+      2,
+      0,
+      10,
+      3,
+      "IMAGE"
+    ],
+    [
+      4,
+      3,
+      0,
+      10,
+      2,
+      "CONTROL_NET"
+    ],
+    [
+      5,
+      4,
+      0,
+      12,
+      0,
+      "MODEL"
+    ],
+    [
       6,
-      7
-     ],
-     "slot_index": 0
-    },
-    {
-     "name": "VAE",
-     "type": "VAE",
-     "links": [
+      4,
+      1,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      7,
+      4,
+      1,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
       8,
-      9
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "CheckpointLoaderSimple"
-   },
-   "widgets_values": [
-    "sd_xl_base_1.0.safetensors"
-   ]
+      4,
+      2,
+      11,
+      1,
+      "VAE"
+    ],
+    [
+      9,
+      4,
+      2,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      10,
+      6,
+      0,
+      10,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      11,
+      7,
+      0,
+      10,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      12,
+      10,
+      0,
+      12,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      13,
+      10,
+      1,
+      12,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      14,
+      11,
+      0,
+      12,
+      3,
+      "LATENT"
+    ],
+    [
+      15,
+      12,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      16,
+      8,
+      0,
+      13,
+      0,
+      "IMAGE"
+    ],
+    [
+      17,
+      13,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.43.18",
+    "linearData": {
+      "inputs": [
+        [
+          "1",
+          "image"
+        ],
+        [
+          "6",
+          "text"
+        ],
+        [
+          "7",
+          "text"
+        ]
+      ],
+      "outputs": [
+        "9"
+      ]
+    },
+    "ds": {
+      "scale": 0.8743771067538129,
+      "offset": [
+        1252.7472427108369,
+        116.94058297945877
+      ]
+    },
+    "linearMode": true
   },
-  {
-   "id": 6,
-   "type": "CLIPTextEncode",
-   "pos": [
-    -330,
-    500
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 4,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "clip",
-     "type": "CLIP",
-     "link": 6
-    }
-   ],
-   "outputs": [
-    {
-     "name": "CONDITIONING",
-     "type": "CONDITIONING",
-     "links": [
-      10
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "CLIPTextEncode"
-   },
-   "widgets_values": [
-    "cyberpunk neon drift car livery, glossy, studio lighting, ultra detailed"
-   ]
-  },
-  {
-   "id": 7,
-   "type": "CLIPTextEncode",
-   "pos": [
-    -330,
-    700
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 5,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "clip",
-     "type": "CLIP",
-     "link": 7
-    }
-   ],
-   "outputs": [
-    {
-     "name": "CONDITIONING",
-     "type": "CONDITIONING",
-     "links": [
-      11
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "CLIPTextEncode"
-   },
-   "widgets_values": [
-    "text, watermark, blurry, low quality"
-   ]
-  },
-  {
-   "id": 10,
-   "type": "ControlNetApplyAdvanced",
-   "pos": [
-    60,
-    300
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 6,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "positive",
-     "type": "CONDITIONING",
-     "link": 10
-    },
-    {
-     "name": "negative",
-     "type": "CONDITIONING",
-     "link": 11
-    },
-    {
-     "name": "control_net",
-     "type": "CONTROL_NET",
-     "link": 4
-    },
-    {
-     "name": "image",
-     "type": "IMAGE",
-     "link": 3
-    }
-   ],
-   "outputs": [
-    {
-     "name": "positive",
-     "type": "CONDITIONING",
-     "links": [
-      12
-     ],
-     "slot_index": 0
-    },
-    {
-     "name": "negative",
-     "type": "CONDITIONING",
-     "links": [
-      13
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "ControlNetApplyAdvanced"
-   },
-   "widgets_values": [
-    0.8,
-    0.0,
-    0.8
-   ]
-  },
-  {
-   "id": 11,
-   "type": "VAEEncode",
-   "pos": [
-    60,
-    560
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 7,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "pixels",
-     "type": "IMAGE",
-     "link": 2
-    },
-    {
-     "name": "vae",
-     "type": "VAE",
-     "link": 8
-    }
-   ],
-   "outputs": [
-    {
-     "name": "LATENT",
-     "type": "LATENT",
-     "links": [
-      14
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "VAEEncode"
-   },
-   "widgets_values": []
-  },
-  {
-   "id": 12,
-   "type": "KSampler",
-   "pos": [
-    420,
-    300
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 8,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "model",
-     "type": "MODEL",
-     "link": 5
-    },
-    {
-     "name": "positive",
-     "type": "CONDITIONING",
-     "link": 12
-    },
-    {
-     "name": "negative",
-     "type": "CONDITIONING",
-     "link": 13
-    },
-    {
-     "name": "latent_image",
-     "type": "LATENT",
-     "link": 14
-    }
-   ],
-   "outputs": [
-    {
-     "name": "LATENT",
-     "type": "LATENT",
-     "links": [
-      15
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "KSampler"
-   },
-   "widgets_values": [
-    42,
-    "randomize",
-    25,
-    7,
-    "euler",
-    "normal",
-    0.6
-   ]
-  },
-  {
-   "id": 8,
-   "type": "VAEDecode",
-   "pos": [
-    760,
-    300
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 9,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "samples",
-     "type": "LATENT",
-     "link": 15
-    },
-    {
-     "name": "vae",
-     "type": "VAE",
-     "link": 9
-    }
-   ],
-   "outputs": [
-    {
-     "name": "IMAGE",
-     "type": "IMAGE",
-     "links": [
-      16
-     ],
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "VAEDecode"
-   },
-   "widgets_values": []
-  },
-  {
-   "id": 13,
-   "type": "DistributedCollector",
-   "pos": [
-    1000,
-    300
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 10,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "images",
-     "type": "IMAGE",
-     "link": 16
-    },
-    {
-     "name": "audio",
-     "type": "AUDIO",
-     "link": null,
-     "shape": 7
-    }
-   ],
-   "outputs": [
-    {
-     "name": "images",
-     "type": "IMAGE",
-     "links": [
-      17
-     ],
-     "slot_index": 0
-    },
-    {
-     "name": "audio",
-     "type": "AUDIO",
-     "links": null,
-     "slot_index": 0
-    }
-   ],
-   "properties": {
-    "Node name for S&R": "DistributedCollector"
-   },
-   "widgets_values": [
-    false
-   ]
-  },
-  {
-   "id": 9,
-   "type": "SaveImage",
-   "pos": [
-    1260,
-    300
-   ],
-   "size": [
-    315,
-    130
-   ],
-   "flags": {},
-   "order": 11,
-   "mode": 0,
-   "inputs": [
-    {
-     "name": "images",
-     "type": "IMAGE",
-     "link": 17
-    }
-   ],
-   "outputs": [],
-   "properties": {
-    "Node name for S&R": "SaveImage"
-   },
-   "widgets_values": [
-    "restyle"
-   ]
-  }
- ],
- "links": [
-  [
-   1,
-   1,
-   0,
-   2,
-   0,
-   "IMAGE"
-  ],
-  [
-   2,
-   1,
-   0,
-   11,
-   0,
-   "IMAGE"
-  ],
-  [
-   3,
-   2,
-   0,
-   10,
-   3,
-   "IMAGE"
-  ],
-  [
-   4,
-   3,
-   0,
-   10,
-   2,
-   "CONTROL_NET"
-  ],
-  [
-   5,
-   4,
-   0,
-   12,
-   0,
-   "MODEL"
-  ],
-  [
-   6,
-   4,
-   1,
-   6,
-   0,
-   "CLIP"
-  ],
-  [
-   7,
-   4,
-   1,
-   7,
-   0,
-   "CLIP"
-  ],
-  [
-   8,
-   4,
-   2,
-   11,
-   1,
-   "VAE"
-  ],
-  [
-   9,
-   4,
-   2,
-   8,
-   1,
-   "VAE"
-  ],
-  [
-   10,
-   6,
-   0,
-   10,
-   0,
-   "CONDITIONING"
-  ],
-  [
-   11,
-   7,
-   0,
-   10,
-   1,
-   "CONDITIONING"
-  ],
-  [
-   12,
-   10,
-   0,
-   12,
-   1,
-   "CONDITIONING"
-  ],
-  [
-   13,
-   10,
-   1,
-   12,
-   2,
-   "CONDITIONING"
-  ],
-  [
-   14,
-   11,
-   0,
-   12,
-   3,
-   "LATENT"
-  ],
-  [
-   15,
-   12,
-   0,
-   8,
-   0,
-   "LATENT"
-  ],
-  [
-   16,
-   8,
-   0,
-   13,
-   0,
-   "IMAGE"
-  ],
-  [
-   17,
-   13,
-   0,
-   9,
-   0,
-   "IMAGE"
-  ]
- ],
- "groups": [],
- "config": {},
- "extra": {
-  "frontendVersion": "1.43.18"
- },
- "version": 0.4
+  "version": 0.4
 }


### PR DESCRIPTION
First curated workflow promoted to its **App Mode form** — the family-facing surface Phase-2a was building toward.

## What

Replaces the raw `restyle-depth.workflow.json` graph with Gavin's App Builder export. The workflow now carries `extra.linearData` (`linearMode: true`), so in App Mode the family sees a clean form instead of the node canvas:

- **Input Image** → LoadImage
- **Positive Prompt** / **Negative Prompt** → the two CLIPTextEncode nodes
- **Run** → SaveImage output

Everything else (depth preprocessor, ControlNet strength, sampler, denoise) stays wired but hidden.

Verified end-to-end before export: depth-guided oil-paint restyle rendered correctly on the heavy tier.

## Tweaks on the way in

- Genericized the baked positive-prompt default (dropped the test subject "red-haired woman") so it reads as a style starting point for any uploaded photo.
- LoadImage reset to the placeholder (family uploads their own).

## Known follow-up (not this PR)

The graph has `DistributedCollector` but no `DistributedSeed`, so both heavy workers render the same seed → two identical images per run. `DistributedSeed` (already in the allowlist) will be wired across all graphs in a follow-up so a run yields distinct variations. Harmless until then.

## Validation

`kustomize build --load-restrictor=LoadRestrictionsNone` renders clean; JSON valid; `linearData` confirmed present (3 inputs + 1 output). After merge + reconcile, every family member gets the form view of restyle-depth.