### PR TITLE
fix(cortex): raise mempalace-bridge memory 3Gi->6Gi (OOMKilled)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -69,10 +69,13 @@ spec:
             resources:
               requests:
                 cpu: 250m
-                memory: 1Gi
+                memory: 2Gi
               limits:
                 cpu: "2"
-                memory: 3Gi
+                # supergateway(node) + python + minilm onnxruntime baseline is
+                # ~1.2Gi idle; embedding (search/write) and server-side mining
+                # spike well above that. 3Gi OOM-killed; 6Gi gives headroom.
+                memory: 6Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
Bridge pod OOMKilled (exit 137) — the supergateway image (node + python + minilm onnxruntime) idles ~1.2Gi and spikes on embedding (search/write). Raise limit 3Gi->6Gi, requests 1Gi->2Gi. Also headroom for the upcoming server-side ingest/mining (B-ii auto-save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)