### PR TITLE
feat(cortex): add mempalace-bridge (pgvector palace over mcp-proxy, LAN-only)

### DIFF
--- a/kubernetes/apps/cortex/kustomization.yaml
+++ b/kubernetes/apps/cortex/kustomization.yaml
@@ -10,4 +10,5 @@ components:
 resources:
   # Applications
   - ./mempalace/ks.yaml
+  - ./mempalace-bridge/ks.yaml
   - ./lighthouse/ks.yaml

--- a/kubernetes/apps/cortex/mempalace-bridge/app/externalsecret.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mempalace-bridge
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mempalace-bridge-secret
+  data:
+    - secretKey: PGUSER
+      remoteRef:
+        key: mempalace
+        property: MEMPALACE_POSTGRES_USER
+    - secretKey: PGPASSWORD
+      remoteRef:
+        key: mempalace
+        property: MEMPALACE_POSTGRES_PASS

--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mempalace-bridge
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    controllers:
+      mempalace-bridge:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gavinmcfall/mempalace-bridge
+              tag: feat-pgvector-bridge@sha256:5a854504efdf1b7b2191caa77a8483b9a3dd1e1be2a9fea392126e6256b1d5ec
+            # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
+            # writes palace markers once, then runs mcp-proxy -> patched serve.py.
+            # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.
+            envFrom:
+              - secretRef:
+                  name: mempalace-bridge-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket: { port: 8080 }
+                  initialDelaySeconds: 40
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket: { port: 8080 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 40
+            resources:
+              requests:
+                cpu: 250m
+                memory: 1Gi
+              limits:
+                cpu: "2"
+                memory: 3Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    service:
+      app:
+        controller: mempalace-bridge
+        ports:
+          http:
+            port: 8080
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/cortex/mempalace-bridge/app/httproute.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/httproute.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mempalace-bridge
+  annotations:
+    internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+spec:
+  hostnames:
+    - mempalace-bridge.${SECRET_DOMAIN}
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: mempalace-bridge
+          port: 8080

--- a/kubernetes/apps/cortex/mempalace-bridge/app/kustomization.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/cortex/mempalace-bridge/ks.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mempalace-bridge
+  namespace: &namespace cortex
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/cortex/mempalace-bridge/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Deploys the **mempalace pgvector bridge** — upstream mempalace (pgvector backend) behind `mcp-proxy` (stdio→streamablehttp), serving the migrated **418,997-drawer** palace to LAN/Tailscale MCP clients.

## What
- Image `ghcr.io/gavinmcfall/mempalace-bridge` (pinned by digest), built from the fork's `bridge/` dir (PR gavinmcfall/mempalace#feat/pgvector-bridge).
- Internal HTTPRoute: `mempalace-bridge.${SECRET_DOMAIN}` (no public route — LAN-only by design; remote via Tailscale).
- PG creds via ExternalSecret from the `mempalace` 1Password item.
- Small `ceph-block` PVC for embedder identity + backend marker + model cache.

## Validated before this PR
- Table renamed to the bridge's palace identity; 418,997 rows / 384-dim confirmed.
- End-to-end via an in-cluster validation deployment: `status` 0.4s (SQL GROUP BY patch, was 344s), `search` 2s — real results.

## Notes
- `serve.py` patches `mempalace_status` to aggregate via SQL; fail-safe (falls back to upstream if internals change).
- Does **not** touch the existing `mempalace` (ChromaDB HTTP) app — that stays as a fallback until the bridge is confirmed in-cluster, then it'll be retired in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)