### PR TITLE
fix(development-container): raise memory limit 28Gi→48Gi

### DIFF
--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -72,9 +72,9 @@ spec:
             resources:
               requests:
                 cpu: "2"
-                memory: 16Gi
+                memory: 20Gi
               limits:
-                memory: 28Gi
+                memory: 48Gi
     persistence:
       # Persist the WHOLE of /home/gavin so no CLI's state is ever stepped over
       # (.claude/.claude.json, .codex, .gemini, .secrets, .zshrc, .config, .ssh,


### PR DESCRIPTION
**Symptom:** the dev pod periodically becomes unusable — Claude chats hang while tmux stays clickable, only a kill+restart fixes it. Confirmed it sits at **28–29 Gi (the limit)** when killed.

**Root cause:** capacity, not a leak. A real 8–10-session workload is ~3 Gi/session (Claude + repoql + MCP node servers) → ~28 Gi, which slams the cgroup ceiling. The kernel then can't allocate; memory-hungry processes (Claude, repoql) stall while idle tmux survives. The original sizing (peak ~21 Gi) under-counted the real MCP/repoql footprint.

**Fix:** request 16→20 Gi, limit 28→**48 Gi**. Nodes are 94 Gi allocatable with ~65–70 Gi free, so this is well within headroom.

⚠️ Merging rolls the pod (resume sessions after). Note: the slow recovery on restart is the RWO Ceph RBD detach/reattach (Multi-Attach) — inherent to pod replacement, separate from this.