### PR TITLE
fix(cortex): mempalace-bridge reap idle MCP sessions (real OOM leak)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace-bridge
-              tag: feat-pgvector-bridge@sha256:c9a326c22675a38e9193272ea39d2d323b1fcda2c69c01618a7c26c850d42749
+              tag: feat-pgvector-bridge@sha256:f41f264c859af54fefb3276d66fe9cdf9f4e6e3cd56463fc8bf2a63fe071b8d2
             # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
             # writes palace markers once, then runs supergateway -> patched serve.py.
             # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.


### PR DESCRIPTION
The bridge kept OOMKilling (~daily) even after the daemon (#2322), chunk cap (#2323), and 16Gi bump (#2321). Those all addressed **mining** memory — but the real leak was in the **MCP session frontend**: stateful streamableHttp spawns one `serve.py` stdio child per MCP session, and with no `--sessionTimeout` idle/abandoned sessions are **never reaped**. Diagnosis found **92 `serve.py` processes = 5.8Gi** accumulated over ~26h (8 live Claude sessions reconnecting).

## Fix
New bridge image (`gavinmcfall/mempalace` `d2c883e`) adds `--sessionTimeout 600000` (10min) to supergateway. Idle sessions and their stdio children are reaped; active clients keep theirs alive. Bounds the `serve.py` count to a handful.

## Validation
`kubeconform` 1/1; image green. Post-merge: confirm `serve.py` count stays low (was 92) and pod memory stays flat.