### PR TITLE
fix(cortex): bump mempalace-bridge to post-v3.5.0 (unblock large-palace mining)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace-bridge
-              tag: feat-pgvector-bridge@sha256:ca8d3be639dac65d99daa90d5354291cae4e5ddf797c9e7cf966428478f79b4d
+              tag: feat-pgvector-bridge@sha256:1c5b5b0343f55ec91a8ed0fc3a7948be13c9844c90f0d5672863c7cbace426ae
             # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
             # writes palace markers once, then runs supergateway -> patched serve.py.
             # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.


### PR DESCRIPTION
Final fix for the write path. After the body-limit (#2318) and GIN-index/CPU (#2319) fixes, mines still stalled because mempalace 3.4.1s pgvector `get()` did a **full-table `SELECT id, document, metadata`** for local-filter queries — streaming the whole 419k palace per mine (caught it live in `ClientWrite`).

Upstream shipped the exact fixes since our pin:
- **SQL-pushdown pagination for pgvector `get()`** (#1840, in v3.5.0)
- **skip the `document` column on metadata-only fetches** (#1892, Jun 28) — kills the O(n×doc) transfer
- surrogate/NUL transcript mine-abort fixes (#1833/#1829); ONNX intra-op thread cap (#1068)

This bumps the bridge image (`gavinmcfall/mempalace` `79ff5c2`, pin → `develop@8ec284db`, digest `1c5b5b03`). No pgvector schema migration between 3.4.1 and this ref; verified `mine_convos`/`_table_name`/`_write_marker`/status-patch targets still exist so the bridges serve.py patches stay compatible.

## Validation
`kubeconform` 1/1; image built green. Post-merge Ill confirm a transcript write lands (the marker that previously never did).