### PR TITLE
fix(cortex): mempalace-bridge native HTTP transport (fix real OOM leak)

### DIFF
--- a/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/mempalace-bridge/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mempalace-bridge
-              tag: feat-pgvector-bridge@sha256:f41f264c859af54fefb3276d66fe9cdf9f4e6e3cd56463fc8bf2a63fe071b8d2
+              tag: feat-pgvector-bridge@sha256:ca73ea111a84e89d03b6ead22ea3707a1e0192456361f7f3417b1fb6e32a5f04
             # Entrypoint (bridge/entrypoint.sh) builds the DSN from PGUSER/PGPASSWORD,
             # writes palace markers once, then runs supergateway -> patched serve.py.
             # MEMPALACE_BACKEND / PALACE_PATH / EMBEDDING_MODEL / HOME baked in image.


### PR DESCRIPTION
The bridge kept OOMKilling (now ~daily) after the daemon (#2322), chunk cap (#2323), 16Gi (#2321), and sessionTimeout rounds. A full process dump found the actual cause: **supergateway leaks serve.py MCP-session processes** — it spawns one per session and never reaps orphans (`--sessionTimeout` reaped the session, not the process). Confirmed **46+ serve.py with 0 active connections** climbing to OOM.

## Fix
New bridge image (`gavinmcfall/mempalace` `972e3ae`) **drops supergateway** and runs mempalace v3.5.0s **native HTTP MCP transport** (`serve.py --transport http` → one `ThreadingHTTPServer`, no per-session spawning) on loopback, behind a **caddy** reverse proxy on :8080 that rewrites `Host` to the loopback literal so the DNS-rebinding Host-pin accepts proxied requests.

- **No client changes** (still `https://mempalace-bridge.nerdz.cloud/mcp`, no bearer token).
- serve.py keeps the custom `ingest_transcript` tool + status patch.
- A POSIX supervisor in the entrypoint restarts the pod if either process dies.

## Validation
Validated in-pod before building: `serve.py --transport http` serves `initialize` + `tools/list` (36 tools incl `mempalace_ingest_transcript`, `mempalace_status`); Caddyfile passes `caddy validate` at image build; `kubeconform` 1/1. Post-merge Ill confirm the MCP works through caddy and the process count stays flat (was climbing to ~90).