### PR TITLE
fix(cortex): mempalace-bridge serialize mines + memory 6Gi->8Gi (OOM)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace-bridge
-              tag: feat-pgvector-bridge@sha256:aac814065d8afcd0bcd63db8de3bd1f43227c551872d98700759ec6b16a070d3
+              tag: feat-pgvector-bridge@sha256:8fd91a6015748494cafa6753882e27a5029b859da3982432682a68ded4bc9d3e
             # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
             # writes palace markers once, then runs supergateway -> patched serve.py.
             # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.
@@ -75,7 +75,7 @@ spec:
                 # supergateway(node) + python + minilm onnxruntime baseline is
                 # ~1.2Gi idle; embedding (search/write) and server-side mining
                 # spike well above that. 3Gi OOM-killed; 6Gi gives headroom.
-                memory: 6Gi
+                memory: 8Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
Bridge OOMKilled again at 6Gi. Cause: concurrent auto-save ingests each spawn a ~2GB mine (onnxruntime arenas scale with the node's 20 cores); several at once exceed 6Gi. New image 8fd91a60 serializes mines via an exclusive fcntl lock acquired *before* the model load (waiters stay tiny), so they run one at a time. Also raises limit 6Gi->8Gi for margin. Bumps aac81406 -> 8fd91a60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)