### PR TITLE
fix(development-container): pin image by digest (new toolchain)

### DIFF
--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -42,7 +42,10 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/development-container
-              tag: latest
+              # Pinned by digest so the node pulls this exact image (a plain
+              # `:latest` got served from the node cache and never updated).
+              # Renovate (or a digest bump) advances this on each rebuild.
+              tag: latest@sha256:a89110704e6d8dec5c15029eabb9401f2a45a2a214426d579d4f6fa395f685e5
             # Bring up tailscaled (userspace) + Tailscale SSH as `development`,
             # then idle. SSH into `development` lands me HERE as gavin; attach
             # tmux from there.


### PR DESCRIPTION
The pod was stuck on the old image: `:latest` resolved from the node cache (a 9ms 'pull') instead of fetching the rebuilt digest. Pinning to `sha256:a89110…` forces the node to pull the new image (aws-cli, rootless podman, hugo/crictl/adb, fd/bat/fzf/zoxide/delta/shellcheck).

⚠️ Merging this **rolls the dev pod** (and any session running inside it — resume after, like the last roll).

Renovate can advance the digest on future rebuilds.