### PR TITLE
fix(cortex): cap mempalace mine at 3000 chunks/file (stop huge-transcript OOM)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -50,6 +50,13 @@ spec:
               # and thrashes; matching threads to the limit keeps mining efficient.
               OMP_NUM_THREADS: "6"
               OPENBLAS_NUM_THREADS: "6"
+              # Per-file chunk admission cap. A mine loads the whole transcript
+              # into memory + holds all chunks/entities, so a single huge session
+              # (a 14MB debugging marathon re-saved across sessions) spiked >16Gi
+              # and OOMKilled the daemon. Files over this cap are skipped (logged),
+              # bounding any single mine to well under the limit. Normal sessions
+              # are far below 3000 chunks; only pathological transcripts skip.
+              MEMPALACE_MAX_CHUNKS_PER_FILE: "3000"
             envFrom:
               - secretRef:
                   name: mempalace-bridge-secret


### PR DESCRIPTION
The bridge OOMKilled again ~6h after the daemon change (#2322). Root cause: a single **14MB transcript** (this long debugging session, re-saved across the 8 active Claude sessions) produces too many chunks. A mine **loads the whole file into memory and holds all chunks/entities** (`miner.py`: reads are not streamed; memory scales with source size), so one giant mine spiked >16Gi even with the daemon loading the model once.

## Fix
Set `MEMPALACE_MAX_CHUNKS_PER_FILE=3000`. The cap is a per-file **admission rail** — files over it are skipped (logged), not truncated — so any single mine is bounded well under the 16Gi limit. Normal sessions are far below 3000 chunks (recent successful mines were ~700–770 drawers), so only pathological transcripts skip.

## Effect
- No single mine can blow the pod.
- The queued backlog of 14MB re-saves will now skip fast instead of OOMing.
- Trade-off: a genuinely huge session (>3000 chunks, ~5MB+) wont be auto-saved. Deeper option if that matters: pre-`split` mega-transcripts or incremental `sweep` so large sessions are mined in bounded pieces — happy to do that as a follow-up.

## Validation
`kubeconform` 1/1. Post-merge: confirm a large mine now skips and memory stays bounded.