### PR TITLE
fix(database): make CNPG failover tolerant of brief network blips

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
@@ -12,6 +12,19 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:18@sha256:7f374e054e46fdefd64b52904e32362949703a75c05302dca8ffa1eb78d41891
   primaryUpdateStrategy: unsupervised
 
+  # Tolerate brief pod-network blips before failing over. On 2026-06-16 a ~45s
+  # stanton-02 network disruption tripped the default 1s isolation check and
+  # fenced the primary, cascading restarts across every DB-dependent app.
+  # Loosen the trigger so short stalls don't cause a failover; genuine outages
+  # (sustained past failoverDelay) still promote a replica.
+  failoverDelay: 30
+  probes:
+    liveness:
+      isolationCheck:
+        enabled: true          # keep split-brain protection
+        connectionTimeout: 3000  # was 1000ms default
+        requestTimeout: 3000     # was 1000ms default
+
   storage:
     size: 20Gi
     storageClass: openebs-hostpath

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-immich/postgres18-immich.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-immich/postgres18-immich.yaml
@@ -14,6 +14,17 @@ spec:
   imageName: ghcr.io/tensorchord/cloudnative-vectorchord:18.0-0.5.3@sha256:267f6cbb32af6e109e138a143c7e9dd5d44d68433ec2303f0c30e745c788d1a9
   primaryUpdateStrategy: unsupervised
 
+  # Tolerate brief pod-network blips before failing over (see postgres18-cluster
+  # for the 2026-06-16 incident). Loosen the default 1s isolation check so short
+  # stalls don't fence the primary; genuine outages still promote a replica.
+  failoverDelay: 30
+  probes:
+    liveness:
+      isolationCheck:
+        enabled: true          # keep split-brain protection
+        connectionTimeout: 3000  # was 1000ms default
+        requestTimeout: 3000     # was 1000ms default
+
   storage:
     size: 10Gi
     storageClass: openebs-hostpath


### PR DESCRIPTION
## Why

On **2026-06-16 ~22:00 UTC**, stanton-02 pod networking stalled for ~45s. The `postgres18-cluster` primary (on stanton-02) couldn't reach its replica on stanton-01, CNPG's default **1-second liveness isolation check** tripped, the primary was fenced (SIGKILL/137), and CNPG failed over to a healthy replica — **cascading restarts across every DB-dependent app** (prowlarr, sonarr×3, pocket-id, mariadb-exporter, etc.).

The failover itself was **correct and recovered cleanly** — 3/3 healthy, replicas streaming with zero lag, no data loss. The problem is the *trigger sensitivity*: with `failoverDelay: 0` and a 1s isolation timeout, any brief network stall causes a full failover and app cascade.

## What

Loosen the failover trigger on **both** CNPG clusters so short network blips are ridden out, while genuine outages still promote a replica:

| Field | Before | After |
|---|---|---|
| `failoverDelay` | `0` (immediate) | `30` (wait 30s before promoting) |
| `probes.liveness.isolationCheck.connectionTimeout` | `1000ms` (default) | `3000ms` |
| `probes.liveness.isolationCheck.requestTimeout` | `1000ms` (default) | `3000ms` |

Split-brain protection (`isolationCheck`) stays **enabled** — this loosens, not disables it.

**Trade-off:** in a *real* primary failure, failover takes ~30s longer. For a homelab that's the right trade — most of these events are transient, and a 5–45s blip shouldn't restart every database client.

## Scope / caveats

- This is a **mitigation for spurious failovers**, not a cure. A sustained outage (like last night's ~45s) will still fail over.
- The **root cause** — stanton-02's pod network dropping out — is unfixed and needs persistent telemetry (Loki/OTel) to catch the next occurrence. Prime suspect: the Thunderbolt mesh (has flaked before) or Cilium datapath.

## Verification

- Both `Cluster` CRs validate `Valid` under kubeconform against the CNPG `cluster_v1` schema (confirms `failoverDelay` + `probes.liveness.isolationCheck` are valid fields for the running CNPG 1.29.1).
- Applies to `postgres18-cluster` and `postgres18-immich`.
