### PR TITLE
feat(development-container): live SMB mount of SC Bridge (non-blocking)

### DIFF
--- a/kubernetes/apps/home/development-container/app/externalsecret-smb.yaml
+++ b/kubernetes/apps/home/development-container/app/externalsecret-smb.yaml
@@ -1,0 +1,24 @@
+---
+# cifs credentials file for the smb-mount sidecar (mount.cifs -o credentials=).
+# Fields SC_BRIDGE_SMB_USER / SC_BRIDGE_SMB_PASS live on the same 1Password
+# `development-container` item (vault Kubernetes) as TS_AUTHKEY etc.
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: development-container-smb
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: development-container-smb-creds
+    template:
+      engineVersion: v2
+      data:
+        creds: |
+          username={{ .SC_BRIDGE_SMB_USER }}
+          password={{ .SC_BRIDGE_SMB_PASS }}
+  dataFrom:
+    - extract:
+        key: development-container

--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -75,6 +75,44 @@ spec:
                 memory: 16Gi
               limits:
                 memory: 28Gi
+          # ---- SMB mount sidecar (non-blocking by design) ----
+          # Mounts \\vengeancepc\SC Bridge to /mnt/e/SCBridge in a retry loop and
+          # shares it into `app` via mountPropagation. The shared volume is an
+          # emptyDir (always mounts instantly), so the pod NEVER blocks on startup
+          # if the PC is off — the sidecar just keeps retrying and /mnt/e/SCBridge
+          # stays empty until vengeancepc is reachable. `soft` mount opts + a stale
+          # check mean runtime drop-outs fail fast and remount instead of hanging.
+          smb-mount:
+            image:
+              repository: docker.io/library/alpine
+              tag: "3.21"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                apk add --no-cache cifs-utils >/dev/null 2>&1 || true
+                TARGET=/mnt/e/SCBridge
+                OPTS="credentials=/etc/smb/creds,uid=1000,gid=1000,file_mode=0664,dir_mode=0775,noserverino,soft,vers=3.0,mfsymlinks,nobrl,echo_interval=10"
+                mkdir -p "$TARGET"
+                while true; do
+                  if mountpoint -q "$TARGET" && ! timeout 10 ls "$TARGET" >/dev/null 2>&1; then
+                    echo "[smb-mount] stale mount; unmounting"; umount -l "$TARGET" 2>/dev/null || true
+                  fi
+                  if ! mountpoint -q "$TARGET"; then
+                    echo "[smb-mount] mounting //10.90.101.86/SC Bridge -> $TARGET"
+                    mount.cifs "//10.90.101.86/SC Bridge" "$TARGET" -o "$OPTS" \
+                      && echo "[smb-mount] mounted" || echo "[smb-mount] mount failed (PC off?); will retry"
+                  fi
+                  sleep 15
+                done
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
     persistence:
       # Persist the WHOLE of /home/gavin so no CLI's state is ever stepped over
       # (.claude/.claude.json, .codex, .gemini, .secrets, .zshrc, .config, .ssh,
@@ -96,3 +134,23 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /home/gavin/.cache
+      # Shared target for the SMB sidecar. emptyDir mounts instantly (pod never
+      # blocks); the cifs mount the sidecar lays inside it propagates into `app`.
+      scbridge:
+        type: emptyDir
+        advancedMounts:
+          development-container:
+            app:
+              - path: /mnt/e
+                mountPropagation: HostToContainer
+            smb-mount:
+              - path: /mnt/e
+                mountPropagation: Bidirectional
+      # cifs credentials file (username/password) — sidecar only.
+      smb-creds:
+        type: secret
+        name: development-container-smb-creds
+        advancedMounts:
+          development-container:
+            smb-mount:
+              - path: /etc/smb

--- a/kubernetes/apps/home/development-container/app/kustomization.yaml
+++ b/kubernetes/apps/home/development-container/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-smb.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml


### PR DESCRIPTION
Restores the old WSL2 `/mnt/e` workflow for the SC Bridge Star Citizen pipeline: a **live read-write mount** of `\\vengeancepc\SC Bridge` at **`/mnt/e/SCBridge`** in the dev container, so extraction scripts read the p4k, write unpacked files, run loot collection and emit SQL **all in place on the share** — exactly like before.

## Why a sidecar, not a CSI volume
A directly-mounted CSI SMB volume **blocks pod startup** if the server is unreachable (stuck in `ContainerCreating` until the desktop is back). To guarantee the dev pod **never blocks / never crash-loops**, the mount is decoupled:

- a **privileged `smb-mount` sidecar** `mount.cifs`-es the share into a shared **emptyDir** in a retry loop;
- the `app` container sees it via **`mountPropagation`** (`HostToContainer`);
- the emptyDir mounts instantly, so the pod **always starts**. PC off → sidecar retries, `/mnt/e/SCBridge` is just empty until it's back. PC sleeps mid-session → `soft` opts + a stale-check fail fast and remount, never hang.

## Details
- **cifs is in the stock Talos kernel** — verified against a working Talos+SMB community setup (no `kernel.modules` load, no node reboot).
- Mount opts mirror the proven community set: `noserverino` (corruption guard), `uid/gid=1000`, `soft`, `mfsymlinks`, `nobrl` (sqlite-friendly), `vers=3.0`.
- Creds via a new ExternalSecret from the existing `development-container` 1Password item (`SC_BRIDGE_SMB_USER`/`PASS`).
- Validated: `kustomize build` + `helm template` (app-template 4.4.0) render a Pod with both containers, correct propagation, privileged sidecar, creds mount.

⚠️ **Merging rolls the dev pod** (strategy `Recreate`, RWO PVCs) — resume sessions after. The `scbridge-*` sync scripts I'd put in `~/.local/bin` become obsolete once this is live (I'll remove them).

ℹ️ Uses the desktop's LAN IP `10.90.101.86` — recommend a DHCP reservation so it stays stable.