### PR TITLE
fix(development-container): SIGTERM trap on smb sidecar (close remount race)

### DIFF
--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -94,6 +94,11 @@ spec:
                 TARGET=/mnt/e/SCBridge
                 OPTS="credentials=/etc/smb/creds,uid=1000,gid=1000,file_mode=0664,dir_mode=0775,noserverino,soft,vers=3.0,mfsymlinks,nobrl,noperm,echo_interval=10"
                 mkdir -p "$TARGET"
+                # On SIGTERM (pod teardown), stop the loop and unmount, so the
+                # mount can't be re-laid in the race between preStop and SIGKILL.
+                # preStop alone left that remount race -> leaked cifs in the
+                # kubelet ns -> stuck (un-terminating) pods. This closes it.
+                trap 'echo "[smb-mount] SIGTERM: unmounting and exiting"; umount -l "$TARGET" 2>/dev/null; exit 0' TERM INT
                 while true; do
                   if mountpoint -q "$TARGET" && ! timeout 10 ls "$TARGET" >/dev/null 2>&1; then
                     echo "[smb-mount] stale mount; unmounting"; umount -l "$TARGET" 2>/dev/null || true


### PR DESCRIPTION
Follow-up to the preStop fix (#2275). **The preStop alone wasn't enough** — two pods (5rksd, v5hxl) got stuck terminating *with* the preStop present. Cause: preStop runs `umount -l`, but the still-running mount loop **re-mounts** in the millisecond window before SIGKILL, re-leaking the Bidirectional cifs mount into the kubelet namespace → pod can't be torn down.

This adds a `trap … TERM INT` to the sidecar loop that **stops the loop and unmounts** on SIGTERM. So even if a remount slips past preStop, the trap removes it before the container exits. **preStop + trap together** make teardown deterministic.

Verified: the two stuck pods both *had* the preStop yet still leaked — that's the race this closes.

⚠️ **Merge while the SMB host (vengeancepc) is UP**, and ideally **from a session outside the dev pod** — merging rolls the dev container, and the *current* pod (preStop-only, no trap) could itself stick on this one transition if the PC is unreachable. With the PC up it's a clean roll, and every pod after this carries the trap.