### PR TITLE
fix(cortex): mempalace-bridge CPU + embed threads + GIN-index-on-boot image

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -40,10 +40,16 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace-bridge
-              tag: feat-pgvector-bridge@sha256:81a8bd3ddb0596982a033d5ce7eb5b008791522d5ad5de7c7e831a573250177d
+              tag: feat-pgvector-bridge@sha256:ca8d3be639dac65d99daa90d5354291cae4e5ddf797c9e7cf966428478f79b4d
             # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
             # writes palace markers once, then runs supergateway -> patched serve.py.
             # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.
+            env:
+              # Cap onnxruntime/BLAS threads to the CPU budget. Without this the
+              # embedder spawns ~1 thread per node core (20+) onto a 6-core cgroup
+              # and thrashes; matching threads to the limit keeps mining efficient.
+              OMP_NUM_THREADS: "6"
+              OPENBLAS_NUM_THREADS: "6"
             envFrom:
               - secretRef:
                   name: mempalace-bridge-secret
@@ -68,10 +74,13 @@ spec:
                   failureThreshold: 40
             resources:
               requests:
-                cpu: 250m
+                cpu: 500m
                 memory: 2Gi
               limits:
-                cpu: "2"
+                # Mining embeds transcripts on CPU (onnxruntime). 2 cores made the
+                # backlog drain glacially; 6 cores (matched by OMP_NUM_THREADS)
+                # lets a mine finish in a sensible time.
+                cpu: "6"
                 # supergateway(node) + python + minilm onnxruntime baseline is
                 # ~1.2Gi idle; embedding (search/write) and server-side mining
                 # spike well above that. 3Gi OOM-killed; 6Gi gives headroom.


### PR DESCRIPTION
Durable follow-ups to the mempalace write-path fix (body limit + GIN index were the root causes).

## Changes
- **CPU 2 → 6** and **OMP_NUM_THREADS / OPENBLAS_NUM_THREADS = 6**: mining embeds transcripts on CPU via onnxruntime. At 2 cores the post-fix backlog drained glacially, and onnxruntime spawned ~20 threads onto 2 cores (context-switch thrash). Matching threads to a larger budget lets a mine finish in reasonable time.
- **New bridge image** (`gavinmcfall/mempalace` `160f396`, digest `ca8d3be`): entrypoint now (a) **creates the `metadata` GIN index on every boot** (idempotent; derives the exact table name from the backend) so dedup/purge is an index scan not a 419k-row seq scan, and (b) sets **`statement_timeout=120s`** on the DSN so any future slow SQL aborts loudly instead of hanging a mine forever and holding the serialize-lock.

## Context
Root cause of writes silently not landing was server-side, not the Windows client: transcripts 413d at the bridge (body limit, already fixed in #2318) and, once past that, every mine seq-scanned the 419k table for dedup → hung. The GIN index (applied live, now also baked into boot) flips that to an index scan; this PR makes it durable and unblocks throughput.

## Validated
`kubeconform`: 1/1 valid. Bridge image rebuilt green in CI.