### PR TITLE
feat(development-container): restore scheduled jobs from the old crontab

### DIFF
--- a/kubernetes/apps/home/development-container/app/cronjobs-scheduled.yaml
+++ b/kubernetes/apps/home/development-container/app/cronjobs-scheduled.yaml
@@ -1,0 +1,145 @@
+# Scheduled jobs migrated from the WSL2 home-ops crontab (which didn't carry
+# over — cron is per-machine and the pod has no cron daemon). Each execs the
+# existing script inside the dev pod via `runuser -l gavin` (login env: PATH,
+# ~/.secrets, op token). ~/.local/bin is prepended so the recent rclone/mempalace
+# binaries win. All reuse the development-container-dotfiles-sync ServiceAccount
+# (pods/exec in ns home — see rbac.yaml); the name is shared, not dotfiles-specific.
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.0/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: development-container-claude-b2-backup
+  namespace: home
+spec:
+  # Nightly 02:00 NZ — non-destructive rclone copy of ~/.claude to Backblaze B2.
+  schedule: "0 2 * * *"
+  timeZone: "Pacific/Auckland"
+  suspend: false
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: development-container-dotfiles-sync
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile: {type: RuntimeDefault}
+          containers:
+            - name: kubectl
+              image: registry.k8s.io/kubectl:v1.33.1
+              args:
+                - exec
+                - deployment/development-container
+                - --
+                - runuser
+                - -l
+                - gavin
+                - -c
+                - export PATH="$HOME/.local/bin:$PATH"; /home/gavin/.claude/backup-to-b2.sh
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: {drop: ["ALL"]}
+              resources:
+                requests: {cpu: 10m, memory: 32Mi}
+                limits: {memory: 64Mi}
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.0/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: development-container-mempalace-sync
+  namespace: home
+spec:
+  # Weekly Sunday 04:00 NZ — safety-net resync of transcripts to mempalace
+  # (the stop-hook does the primary sync; shares its flock so they never race).
+  schedule: "0 4 * * 0"
+  timeZone: "Pacific/Auckland"
+  suspend: false
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: development-container-dotfiles-sync
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile: {type: RuntimeDefault}
+          containers:
+            - name: kubectl
+              image: registry.k8s.io/kubectl:v1.33.1
+              args:
+                - exec
+                - deployment/development-container
+                - --
+                - runuser
+                - -l
+                - gavin
+                - -c
+                - export PATH="$HOME/.local/bin:$PATH"; /home/gavin/.local/bin/mempalace-sync.sh
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: {drop: ["ALL"]}
+              resources:
+                requests: {cpu: 10m, memory: 32Mi}
+                limits: {memory: 64Mi}
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.0/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: development-container-abms-lifecycle
+  namespace: home
+spec:
+  # Weekly Monday 09:00 NZ — ABMS correction lifecycle review (rules-engine).
+  schedule: "0 9 * * 1"
+  timeZone: "Pacific/Auckland"
+  suspend: false
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: development-container-dotfiles-sync
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile: {type: RuntimeDefault}
+          containers:
+            - name: kubectl
+              image: registry.k8s.io/kubectl:v1.33.1
+              args:
+                - exec
+                - deployment/development-container
+                - --
+                - runuser
+                - -l
+                - gavin
+                - -c
+                - /home/gavin/.claude/rules-engine/lifecycle.sh >> /tmp/abms-lifecycle.log 2>&1
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: {drop: ["ALL"]}
+              resources:
+                requests: {cpu: 10m, memory: 32Mi}
+                limits: {memory: 64Mi}

--- a/kubernetes/apps/home/development-container/app/kustomization.yaml
+++ b/kubernetes/apps/home/development-container/app/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - ./helmrelease.yaml
   - ./rbac.yaml
   - ./cronjob.yaml
+  - ./cronjobs-scheduled.yaml
 components:
   - ../../../../components/priority/priority-08


### PR DESCRIPTION
The WSL2 `home-ops` crontab didn't migrate (cron is per-machine, and the pod has no cron daemon). This re-establishes the 3 jobs as k8s CronJobs that exec the existing scripts inside the dev pod via `runuser -l gavin` (login env: PATH, ~/.secrets, op token), with NZ timezones matching the originals.

| Job | Schedule (NZ) | Script |
|---|---|---|
| B2 config backup | nightly 02:00 | `backup-to-b2.sh` (rclone copy → Backblaze) |
| mempalace sync | Sun 04:00 | `mempalace-sync.sh` (safety-net for the stop-hook) |
| ABMS lifecycle | Mon 09:00 | `rules-engine/lifecycle.sh` |

Found during a migration-completeness audit (diffing the booted WSL2 distro against the pod). Reuses the existing `development-container-dotfiles-sync` SA (pods/exec in `home`).

**Note:** the B2 script needs rclone ≥1.74 (B2 rejects the apt v1.60); a current static rclone is in `~/.local/bin` on the PVC. Image-config follow-up: swap apt rclone → a pinned binary so a fresh reseed keeps it.

Validated: kustomize build + kubeconform strict + `kubectl apply --dry-run=server` (all 3 created).