### PR TITLE
chore(home): retire development-container (moved to native Windows)

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -16,7 +16,7 @@ resources:
   - ./bookstack/ks.yaml
   - ./calibre-web-automated/ks.yaml
   - ./cdn-sync/ks.yaml
-  - ./development-container/ks.yaml
+  # - ./development-container/ks.yaml  # retired 2026-06-29 → moved to native Windows. Flux prunes the deployment, CronJobs, RBAC, ExternalSecrets, AND the home/code PVCs (prune: true). Dir kept for archival — delete after confidence.
   - ./ebook-reconcile/ks.yaml
   - ./homepage/ks.yaml
   - ./filebrowser/ks.yaml


### PR DESCRIPTION
Retires the `development-container` dev pod — the source of the failing CronJobs — now that the workflow has moved to running Claude natively on Windows.

## What this does
Comments out the `development-container/ks.yaml` reference in `apps/home/kustomization.yaml` (same pattern as the `nerdz-landing` retirement). With `prune: true` on its Flux Kustomization, merging makes Flux tear down the entire app:
- the `development-container` Deployment (already scaled to 0, HR suspended)
- the failing CronJobs (`mempalace-sync`, `doctor`, `dotfiles-sync`, `abms-lifecycle`, `claude-b2-backup`) — **this is the actual fix for the "failed job runs"**
- RBAC, ExternalSecrets, SMB creds
- **both PVCs** — `development-container-home` (60Gi) and `development-container-code` (50Gi). Code is already mirrored to the workstation; home is being released per decision.

## Why
The box is retired; Claude now runs natively on Windows and ingests transcripts into the shared mempalace palace via the bridge (`mempal_bridge_save.py` → `mempalace_ingest_transcript`), so the in-pod cron/hook mining is no longer needed.

## Notes
- The deployment is already scaled to 0 and the HR suspended. If the suspended HelmRelease’s deletion hangs on its finalizer during prune, `flux resume hr development-container -n home` lets helm-controller complete the uninstall.
- The `kubernetes/apps/home/development-container/` dir is left in-tree for archival and will be deleted in a follow-up.
- Supersedes the now-closed #2314 and #2315 (which fixed the pod in place).

## Validated
`kubectl kustomize kubernetes/apps/home` builds cleanly with **0** development-container references.