### PR TITLE
fix(development-container): raise memory request/limit to 20Gi/48Gi

### DIFF
--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -72,9 +72,9 @@ spec:
             resources:
               requests:
                 cpu: "2"
-                memory: 16Gi
+                memory: 20Gi
               limits:
-                memory: 28Gi
+                memory: 48Gi
           # ---- SMB mount sidecar (non-blocking by design) ----
           # Mounts \\vengeancepc\SC Bridge to /mnt/e/SCBridge in a retry loop and
           # shares it into `app` via mountPropagation. The shared volume is an


### PR DESCRIPTION
The dev pod hits the 28Gi limit and becomes unusable even with ~3 active sessions — every *open* session (active or idle) holds its full stdio-MCP + repoql stack resident, and they accumulate. Combined with the separate MCP-server trim (removed 6 redundant/unused local stdio servers), this raises the ceiling for headroom. Nodes are 94Gi with ~65Gi free, so a 48Gi limit is well within capacity.

Redo of the stale #2271 (which conflicted after the SMB sidecar/noperm/preStop PRs) off current main. Only the **app** container's request (16→20Gi) and limit (28→48Gi) change; the smb-mount sidecar's resources are untouched.

⚠️ Merging rolls the pod.