### PR TITLE
feat(development-container): hourly chezmoi re-add CronJob

### DIFF
--- a/kubernetes/apps/home/development-container/app/cronjob.yaml
+++ b/kubernetes/apps/home/development-container/app/cronjob.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.0/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: development-container-dotfiles-sync
+  namespace: home
+spec:
+  # Hourly. autoCommit+autoPush already cover chezmoi-driven changes; this only
+  # captures DIRECT edits to managed files (e.g. `vim ~/.zshrc`) back to the repo.
+  schedule: "17 * * * *"
+  suspend: false
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: development-container-dotfiles-sync
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile: {type: RuntimeDefault}
+          containers:
+            - name: kubectl
+              image: registry.k8s.io/kubectl:v1.33.1
+              # Exec into the running dev pod and re-capture managed dotfiles.
+              # `runuser -l gavin` gives a login env (PATH, op token); chezmoi's
+              # autoCommit+autoPush then push any drift. Templates (.secrets) are
+              # skipped by re-add, so no 1Password resolution is needed here.
+              args:
+                - exec
+                - deployment/development-container
+                - --
+                - runuser
+                - -l
+                - gavin
+                - -c
+                - chezmoi re-add
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: {drop: ["ALL"]}
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi

--- a/kubernetes/apps/home/development-container/app/kustomization.yaml
+++ b/kubernetes/apps/home/development-container/app/kustomization.yaml
@@ -6,5 +6,7 @@ resources:
   - ./externalsecret.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./rbac.yaml
+  - ./cronjob.yaml
 components:
   - ../../../../components/priority/priority-08

--- a/kubernetes/apps/home/development-container/app/rbac.yaml
+++ b/kubernetes/apps/home/development-container/app/rbac.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: &app development-container-dotfiles-sync
+  namespace: home
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: &app development-container-dotfiles-sync
+  namespace: home
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+rules:
+  # Resolve the deployment's pod, then exec `chezmoi re-add` into it
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: &app development-container-dotfiles-sync
+  namespace: home
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: *app
+subjects:
+  - kind: ServiceAccount
+    name: *app
+    namespace: home


### PR DESCRIPTION
Adds an hourly CronJob that execs `chezmoi re-add` into the dev pod to capture **direct** edits to managed dotfiles back to the public `gavinmcfall/dotfiles` repo.

### Why
`chezmoi` is configured with `autoCommit`+`autoPush`, so changes made *through* chezmoi (`chezmoi edit`/`add`/`re-add`) already push automatically. The only gap is editing a managed file **directly** (`vim ~/.zshrc`). This CronJob closes that gap.

### How
- **rbac.yaml** — least-privilege `ServiceAccount` + namespaced `Role` (`pods`/`pods/exec` in ns `home`, `deployments` get) + `RoleBinding`.
- **cronjob.yaml** — `registry.k8s.io/kubectl:v1.33.1`, runs `kubectl exec deployment/development-container -- runuser -l gavin -c 'chezmoi re-add'` at `:17` each hour. Distroless, non-root (65532), read-only rootfs, all caps dropped.
- Templates (`.secrets`) are skipped by `re-add`, so **no 1Password token is needed** in the job.

### Validation
- `kustomize build` ✅ (8 objects) · `kubeconform -strict` ✅ · `kubectl apply --dry-run=server` ✅
- Dry-ran the exact exec path in-pod (`chezmoi re-add --dry-run`): EXIT=0, correctly skipped the secrets template and detected real drift in a managed package list.