### PR TITLE
feat(lighthouse): per-user input-asset isolation (input PVC + licence-gate 0.1.14)

### DIFF
--- a/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/helmrelease.yaml
@@ -110,13 +110,13 @@ spec:
           licence-gate:
             image:
               repository: ghcr.io/gavinmcfall/licence-gate
-              # 0.1.13 logs denials (401/403/400/5xx with method/path/user); the
-              # gate was previously silent on rejects, which made a forward-auth
-              # mis-wire an hour of blind debugging. 404 + success stay unlogged.
-              # 0.1.12 made the gallery delete real: POST /history with one of the
-              # gate's synthetic disk ids removes the caller's own render file from
-              # /output (ownership-checked, fail closed). Needs the /output mount RW below.
-              tag: 0.1.13@sha256:cf5eee7536358461b72f832a316a0e92414ea60a023a87e91aaa6b0fb6101849
+              # 0.1.14 isolates LoadImage uploads per user: /upload/image forces
+              # subfolder=<user>, /object_info lists only the caller's own uploads,
+              # /view?type=input is own-bucket only, and /prompt enforces own-bucket
+              # input refs. Enabled by LIGHTHOUSE_INPUT_DIR + the input mount below.
+              # 0.1.13 logs denials (401/403/400/5xx with method/path/user).
+              # 0.1.12 made the gallery delete real (needs the /output mount RW below).
+              tag: 0.1.14@sha256:94abe9c1ce9201017aee55cef0e330bbbdcfc9185a9d93978749835b9c674e7a
             env:
               LIGHTHOUSE_LISTEN: ":8000"
               LIGHTHOUSE_UPSTREAM: "http://127.0.0.1:8188"
@@ -130,6 +130,10 @@ spec:
               # master restarts that wipe ComfyUI's in-memory /api/jobs history.
               # RW since 0.1.12: gallery delete removes the caller's own files.
               LIGHTHOUSE_OUTPUT_DIR: "/output"
+              # Per-user input bucket root (mounted below): enables LoadImage upload
+              # isolation — uploads land in /input/<user>/, object_info lists only
+              # the caller's own, /prompt enforces own-bucket refs. Requires ≥ 0.1.14.
+              LIGHTHOUSE_INPUT_DIR: "/input"
               # Curated-workflow dir (configMap below): role-scoped App Mode
               # curation overlaid onto each caller's workflow sidebar, served
               # read-only from this gate. Empty would disable curation.
@@ -272,6 +276,18 @@ spec:
             # by the gate's ownership checks. The gate never creates files here.
             licence-gate:
               - path: /output
+      input:
+        existingClaim: lighthouse-input
+        advancedMounts:
+          lighthouse:
+            # Master writes uploads here (ComfyUI's input dir); the gate forces each
+            # upload into /input/<user>/ and reads the dir to list the caller's own
+            # files in object_info (LIGHTHOUSE_INPUT_DIR=/input). Per-user upload
+            # isolation (0.1.14); also makes uploads durable across pod rolls.
+            main:
+              - path: /app/input
+            licence-gate:
+              - path: /input
       workflows:
         existingClaim: lighthouse-workflows
         advancedMounts:

--- a/kubernetes/apps/cortex/lighthouse/app/pvc.yaml
+++ b/kubernetes/apps/cortex/lighthouse/app/pvc.yaml
@@ -16,6 +16,23 @@ spec:
   storageClassName: ceph-filesystem
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/persistentvolumeclaim_v1.json
+# Per-user input buckets (/input/<user>/) for LoadImage uploads. RW to the master
+# (/app/input) and read by the licence-gate (/input) for per-user upload isolation.
+# Previously uploads were on the master's ephemeral rootfs (wiped every roll); this
+# also makes them durable. RWX ceph-filesystem so master + gate co-mount. Small +
+# expandable (scale on demand) — uploads are reference images, not a model store.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lighthouse-input
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-filesystem
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/persistentvolumeclaim_v1.json
 # Per-user output buckets (/output/<user>/). RWX so Plan 6 portal can multi-read.
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/kubernetes/apps/cortex/lighthouse/app/resources/allowlist.json
+++ b/kubernetes/apps/cortex/lighthouse/app/resources/allowlist.json
@@ -78,7 +78,7 @@
   "UltralyticsDetectorProvider": {},
   "SAMLoader": {},
   "FaceDetailer": {},
-  "LoadImage": {},
+  "LoadImage": { "input_field": "image" },
   "VAEEncode": {},
   "CannyEdgePreprocessor": {},
   "DepthAnythingV2Preprocessor": {},


### PR DESCRIPTION
Deploys the gate-side per-user upload isolation (containers #24, licence-gate 0.1.14).

**Problem:** uploads landed in ComfyUI's global `/input`, so every family member's `LoadImage` dropdown listed everyone's uploads (and the OSS frontend couldn't delete them). Now that Serina's a live user this leaked input references between accounts.

**Changes:**
- New `lighthouse-input` PVC (RWX `ceph-filesystem`, 5Gi, expandable), mounted **RW to master `/app/input`** and **into the gate `/input`**. Bonus: uploads now survive pod rolls (they were on ephemeral rootfs).
- Gate env `LIGHTHOUSE_INPUT_DIR=/input` turns on the isolation (upload→`<user>/`, object_info lists only own uploads, `/view?type=input` own-bucket only, `/prompt` enforces own-bucket refs).
- `allowlist.json`: `LoadImage` gains `input_field: "image"` — **production loads this file, not the built-in default**, so without it the feature would be inert.
- Repin licence-gate `0.1.13 → 0.1.14@sha256:94abe9c1`.

Verified: `kustomize build --load-restrictor=LoadRestrictionsNone …/lighthouse/app` renders the pin, the input PVC + both mounts, and the env, and builds clean.

Plan: `lighthouse/docs/declaration/plans/2026-06-23-input-asset-isolation.md`.