### PR TITLE
chore(lighthouse): repin licence-gate 0.1.13 (deny logging)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -110,12 +110,13 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              # 0.1.12 makes the gallery delete real: POST /history with one of the
+              # 0.1.13 logs denials (401/403/400/5xx with method/path/user); the
+              # gate was previously silent on rejects, which made a forward-auth
+              # mis-wire an hour of blind debugging. 404 + success stay unlogged.
+              # 0.1.12 made the gallery delete real: POST /history with one of the
               # gate's synthetic disk ids removes the caller's own render file from
-              # /output (ownership-checked, fail closed) — previously the frontend's
-              # delete only cleared master's in-memory history and the disk-scan
-              # gallery resurrected the image. Needs the /output mount RW below.
-              tag: 0.1.12@sha256:9d7d0d1813041923fe3d2be41ab931cf00c7c053d67bd0bccc29e0ca145eb532
+              # /output (ownership-checked, fail closed). Needs the /output mount RW below.
+              tag: 0.1.13@sha256:cf5eee7536358461b72f832a316a0e92414ea60a023a87e91aaa6b0fb6101849
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"


### PR DESCRIPTION
Repins the licence-gate sidecar `0.1.12 → 0.1.13@sha256:cf5eee75…` (containers #23, merged 4b25ec1).

**Why:** the gate was silent on rejections (401/403/400/5xx). When the forward-auth headers were mis-wired on 06-13 that silence cost ~an hour of blind debugging. 0.1.13 logs denials with method/path/user; 404 + success stay unlogged. Logging-only — no change to policy, isolation, or curation behaviour.

Verified: `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/cortex/lighthouse/app` renders the new pin and builds clean.