### PR TITLE
feat(home): dev-container mempalace → pgvector shared palace

### DIFF
--- a/kubernetes/apps/home/development-container/app/cronjobs-scheduled.yaml
+++ b/kubernetes/apps/home/development-container/app/cronjobs-scheduled.yaml
@@ -89,7 +89,7 @@ spec:
                 - -l
                 - gavin
                 - -c
-                - export PATH="$HOME/.local/bin:$PATH"; /home/gavin/.local/bin/mempalace-sync.sh
+                - export PATH="$HOME/.local/bin:$HOME/.mempalace-venv/bin:$PATH"; /home/gavin/.local/bin/mempalace-sync.sh
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -183,7 +183,7 @@ spec:
                 - -l
                 - gavin
                 - -c
-                - devpod-doctor --notify
+                - export PATH="$HOME/.local/bin:$PATH"; devpod-doctor --notify
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/kubernetes/apps/home/development-container/app/helmrelease.yaml
+++ b/kubernetes/apps/home/development-container/app/helmrelease.yaml
@@ -151,6 +151,16 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /home/gavin/.cache
+      # mempalace pgvector marker dir. The shared palace lives in cluster Postgres;
+      # mempalace keys the table off sha256(palace_path), so clients must use
+      # MEMPALACE_PALACE_PATH=/data/palace (the server's path) to hit the shared
+      # 418k-drawer table. This dir only holds the tiny, regenerable backend +
+      # embedder markers — no drawer data — so emptyDir is fine (fsGroup 1000
+      # lets gavin's hooks/cron write the marker on first mine after a roll).
+      palace:
+        type: emptyDir
+        globalMounts:
+          - path: /data/palace
       # Shared target for the SMB sidecar. emptyDir mounts instantly (pod never
       # blocks); the cifs mount the sidecar lays inside it propagates into `app`.
       scbridge:


### PR DESCRIPTION
Completes the mempalace pgvector cutover for the dev-container (the cron + hooks were writing to a non-existent local table after the server moved to pgvector).

## The problem
mempalace v3.4.1 keys its Postgres table off `sha256(palace_path)`. The shared palace is one table — `mempalace_9a994364b7c26031…` (**~419k drawers**) — keyed to the server path `/data/palace`. The dev-container was keyed to `/home/gavin/.mempalace/palace` → a different (empty, non-existent) table, so nothing it mined ever reached the shared palace.

## This PR (home-ops)
Adds a writable `emptyDir` at `/data/palace` so the client can use `MEMPALACE_PALACE_PATH=/data/palace` and land on the shared table. The dir only holds the tiny, regenerable backend + embedder markers — drawer data lives in Postgres — so emptyDir is correct (fsGroup 1000 lets the hooks/cron write the marker on first mine).

## Companion change (dotfiles `6e5c157`)
`~/.secrets` now exports `MEMPALACE_BACKEND=pgvector`, `MEMPALACE_PGVECTOR_DSN` (from 1Password pg creds), `MEMPALACE_PALACE_PATH=/data/palace`, `MEMPALACE_EMBEDDING_MODEL=minilm`, drops the dead `MEMPAL_REMOTE_URL`, and versions `mempalace-sync.sh` with the obsolete `--remote-url/--remote-token` flags removed. `~/.zshenv` sources `~/.secrets`, so both Claude hooks and the `runuser -l` cron pick the vars up.

## Validated (live, read-only)
- With this exact config, `mempalace status` against `/data/palace` reports **419,000 drawers** (the shared palace), and opening the collection did **not** fork a new table (still exactly one `mempalace_*` table in Postgres).
- DSN connects; embedder recorded as `minilm (dim=384)`, matching the shared palace.

## Activation
On merge → Flux rolls the pod → init `chezmoi apply` regenerates `~/.secrets` + the `/data/palace` volume exists → the next stop-hook / weekly cron mines this box’s transcript backlog into the shared palace (content-dedup, so idempotent).

Depends on dotfiles `6e5c157` (already pushed). Related: #2314 (cron PATH fix).