### PR TITLE
feat(home): inject OP_SERVICE_ACCOUNT_TOKEN into dev pod

### DIFF
--- a/kubernetes/apps/home/development-container/app/externalsecret.yaml
+++ b/kubernetes/apps/home/development-container/app/externalsecret.yaml
@@ -18,6 +18,10 @@ spec:
       engineVersion: v2
       data:
         TS_AUTHKEY: "{{ .TS_AUTHKEY }}"
+        # Scoped 1Password service-account token (R/W on the 'Dev Container'
+        # vault, read on 'Kubernetes'). Injected as pod env so `op` / chezmoi's
+        # onepasswordRead works before ~/.secrets (now a template) is rendered.
+        OP_SERVICE_ACCOUNT_TOKEN: "{{ .OP_SERVICE_ACCOUNT_TOKEN }}"
   dataFrom:
     - extract:
         key: development-container


### PR DESCRIPTION
Maps the scoped 1Password service-account token (R/W on the `Dev Container` vault, read on `Kubernetes`) from the `development-container` 1P item into the pod's env via the existing ExternalSecret (`envFrom` already wires it into the container).

**Why:** prereq for moving `~/.secrets` to a 1Password-backed chezmoi template — `op`/`onepasswordRead` need the token in the env *before* `~/.secrets` is rendered (the file currently *holds* the token, a chicken-and-egg). It also activates the new scoped SA (the old token only read Kubernetes; the new one can read the 49 `Dev Container` items).

Validated: `kustomize` builds, `kubeconform` passes.

After merge: pod gets the new token in env → I flip `~/.secrets` to the template (op:// refs only) and verify.