### PR TITLE
fix(mangarr): prune library_cache on sync (sha-79dc68b)

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-ab948e4@sha256:927fc13f49afb513f83a2fe3b81d47f806a0d8c99290291701f24f66314f78a5
+              tag: sha-79dc68b@sha256:ead7fc49064bb35b8f5b9ca4bf5413cf4847f79efad40586ac5c263a7192a5d5
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
Sync now removes library_cache rows for mangas no longer in the Suwayomi library, so a deleted series stops showing on /library (gavinmcfall/mangarr#66). Image: `ghcr.io/gavinmcfall/mangarr:sha-79dc68b@sha256:ead7fc49064bb35b8f5b9ca4bf5413cf4847f79efad40586ac5c263a7192a5d5`