### PR TITLE
fix(home): put mempalace + devpod-doctor on the dev-container cron PATH

### DIFF
--- a/kubernetes/apps/home/development-container/app/cronjobs-scheduled.yaml
+++ b/kubernetes/apps/home/development-container/app/cronjobs-scheduled.yaml
@@ -89,7 +89,7 @@ spec:
                 - -l
                 - gavin
                 - -c
-                - export PATH="$HOME/.local/bin:$PATH"; /home/gavin/.local/bin/mempalace-sync.sh
+                - export PATH="$HOME/.local/bin:$HOME/.mempalace-venv/bin:$PATH"; /home/gavin/.local/bin/mempalace-sync.sh
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -183,7 +183,7 @@ spec:
                 - -l
                 - gavin
                 - -c
-                - devpod-doctor --notify
+                - export PATH="$HOME/.local/bin:$PATH"; devpod-doctor --notify
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true


### PR DESCRIPTION
The development-container scheduled CronJobs run via `kubectl exec ... runuser -l gavin -c`, whose **login-shell PATH does not include `~/.local/bin`**. Jobs that work set it themselves; two did not, and were failing on every run.

## Changes
- **mempalace-sync**: add `~/.mempalace-venv/bin` to the exported PATH (where the `mempalace` CLI actually lives), so it resolves even if the `~/.local/bin/mempalace` symlink is missing.
- **doctor**: add `export PATH="$HOME/.local/bin:$PATH"` — it previously had *no* PATH export and could not find `devpod-doctor` at all, so the job failed before running a single check. Kept narrow (no venv path) so the doctor still honestly detects a missing `mempalace` link.

## Companion fix (dotfiles repo)
A chezmoi `run_onchange_` script now recreates the `~/.local/bin/mempalace` symlink on pod reseed (gavinmcfall/dotfiles `7438c40`).

## Validated
- `kubeconform -strict`: 4/4 resources valid
- `devpod-doctor` now runs in-pod; `mempalace` reports `[ ok ]`

## Known follow-ups (not in this PR)
- `mempalace-sync.sh` targets the *old* remote API; mempalace v3.4.1 uses a pgvector backend (separate change, in progress).
- `doctor` still flags real gaps it is designed to catch: missing `uuidgen` (`uuid-runtime`) and `any-buddy`.