### PR TITLE
fix(cortex): raise mempalace-bridge memory to 16Gi (stop OOMKills)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -81,10 +81,13 @@ spec:
                 # backlog drain glacially; 6 cores (matched by OMP_NUM_THREADS)
                 # lets a mine finish in a sensible time.
                 cpu: "6"
-                # supergateway(node) + python + minilm onnxruntime baseline is
-                # ~1.2Gi idle; embedding (search/write) and server-side mining
-                # spike well above that. 3Gi OOM-killed; 6Gi gives headroom.
-                memory: 8Gi
+                # Idle is ~0.5Gi, but now that writes actually land, each mine
+                # subprocess loads onnxruntime fresh (~2Gi) and big sessions
+                # (700+ drawers) + onnxruntime arenas spike past 8Gi → OOMKilled
+                # several times/day. Node has ~75Gi free, so give generous
+                # headroom over the observed spikes. (Deeper fix: a persistent
+                # embed worker / v3.5.0 daemon so the model loads once, not per mine.)
+                memory: 16Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
The bridge has been OOMKilled (exit 137) several times a day, firing alerts.

## Cause
Now that the write path works, each ingest spawns a mine subprocess that loads onnxruntime fresh (~2Gi). Big sessions mine 700+ drawers each, and onnxruntime memory arenas (with `OMP_NUM_THREADS=6`) push a single mine past the **8Gi** limit. Confirmed: `lastState.reason=OOMKilled`, cgroup peak >8Gi.

## Fix
Raise the memory **limit 8Gi → 16Gi**. `stanton-02` has ~75Gi free, requests stay at 2Gi (scheduling unchanged), so this is just headroom for the transient mining spikes. CPU/threads unchanged.

## Deeper follow-up (not in this PR)
The root inefficiency is loading the embedder per-mine (and re-mining large growing sessions on every stop). A persistent embed worker / the v3.5.0 local daemon (model loaded once, reused) would cut memory and CPU substantially. Tracked for later.

## Validated
`kubeconform` 1/1.