### PR TITLE
feat(romm): update 4.8.1 -> 4.9.2

### DIFF
--- a/kubernetes/apps/games/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/games/romm/app/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rommapp/romm
-              tag: 4.8.1@sha256:2b7a1714b287f69b081ad2a63bb8c2fa673666a17b2f21322b580b0cd51cb266
+              tag: 4.9.2@sha256:c81778afcafe7c865bdf156d1c62349aec3dfca3aca5ec0d6c2c2e8bfa9fb071
             env:
               ROMM_DB_DRIVER: postgresql
               ROMM_BASE_PATH: /romm
@@ -113,6 +113,8 @@ spec:
                 subPath: assets
               - path: /romm/resources
                 subPath: resources
+              - path: /var/lib/romm/sync
+                subPath: sync
       nginx-conf:
         type: emptyDir
         globalMounts:

--- a/kubernetes/apps/games/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/games/romm/app/helmrelease.yaml
@@ -113,8 +113,6 @@ spec:
                 subPath: assets
               - path: /romm/resources
                 subPath: resources
-              - path: /var/lib/romm/sync
-                subPath: sync
       nginx-conf:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
@
## Summary
Updates RomM from `4.8.1` to the latest stable `4.9.2`. Pure image bump (pinned by digest `sha256:c81778af…`).

## Breaking changes reviewed (4.8.1 → 4.9.2)
- **4.9.0 API/security** — private user assets (saves, states, personal screenshots) now require auth instead of being served via the unauthenticated nginx static route. Security fix; **no impact** on the web UI or the ROM download endpoint (`DISABLE_DOWNLOAD_ENDPOINT_AUTH` governs a different endpoint).
- **4.9.0 config** — gamelist export moved under `scan.gamelist.export`. **Not used here**, no migration needed.
- DB migrations run automatically on startup (Alembic).

## New 4.9.x features (no server config required)
- **Save Sync** and **play-session tracking** are client/API-driven. Devices register via the API; saves persist in the existing `/romm/assets` mount. Nothing to enable server-side — set up on the client (handheld/companion app) by registering it against this instance.
- **Libretro thumbnails** — enabled by default, additive.

## Note
An earlier revision of this branch added a `/var/lib/romm/sync` mount based on a release-note summary that turned out to be inaccurate — there is no `SYNC_BASE_PATH` in 4.9.2 and Save Sync needs no server-side path. That mount was removed; final diff is the image bump only.

## Validation
- `kustomize build --load-restrictor LoadRestrictionsNone kubernetes/apps/games/romm/app` renders cleanly with the new tag.
@