### PR TITLE
fix(cortex): bump mempalace-bridge to supergateway image (Claude Code compat)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -40,9 +40,9 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace-bridge
-              tag: feat-pgvector-bridge@sha256:5a854504efdf1b7b2191caa77a8483b9a3dd1e1be2a9fea392126e6256b1d5ec
+              tag: feat-pgvector-bridge@sha256:d70980b03b1a58527781db17d20b15cade7cb24f6d968f3e27329e0e13eb066f
             # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
-            # writes palace markers once, then runs mcp-proxy -> patched serve.py.
+            # writes palace markers once, then runs supergateway -> patched serve.py.
             # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.
             envFrom:
               - secretRef:


### PR DESCRIPTION
mcp-proxy 0.12.0 (latest) streamable-http is incompatible with Claude Code's MCP client — `initialize` succeeds but `tools/list` fails ("tools fetch failed"), reproduced over both the Envoy gateway and a raw port-forward. supergateway 3.4.3 works with the same client (verified locally: `✔ Connected`, tools loaded).

Bumps the bridge image digest `5a854504` → `d70980b0` (now node + supergateway; serves streamable-http at `/mcp` + `/healthz`). Builds from gavinmcfall/mempalace `bridge/` (commit 0743e7e).

After merge: verify the Windows MCP client connects through `mempalace-bridge.nerdz.cloud` and a write round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)