### PR TITLE
fix(development-container): preStop unmount on smb sidecar to prevent stuck termination

### DIFF
--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -105,6 +105,18 @@ spec:
                   fi
                   sleep 15
                 done
+            # Lazy-unmount the cifs share before the sidecar dies so the mount
+            # never leaks into the host/kubelet mount namespace and blocks pod
+            # teardown (this scbridge mount is Bidirectional, so the umount
+            # propagates back to the host). `umount -l` returns instantly even
+            # when the PC is off, so preStop can't hang the termination either.
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - umount -l /mnt/e/SCBridge 2>/dev/null || true
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
## Problem

The `development-container` old-ReplicaSet pod got stuck and never terminated. Root cause: the privileged `smb-mount` sidecar lays a cifs mount inside the `scbridge` emptyDir with **Bidirectional** mount propagation, so the mount propagates into the host/kubelet mount namespace. On pod deletion the container is SIGKILLed without unmounting, leaking the cifs mount into the kubelet namespace. With the SMB host unreachable at teardown, the kubelet looped on `mounted volumes=[scbridge]: context deadline exceeded` and the pod never went away.

The live stuck pod was cleared by manually `umount -l`-ing the leaked mount in the kubelet mount namespace.

## Fix

Add a `preStop` hook to the `smb-mount` sidecar that lazily unmounts `/mnt/e/SCBridge` before the container exits. `umount -l` returns instantly even when the PC is off, and the Bidirectional propagation carries the unmount back to the host — so the mount can no longer leak and block teardown on future rollouts.