### PR TITLE
feat(home): add AFFiNE self-hosted knowledge base

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/affine-db.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/affine-db.yaml
@@ -1,0 +1,42 @@
+---
+# Role password for the affine database.
+# 1Password item `affine` must provide fields: AFFINE_DB_USER, AFFINE_DB_PASSWORD.
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: affine-pg-role
+  namespace: database
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: affine-pg-role
+    template:
+      engineVersion: v2
+      data:
+        # CNPG managed-role passwordSecret expects username + password keys.
+        username: "{{ .AFFINE_DB_USER }}"
+        password: "{{ .AFFINE_DB_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: affine
+---
+# The affine database, owned by the managed `affine` role (declared in
+# postgres18-cluster.yaml spec.managed.roles), with the pgvector extension that
+# AFFiNE requires. Created declaratively so it persists independently of the app.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: affine
+  namespace: database
+spec:
+  cluster:
+    name: postgres18-cluster
+  name: affine
+  owner: affine
+  ensure: present
+  extensions:
+    - name: vector
+      ensure: present

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./pluginconfig.yaml
   - ./postgres18-cluster.yaml
   - ./mempalace-db.yaml
+  - ./affine-db.yaml
   - ./pooler.yaml
   - ./scheduledbackup.yaml
   - ./scheduledbackup-weekly-full.yaml

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-cluster/postgres18-cluster.yaml
@@ -65,6 +65,7 @@ spec:
 
   # Managed roles. `mempalace` owns the mempalace pgvector database
   # (see mempalace-db.yaml). Password sourced from the mempalace-pg-role secret.
+  # `affine` owns the affine pgvector database (see affine-db.yaml).
   managed:
     roles:
       - name: mempalace
@@ -72,6 +73,11 @@ spec:
         login: true
         passwordSecret:
           name: mempalace-pg-role
+      - name: affine
+        ensure: present
+        login: true
+        passwordSecret:
+          name: affine-pg-role
 
   bootstrap:
     initdb:

--- a/kubernetes/apps/home/affine/app/externalsecret.yaml
+++ b/kubernetes/apps/home/affine/app/externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: affine
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: affine-secret
+    template:
+      engineVersion: v2
+      data:
+        # Postgres connection string (shared CloudNativePG instance, `affine`
+        # database + managed role created in
+        # kubernetes/apps/database/cloudnative-pg/postgres18-cluster/affine-db.yaml).
+        # AFFiNE wants a single DATABASE_URL, not discrete PG* vars.
+        DATABASE_URL: "postgresql://{{ .AFFINE_DB_USER }}:{{ .AFFINE_DB_PASSWORD }}@postgres18-cluster-rw.database.svc.cluster.local:5432/affine"
+
+        # Redis → shared Dragonfly. A dedicated logical DB index keeps AFFiNE's
+        # keyspace off the default db other apps share. Verify index 3 is unused.
+        REDIS_SERVER_HOST: "dragonfly.database.svc.cluster.local"
+        REDIS_SERVER_PORT: "6379"
+        REDIS_SERVER_DATABASE: "3"
+
+        # Public URL used for OAuth redirects, share links, and outgoing mail.
+        AFFINE_SERVER_HTTPS: "true"
+        AFFINE_SERVER_EXTERNAL_URL: "https://affine.${SECRET_DOMAIN}"
+
+        # The full-text indexer needs extra setup; disabled to match the
+        # upstream self-host default. Enable later once the base deploy is happy.
+        AFFINE_INDEXER_ENABLED: "false"
+  dataFrom:
+    - extract:
+        key: affine

--- a/kubernetes/apps/home/affine/app/externalsecret.yaml
+++ b/kubernetes/apps/home/affine/app/externalsecret.yaml
@@ -20,10 +20,12 @@ spec:
         DATABASE_URL: "postgresql://{{ .AFFINE_DB_USER }}:{{ .AFFINE_DB_PASSWORD }}@postgres18-cluster-rw.database.svc.cluster.local:5432/affine"
 
         # Redis → shared Dragonfly. A dedicated logical DB index keeps AFFiNE's
-        # keyspace off the default db other apps share. Verify index 3 is unused.
+        # keyspace off the default db other apps share. Indexes in use:
+        # 0 plane/manyfold, 1 immich, 2 paperless, 3 romm, 4 searxng, 5 outline.
+        # 6 is the lowest free index.
         REDIS_SERVER_HOST: "dragonfly.database.svc.cluster.local"
         REDIS_SERVER_PORT: "6379"
-        REDIS_SERVER_DATABASE: "3"
+        REDIS_SERVER_DATABASE: "6"
 
         # Public URL used for OAuth redirects, share links, and outgoing mail.
         AFFINE_SERVER_HTTPS: "true"

--- a/kubernetes/apps/home/affine/app/helmrelease.yaml
+++ b/kubernetes/apps/home/affine/app/helmrelease.yaml
@@ -1,0 +1,123 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app affine
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: storage
+  values:
+    controllers:
+      affine:
+        # RWO ceph-block volumes → only one pod may mount at a time.
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Runs AFFiNE's schema migrations against the (already-provisioned)
+          # `affine` database before the server starts. Must run to completion;
+          # app-template orders initContainers ahead of the app container.
+          migrate:
+            image: &image
+              repository: ghcr.io/toeverything/affine
+              tag: 0.26.3@sha256:725aaceb0ed94d4b832ae6ef9414503291c9b2b4f60bd6f3c7eef571b6149add
+            command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
+            envFrom: &envFrom
+              - secretRef:
+                  name: affine-secret
+        containers:
+          app:
+            image: *image
+            envFrom: *envFrom
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                # Doc merges scale with edit count; upstream notes a 10k-edit doc
+                # can peak ~1Gi. 2Gi gives headroom.
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      # NOTE: the AFFiNE image is built to run as root with HOME=/root and
+      # hard-codes its data paths under /root/.affine. A non-root UID (the repo
+      # default 568) cannot traverse /root, so the container runs as root but
+      # unprivileged (caps dropped, no privilege escalation). Revisit if a future
+      # AFFiNE release supports relocating its data dir for a non-root UID.
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 3010
+    route:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: external
+            namespace: network
+            sectionName: https
+    persistence:
+      # Uploaded + AI-generated blobs (filesystem provider). AFFiNE's S3/R2
+      # provider is configured in the Admin Panel, not via env, so a PVC keeps
+      # the base deploy fully declarative. Switch to rook-ceph S3 / R2 later in
+      # /admin → Settings → Storage if blob volume grows.
+      storage:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 50Gi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /root/.affine/storage
+      # Persists Admin-Panel config (OAuth/OIDC client, SMTP, storage provider).
+      config:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /root/.affine/config

--- a/kubernetes/apps/home/affine/app/kustomization.yaml
+++ b/kubernetes/apps/home/affine/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/affine/ks.yaml
+++ b/kubernetes/apps/home/affine/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app affine
+  namespace: &namespace home
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: cluster-apps-rook-ceph-cluster
+      namespace: rook-ceph
+    - name: dragonfly-cluster
+      namespace: database
+    - name: cloudnative-pg-postgres18-cluster
+      namespace: database
+  path: ./kubernetes/apps/home/affine/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 
 resources:
   # Applications
+  - ./affine/ks.yaml
   - ./anytype/ks.yaml
   - ./atuin/ks.yaml
   - ./bentopdf/ks.yaml


### PR DESCRIPTION
Deploy AFFiNE (Notion + whiteboard alternative) to the home namespace via app-template, reusing shared infra:

- CloudNativePG: dedicated `affine` database + managed role with pgvector (mirrors the mempalace pattern)
- Dragonfly for Redis (logical db index 3)
- ceph-block PVCs for blob storage + Admin-Panel config
- ExternalSecret from 1Password (`affine` item) builds DATABASE_URL
- migrate initContainer runs self-host-predeploy before the server starts
- exposed at affine.${SECRET_DOMAIN} on the external gateway

Notes: AFFiNE hardcodes HOME=/root/.affine so the container runs as root (unprivileged, caps dropped). OIDC (pocket-id) and S3/R2 storage are configured post-deploy in the Admin Panel and persist on the config PVC.