### PR TITLE
feat(cilium): export dropped/errored Hubble flows for blip forensics

### DIFF
--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
@@ -27,6 +27,21 @@ spec:
     #% if bootstrap_cloudflare.enabled %#
     hubble:
       enabled: true
+      export:
+        # Persist dropped/errored flows so the next network blip is diagnosable at
+        # the datapath level (file is node-local: /var/run/cilium/hubble/ on each
+        # agent; read it from the cilium pod after an event). DROPPED+ERROR only;
+        # baseline FORWARDED traffic is excluded. Activates after the cilium
+        # DaemonSet is rolled.
+        fileMaxSizeMb: 50
+        fileMaxBackups: 5
+        static:
+          enabled: true
+          filePath: /var/run/cilium/hubble/events.log
+          fieldMask: []
+          allowList:
+            - '{"verdict":["DROPPED","ERROR"]}'
+          denyList: []
       metrics:
         enabled:
           - dns:query

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -27,6 +27,21 @@ spec:
   values:
     hubble:
       enabled: true
+      export:
+        # Persist dropped/errored flows so the next network blip is diagnosable at
+        # the datapath level (file is node-local: /var/run/cilium/hubble/ on each
+        # agent; read it from the cilium pod after an event). DROPPED+ERROR only;
+        # baseline FORWARDED traffic is excluded. Activates after the cilium
+        # DaemonSet is rolled.
+        fileMaxSizeMb: 50
+        fileMaxBackups: 5
+        static:
+          enabled: true
+          filePath: /var/run/cilium/hubble/events.log
+          fieldMask: []
+          allowList:
+            - '{"verdict":["DROPPED","ERROR"]}'
+          denyList: []
       metrics:
         enabled:
           - dns:query


### PR DESCRIPTION
## Why

On **2026-06-16 ~22:00 UTC** a ~3-minute cluster-wide pod-network disruption (Cilium datapath — no physical link flap, no NIC errors, no agent restart, no node reboot) tripped a Postgres failover and restarted DB-dependent apps. Prometheus metrics let me *characterise* it (cluster-wide `up==0` spike 4→17, Cilium drop-reason rise) and rule out hardware / OOM / my changes / the envoy PushSecret — but there was **no per-flow detail to pin the trigger**, because Hubble flows live only in an in-memory ring buffer that's gone after the event.

This closes that gap so the **next** blip is diagnosable at the datapath level.

## What

Enable Hubble **static flow export** on both the live HelmRelease and the bootstrap template (Cilium 1.19.4):

```yaml
hubble:
  export:
    fileMaxSizeMb: 50
    fileMaxBackups: 5
    static:
      enabled: true
      filePath: /var/run/cilium/hubble/events.log
      allowList:
        - '{"verdict":["DROPPED","ERROR"]}'
```

`DROPPED`/`ERROR` verdicts only — baseline `FORWARDED` traffic is excluded to keep volume sane. After an event, read `/var/run/cilium/hubble/events.log` from the cilium agent pod on the affected node to see exactly which flows dropped and why.

## ⚠️ Activation requires rolling the Cilium DaemonSet

The config lands in `cilium-config` on merge, but the agents only pick it up on restart. After merge, activate with:
```
kubectl -n kube-system rollout restart ds/cilium
```
That causes a brief per-node network blip as each agent restarts (eBPF datapath stays attached, so it's minimal). **CNPG failover is now tolerant of short blips (PR #2265, `failoverDelay=30`), so this is low-risk** — but do it deliberately, one cluster-quiet moment.

## Follow-ups (not in this PR)

- The export file is node-local. To make flows queryable in Grafana/Loki, a later change can hostPath-mount the file for promtail to tail.
- An early-warning alert on `count(up==0)` spiking above its ~4 baseline would page the moment the fabric blips.

## Verification

- Live HelmRelease YAML is well-formed; both files carry identical `hubble.export` blocks.
- `allowList` uses a guaranteed-valid FlowFilter (`verdict`), avoiding fragile drop-reason enums.
