### PR TITLE
fix(development-container): add noperm to SC Bridge cifs mount (enable writes)

### DIFF
--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -92,7 +92,7 @@ spec:
               - |
                 apk add --no-cache cifs-utils >/dev/null 2>&1 || true
                 TARGET=/mnt/e/SCBridge
-                OPTS="credentials=/etc/smb/creds,uid=1000,gid=1000,file_mode=0664,dir_mode=0775,noserverino,soft,vers=3.0,mfsymlinks,nobrl,echo_interval=10"
+                OPTS="credentials=/etc/smb/creds,uid=1000,gid=1000,file_mode=0664,dir_mode=0775,noserverino,soft,vers=3.0,mfsymlinks,nobrl,noperm,echo_interval=10"
                 mkdir -p "$TARGET"
                 while true; do
                   if mountpoint -q "$TARGET" && ! timeout 10 ls "$TARGET" >/dev/null 2>&1; then


### PR DESCRIPTION
Follow-up to #2273. The live mount came up **read-only**: cifs shows the share dir as `r-xr-xr-x` and enforces a *client-side* permission check that blocks writes — even though the SMB account has Modify rights (rclone writes with the same creds succeed). **`noperm`** skips the client-side check and lets the Windows server enforce, matching the proven community `csi-driver-smb` mount set.

**Verified live** before this PR: hot-fixed the running mount with `noperm` → a write from the app container as gavin succeeds. This PR bakes it into the mount opts so it survives rolls.

⚠️ Merging rolls the pod once more (cleanly). The running pod already has the hot-fix, so there's no rush — write works now; merge when convenient.