### PR TITLE
fix(home): restore whole-home persistence for dev pod

### DIFF
--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
               - -c
               - |
                 set -e
-                tailscaled --tun=userspace-networking --statedir=/var/lib/tailscale \
+                tailscaled --tun=userspace-networking --statedir=/home/gavin/.tailscale \
                   --socks5-server=localhost:1055 >/var/log/tailscaled.log 2>&1 &
                 until tailscale up --ssh --hostname="${TS_HOSTNAME:-development}" \
                   --authkey="${TS_AUTHKEY}" --accept-routes --accept-dns=false; do
@@ -73,23 +73,18 @@ spec:
               limits:
                 memory: 28Gi
     persistence:
-      # Persist ONLY personal state via subPaths — mounting the whole of
-      # /home/gavin would shadow the image's toolchains (.nvm/.cargo/.local/
-      # bin/claude/.oh-my-zsh). Toolchains come from the image (rebuilt, correct
-      # arch); these dirs are the things that must survive a pod restart.
+      # Persist the WHOLE of /home/gavin so no CLI's state is ever stepped over
+      # (.claude/.claude.json, .codex, .gemini, .secrets, .zshrc, .config, .ssh,
+      # tailscale identity at ~/.tailscale, etc.). The trade-off: this mount
+      # shadows the image's toolchains, so .nvm/.cargo/.rustup/.local/bin are
+      # seeded onto the PVC from WSL2 (same arch) and live here. The denylist
+      # (development-container repo: config/seed-excludes.txt) keeps the seed to
+      # ~18G by dropping regenerable caches; ~/code and ~/.cache are separate
+      # mounts below so they are excluded from this PVC.
       home:
         existingClaim: development-container-home
         globalMounts:
-          - path: /home/gavin/.claude        # conversations + memory
-            subPath: claude
-          - path: /home/gavin/.config         # app configs
-            subPath: config
-          - path: /home/gavin/.ssh            # keys
-            subPath: ssh
-          - path: /home/gavin/.local/share    # atuin db, etc.
-            subPath: local-share
-          - path: /var/lib/tailscale          # tailnet node identity (no re-auth on restart)
-            subPath: tailscale
+          - path: /home/gavin
       code:
         existingClaim: development-container-code
         globalMounts:

--- a/kubernetes/apps/home/development-container/app/pvc.yaml
+++ b/kubernetes/apps/home/development-container/app/pvc.yaml
@@ -11,7 +11,9 @@ spec:
       storage: 50Gi
   storageClassName: ceph-block
 ---
-# Home — ~/.claude (history+memory), dotfiles, ~/.config, ~/.ssh, ~/.secrets.
+# Home — WHOLE /home/gavin (so every CLI's state + toolchains survive a restart;
+# see helmrelease persistence note). Seed ~18G after the denylist; sized to also
+# absorb caches that regenerate in-pod (.npm, .local/lib) onto this PVC.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -20,5 +22,5 @@ spec:
   accessModes: ["ReadWriteOnce"]
   resources:
     requests:
-      storage: 15Gi
+      storage: 60Gi
   storageClassName: ceph-block


### PR DESCRIPTION
## What

The dev-pod PR (#2246) merged an earlier **sub-path allowlist** persistence model that only persists `.claude`, `.config`, `.ssh`, `.local/share`, and tailscale state. That steps over other CLI state on restart: `.codex`, `.gemini`, `.secrets`, `.zshrc`, and the Code CLI's `~/.claude.json`.

This restores the agreed **whole-home** design:

- mount the whole of `/home/gavin` — one mount, nothing missed
- `tailscaled --statedir` → `/home/gavin/.tailscale` so the tailnet identity rides the home PVC (no re-auth on restart)
- home PVC **15Gi → 60Gi** — ~18G seed (after the denylist) plus headroom for caches that regenerate in-pod (`.npm`, `.local/lib`) onto this PVC

`~/code` (50Gi) and `~/.cache` (emptyDir) stay separate mounts and are excluded from the home seed.

## Validation

`kubectl kustomize` builds clean; `kubeconform` passes (2 valid, 2 CRD-skipped).

## Note

Toolchains (`.nvm/.cargo/.rustup/.local/bin`) are seeded from WSL2 (same arch) since the whole-home mount shadows the image's copies. Seed denylist lives in the `development-container` repo at `config/seed-excludes.txt`.