### PR TITLE
fix(cortex): mempalace-bridge body limit (unbreak transcript auto-save)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace-bridge
-              tag: feat-pgvector-bridge@sha256:8fd91a6015748494cafa6753882e27a5029b859da3982432682a68ded4bc9d3e
+              tag: feat-pgvector-bridge@sha256:81a8bd3ddb0596982a033d5ce7eb5b008791522d5ad5de7c7e831a573250177d
             # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
             # writes palace markers once, then runs supergateway -> patched serve.py.
             # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.


### PR DESCRIPTION
The mempalace bridge silently dropped every real transcript auto-save since the pgvector cutover.

## Root cause
supergateway (3.4.3) wraps the MCP server in Express with a bare `app.use(express.json())` → **100kb body limit**. Claude transcripts are MBs, so `mempalace_ingest_transcript` POSTs were rejected with `PayloadTooLargeError: request entity too large` (confirmed in bridge logs, repeated). The stop-hook auto-save swallows errors → silent data loss. Palace had no new writes since ~2026-06-23.

## Fix
New bridge image (`gavinmcfall/mempalace` `28df5f2`) patches supergateway’s pinned dist to `express.json({ limit: "50mb" })`, with a build-time grep guard. This PR bumps the digest.

## Validated
- Bridge ingest tool itself works (a small probe queued + `success`); the failure was purely the size limit.
- `kubeconform`: 1/1 valid.
- Post-merge I will confirm a large-transcript probe lands in the palace.