### PR TITLE
feat(home): wire AFFiNE SMTP via env + document URL-safe DB password

### DIFF
--- a/kubernetes/apps/home/affine/app/externalsecret.yaml
+++ b/kubernetes/apps/home/affine/app/externalsecret.yaml
@@ -17,6 +17,10 @@ spec:
         # database + managed role created in
         # kubernetes/apps/database/cloudnative-pg/postgres18-cluster/affine-db.yaml).
         # AFFiNE wants a single DATABASE_URL, not discrete PG* vars.
+        # NOTE: AFFINE_DB_PASSWORD must be URL-safe — it's interpolated raw into
+        # this URL and Prisma rejects reserved chars (+ / = @ :). Generate it with
+        # `openssl rand -hex 32`, NOT `-base64` (a base64 password caused a P1013
+        # "invalid port number" on first deploy).
         DATABASE_URL: "postgresql://{{ .AFFINE_DB_USER }}:{{ .AFFINE_DB_PASSWORD }}@postgres18-cluster-rw.database.svc.cluster.local:5432/affine"
 
         # Redis → shared Dragonfly. A dedicated logical DB index keeps AFFiNE's

--- a/kubernetes/apps/home/affine/app/helmrelease.yaml
+++ b/kubernetes/apps/home/affine/app/helmrelease.yaml
@@ -49,6 +49,14 @@ spec:
         containers:
           app:
             image: *image
+            env:
+              # Mailer (password reset, invites, OIDC). Internal relay, no auth.
+              # AFFiNE maps each Admin-Panel mailer field to a MAILER_* env var,
+              # so SMTP can be set declaratively here instead of via the GUI.
+              MAILER_HOST: smtp-relay.home.svc.cluster.local
+              MAILER_PORT: "25"
+              MAILER_SENDER: AFFiNE <affine@${SECRET_DOMAIN}>
+              MAILER_IGNORE_TLS: "true"
             envFrom: *envFrom
             probes:
               liveness:


### PR DESCRIPTION
- Add MAILER_* env (smtp-relay, port 25, affine@${SECRET_DOMAIN}) so the mailer is set declaratively instead of via the Admin Panel GUI — unblocks password reset, invites, and OIDC email.
- Document that AFFINE_DB_PASSWORD must be URL-safe (openssl rand -hex); a base64 password broke Prisma's DATABASE_URL parse (P1013) on first deploy.