### PR TITLE
fix(dragonfly): allow Prometheus to scrape instance metrics (port 9999)

### DIFF
--- a/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster.yaml
+  - ./networkpolicy.yaml
   - ./podmonitor.yaml
   - ./service.yaml

--- a/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/networking.k8s.io/networkpolicy_v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dragonfly-allow-metrics-scrape
+  namespace: database
+spec:
+  # The Dragonfly operator auto-creates a NetworkPolicy that restricts the admin
+  # metrics port (9999) to the operator + dragonfly pods, which blocks Prometheus
+  # and leaves all instances up=0 (no dragonfly metrics). NetworkPolicies are
+  # additive, so this supplementary policy restores scraping without fighting the
+  # operator-owned policy (which would revert any direct edit).
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 9999
+          protocol: TCP


### PR DESCRIPTION
## Why

While auditing the Hubble flow export, the only `POLICY_DENIED` traffic to the database namespace was **`prometheus → dragonfly:9999`** (504 drops in a short window). Investigation:

- All 4 dragonfly instances are **`up=0`** in Prometheus — **metrics, dashboards, and alerting are completely missing**.
- Cause: the **Dragonfly operator (v1.5.0) auto-creates a NetworkPolicy** that only allows the admin metrics port (9999) from the operator + dragonfly pods. The Prometheus scrape from `observability` is denied.
- The `Dragonfly` CR has no field to customize this, and editing the operator-owned policy would be reverted.
- These 4 denied targets are the steady "4 down targets" baseline seen during the 2026-06-16 incident triage.

## What

Add a **supplementary** NetworkPolicy in `database`. NetworkPolicies are additive, so this grants Prometheus access on 9999 without touching the operator's policy:

```yaml
podSelector: { matchLabels: { app.kubernetes.io/part-of: dragonfly } }
ingress:
  - from: [{ namespaceSelector: { matchLabels: { kubernetes.io/metadata.name: observability } } }]
    ports: [{ port: 9999, protocol: TCP }]
```

## Verification

- `kubeconform` Valid; `kustomize build` of the dragonfly cluster dir succeeds.
- Confirmed PodMonitor scrapes the `admin` port → **9999** on the instances, and instance pods carry `app.kubernetes.io/part-of=dragonfly`.
- **After merge:** the 4 dragonfly targets should flip to `up=1`, and the `POLICY_DENIED` flows to `:9999` should stop appearing in the Hubble export — both checkable immediately.
