### PR TITLE
fix(keda): nfs-scaler tolerant of transient probe failures

### DIFF
--- a/kubernetes/components/keda/nfs-scaler/scaledobject.yaml
+++ b/kubernetes/components/keda/nfs-scaler/scaledobject.yaml
@@ -26,6 +26,11 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://prometheus-operated.observability.svc.cluster.local:9090
-        query: probe_success{instance=~".+:2049"}
+        # max_over_time keeps the app up as long as the NFS probe succeeded at
+        # least once in the window, so a transient probe blip (a failed scrape
+        # or two) can't scale it to zero — only a sustained NFS outage does.
+        query: max_over_time(probe_success{instance=~".+:2049"}[10m])
         threshold: "1"
-        ignoreNullValues: "0"
+        # Ignore a missing/null metric (e.g. a Prometheus scrape gap) rather
+        # than treating it as 0 and scaling down.
+        ignoreNullValues: "1"


### PR DESCRIPTION
The shared `nfs-scaler` KEDA component scaled NFS-gated apps to zero on an **instantaneous** `probe_success{...:2049}` reading, so any transient NFS-probe blip (or a Prometheus scrape gap, with `ignoreNullValues:0`) bounced the app. Kavita was flapping as a result, and dependents (Mangarr) logged bursts of connection-refused errors during the gaps.

- `query` → `max_over_time(probe_success{instance=~".+:2049"}[10m])` — stays up while the probe succeeded at least once in the last 10 min; only a sustained outage scales down.
- `ignoreNullValues` → `1` — a missing scrape no longer counts as a failure.

Affects every app using the `nfs-scaler` component (intended — the whole pattern was too twitchy).