### PR TITLE
fix(cortex): mempalace-bridge daemon ingest (bound mining memory)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace-bridge
-              tag: feat-pgvector-bridge@sha256:1c5b5b0343f55ec91a8ed0fc3a7948be13c9844c90f0d5672863c7cbace426ae
+              tag: feat-pgvector-bridge@sha256:c9a326c22675a38e9193272ea39d2d323b1fcda2c69c01618a7c26c850d42749
             # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
             # writes palace markers once, then runs supergateway -> patched serve.py.
             # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.


### PR DESCRIPTION
Robustness follow-up to the OOM mitigation (#2321 raised the limit to 16Gi). This fixes the **cause**: the bridge spawned a fresh onnxruntime subprocess (~2GB) per ingest, so memory scaled with ingest volume.

## Change
New bridge image (gavinmcfall/mempalace afe2daa) routes ingests through the **v3.5.0 local daemon**: one long-lived process loads the embedder **once** and serializes mines via its SQLite job queue.
- **Bounded memory** — model loaded once and reused, not ~2GB per mine.
- **Dedupe** — content-hash dedupe_key collapses repeat saves of an unchanged growing session.
- **No regression** — auto_start spins the daemon up on first ingest; falls back to the original detached subprocess if unavailable. Temp dirs GC after 6h.

## Validation
kubeconform 1/1; image green. Post-merge: confirm ingests report "via":"daemon" and memory stays flat.