### PR TITLE
feat(downloads): rom-ingest validate-before-promote gate

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - ./radarr/ks.yaml
   - ./radarr-uhd/ks.yaml
   - ./recyclarr/ks.yaml
+  - ./rom-ingest/ks.yaml
   - ./rreading-glasses/ks.yaml
   - ./sabnzbd/ks.yaml
   - ./shelfmark/ks.yaml

--- a/kubernetes/apps/downloads/rom-ingest/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/rom-ingest/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rom-ingest
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: rom-ingest-secret
+    template:
+      engineVersion: v2
+      data:
+        # Add a DISCORD_WEBHOOK_ROMGATE field to the 1Password "discord" item.
+        # Renders empty (notifications skipped) until that field exists.
+        DISCORD_WEBHOOK: "{{ .DISCORD_WEBHOOK_ROMGATE }}"
+  dataFrom:
+    - extract:
+        key: discord

--- a/kubernetes/apps/downloads/rom-ingest/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/rom-ingest/app/helmrelease.yaml
@@ -1,0 +1,134 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rom-ingest
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      # -- Weekly refresh of Logiqx DAT files into the shared /dats PVC.
+      dat-refresh:
+        type: cronjob
+        cronjob:
+          schedule: "0 4 * * 0" # Sundays 04:00
+          timeZone: &timeZone ${TIMEZONE}
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          ttlSecondsAfterFinished: 86400
+        containers:
+          git:
+            image:
+              repository: docker.io/alpine/git
+              tag: latest@sha256:e043be20669db13cbcfb6190192babee4cf2dca98709bb0c2d08ca2d35a0a06a
+            command: ["/bin/sh", "/scripts/dat-refresh.sh"]
+            env:
+              TZ: *timeZone
+              HOME: /tmp
+              # Sources (see dat-refresh.sh): libretro metadat/* = cart+disc DATs,
+              # PureDOS = DOS games. All git repos, so refresh stays automatic.
+              LIBRETRO_SUBDIRS: "metadat/no-intro metadat/redump"
+              DOS_ENABLED: "true"
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+        pod:
+          restartPolicy: OnFailure
+      # -- Hourly validate-before-promote gate (cart/disc via igir).
+      ingest:
+        type: cronjob
+        annotations:
+          reloader.stakater.com/auto: "true"
+        cronjob:
+          schedule: "@hourly"
+          timeZone: *timeZone
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          ttlSecondsAfterFinished: 86400
+        containers:
+          igir:
+            image:
+              repository: docker.io/library/node
+              tag: 22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
+            command: ["/bin/sh", "/scripts/ingest.sh"]
+            env:
+              TZ: *timeZone
+              HOME: /tmp
+              npm_config_cache: /tmp/.npm
+              IGIR_VERSION: "5.3.0"
+            envFrom:
+              - secretRef:
+                  name: rom-ingest-secret
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+        pod:
+          restartPolicy: OnFailure
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    persistence:
+      scripts:
+        type: configMap
+        name: rom-ingest-scripts
+        defaultMode: 0755
+        globalMounts:
+          - path: /scripts
+            readOnly: true
+      dats:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteMany
+        size: 2Gi
+        storageClass: ceph-filesystem
+        globalMounts:
+          - path: /dats
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      media:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        advancedMounts:
+          ingest:
+            igir:
+              - path: /media

--- a/kubernetes/apps/downloads/rom-ingest/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/rom-ingest/app/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/priority/priority-08
+configMapGenerator:
+  - name: rom-ingest-scripts
+    files:
+      - ./resources/dat-refresh.sh
+      - ./resources/ingest.sh
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/downloads/rom-ingest/app/resources/dat-refresh.sh
+++ b/kubernetes/apps/downloads/rom-ingest/app/resources/dat-refresh.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# rom-ingest :: dat-refresh
+# Weekly refresh of Logiqx/clrmamepro DAT files into the shared /dats PVC so the
+# ingest gate always validates against current data. Two sources:
+#   1. libretro-database  metadat/{no-intro,redump}  — cart + optical DATs
+#   2. PureDOS/DAT        PureDOSDAT.xml              — DOS games (DOSBox-Pure)
+# All sources are git repos so this stays fully automatic. igir parses Logiqx
+# and clrmamepro regardless of file extension; PureDOS's .xml is copied as .dat.
+set -u
+
+DEST="/dats"
+TMP="/tmp/dat-src"
+STAGE="$DEST/.new"
+
+# --- source config (override via env) ------------------------------------
+LIBRETRO_REPO="${LIBRETRO_REPO:-https://github.com/libretro/libretro-database.git}"
+# metadat/* holds the real hash-bearing No-Intro/Redump DATs (not top-level dat/).
+LIBRETRO_SUBDIRS="${LIBRETRO_SUBDIRS:-metadat/no-intro metadat/redump}"
+DOS_ENABLED="${DOS_ENABLED:-true}"
+DOS_REPO="${DOS_REPO:-https://github.com/PureDOS/DAT.git}"
+DOS_FILES="${DOS_FILES:-PureDOSDAT.xml}"
+
+mkdir -p "$DEST"
+rm -rf "$STAGE"; mkdir -p "$STAGE"
+
+# --- source 1: libretro (sparse dirs) ------------------------------------
+echo "[dat-refresh] libretro: ${LIBRETRO_REPO} (${LIBRETRO_SUBDIRS})"
+rm -rf "$TMP"
+git clone --depth 1 --no-checkout --filter=tree:0 "$LIBRETRO_REPO" "$TMP" \
+  && cd "$TMP" \
+  && git sparse-checkout init --cone \
+  && git sparse-checkout set $LIBRETRO_SUBDIRS \
+  && git checkout || { echo "[dat-refresh] ERROR: libretro fetch failed"; exit 1; }
+for sub in $LIBRETRO_SUBDIRS; do
+  [ -d "$TMP/$sub" ] || { echo "[dat-refresh] WARN: missing $sub"; continue; }
+  find "$TMP/$sub" -name '*.dat' -exec cp -f {} "$STAGE/" \;
+done
+
+# --- source 2: PureDOS (root files, copied as .dat) ----------------------
+if [ "$DOS_ENABLED" = "true" ]; then
+  echo "[dat-refresh] PureDOS: ${DOS_REPO} (${DOS_FILES})"
+  rm -rf "$TMP"
+  if git clone --depth 1 "$DOS_REPO" "$TMP"; then
+    for f in $DOS_FILES; do
+      if [ -f "$TMP/$f" ]; then
+        base=$(basename "$f" | sed 's/\.[Xx][Mm][Ll]$//')
+        cp -f "$TMP/$f" "$STAGE/${base}.dat"
+      else
+        echo "[dat-refresh] WARN: PureDOS file '$f' not found"
+      fi
+    done
+  else
+    echo "[dat-refresh] WARN: PureDOS fetch failed (continuing without DOS)"
+  fi
+fi
+
+# --- swap staged DATs into place -----------------------------------------
+found=$(find "$STAGE" -name '*.dat' | wc -l)
+echo "[dat-refresh] staged ${found} DAT(s)"
+if [ "$found" -eq 0 ]; then
+  echo "[dat-refresh] ERROR: no DATs fetched — leaving existing set untouched"
+  rm -rf "$STAGE" "$TMP"; exit 1
+fi
+rm -f "$DEST"/*.dat 2>/dev/null || true
+mv -f "$STAGE"/*.dat "$DEST/" 2>/dev/null || true
+rm -rf "$STAGE" "$TMP"
+
+total=$(find "$DEST" -maxdepth 1 -name '*.dat' | wc -l)
+echo "[dat-refresh] done — ${total} DAT(s) available in ${DEST}"

--- a/kubernetes/apps/downloads/rom-ingest/app/resources/ingest.sh
+++ b/kubernetes/apps/downloads/rom-ingest/app/resources/ingest.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# rom-ingest :: ingest gate
+# Validate freshly-downloaded ROMs against DATs BEFORE they enter the RomM
+# library. Matched files are promoted into roms/<slug>/; everything else is
+# quarantined for manual review. RomM's filesystem-change watch imports the
+# promoted files automatically.
+set -u
+
+IGIR_VERSION="${IGIR_VERSION:-5.3.0}"
+DATS_GLOB="/dats/**/*.dat"
+LIBRARY="/media/Library/Emulation/roms"
+BASE="/media/Downloads/rom-ingest"
+WORK="$BASE/work"
+QUARANTINE="$BASE/quarantine"
+STAGING="/media/Downloads/sabnzbd/complete/roms /media/Downloads/qbittorrent/complete/roms"
+WEBHOOK="${DISCORD_WEBHOOK:-}"
+
+log() { echo "[rom-ingest] $*"; }
+
+notify() {
+  [ -z "$WEBHOOK" ] && return 0
+  msg=$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  wget -q -O- --header="Content-Type: application/json" \
+    --post-data="{\"username\":\"ROM Gate\",\"content\":\"$msg\"}" \
+    "$WEBHOOK" >/dev/null 2>&1 || log "discord notify failed"
+}
+
+# --- preconditions -------------------------------------------------------
+if [ -z "$(find /dats -maxdepth 2 -name '*.dat' 2>/dev/null | head -1)" ]; then
+  log "no DAT files in /dats yet — has dat-refresh run? aborting run."
+  exit 0
+fi
+
+mkdir -p "$WORK" "$QUARANTINE" "$LIBRARY"
+cd "$WORK" || exit 1
+
+# --- collect non-empty staging inputs -----------------------------------
+INPUTS=""
+for d in $STAGING; do
+  if [ -d "$d" ] && [ -n "$(ls -A "$d" 2>/dev/null)" ]; then
+    INPUTS="$INPUTS --input $d"
+  fi
+done
+if [ -z "$INPUTS" ]; then
+  log "nothing staged. done."
+  exit 0
+fi
+
+# --- validate + move matched ROMs into WORK, organised by DAT name -------
+log "validating staged ROMs against DATs (igir ${IGIR_VERSION})..."
+# igir moves recognised ROMs to --output (extracting them from any archive);
+# anything it does not recognise is left in the input dirs (swept to
+# quarantine below).
+npx --yes "igir@${IGIR_VERSION}" move extract report \
+  --dat "$DATS_GLOB" \
+  $INPUTS \
+  --output "$WORK" \
+  --dir-dat-name \
+  --report-output "$WORK/report.csv" \
+  2>&1 | tail -50 || log "igir exited non-zero (continuing to sweep)"
+
+# --- map DAT-name folders -> RomM platform slug and promote --------------
+map_slug() {
+  case "$1" in
+    *"Game Boy Advance"*)                echo gba ;;
+    *"Game Boy Color"*)                  echo gbc ;;
+    *"Game Boy"*)                        echo gb ;;
+    *"Super Nintendo"*|*"Super Famicom"*) echo snes ;;
+    *"Nintendo 64"*)                     echo n64 ;;
+    *"Nintendo DS"*)                     echo nds ;;
+    *"Nintendo 3DS"*|*"New Nintendo 3DS"*) echo 3ds ;;
+    *"Nintendo Entertainment System"*|*"Famicom"*) echo nes ;;
+    *"GameCube"*)                        echo ngc ;;
+    *"Master System"*|*"Mark III"*)      echo sms ;;
+    *"Mega Drive"*|*"Genesis"*)          echo genesis ;;
+    *"Dreamcast"*)                       echo dc ;;
+    *"PlayStation Portable"*)            echo psp ;;
+    *"PlayStation Vita"*)                echo psvita ;;
+    *"PlayStation 2"*)                   echo ps2 ;;
+    *"PlayStation 3"*)                   echo ps3 ;;
+    *"PlayStation"*)                     echo psx ;;
+    *"Xbox 360"*|*"XBOX 360"*)           echo xbox360 ;;
+    *"Xbox"*|*"XBOX"*)                   echo xbox ;;
+    *"Pure DOS"*|*"DOS Games"*)          echo dos ;;
+    *) echo "" ;;
+  esac
+}
+
+promoted=0
+unmapped=0
+for sysdir in "$WORK"/*/; do
+  [ -d "$sysdir" ] || continue
+  name=$(basename "$sysdir")
+  slug=$(map_slug "$name")
+  n=$(find "$sysdir" -type f | wc -l)
+  [ "$n" -eq 0 ] && { rmdir "$sysdir" 2>/dev/null || true; continue; }
+  if [ -n "$slug" ]; then
+    mkdir -p "$LIBRARY/$slug"
+    find "$sysdir" -mindepth 1 -maxdepth 1 -exec mv -f {} "$LIBRARY/$slug/" \; 2>/dev/null || true
+    promoted=$((promoted + n))
+    log "promoted ${n} file(s): ${name} -> roms/${slug}"
+  else
+    mkdir -p "$QUARANTINE/_unmapped/$name"
+    find "$sysdir" -mindepth 1 -maxdepth 1 -exec mv -f {} "$QUARANTINE/_unmapped/$name/" \; 2>/dev/null || true
+    unmapped=$((unmapped + n))
+    log "no slug mapping for '${name}' -> quarantine/_unmapped (${n} file(s))"
+  fi
+  rmdir "$sysdir" 2>/dev/null || true
+done
+
+# --- sweep anything igir did NOT recognise into quarantine ---------------
+mkdir -p "$QUARANTINE/_unmatched"
+for d in $STAGING; do
+  [ -d "$d" ] || continue
+  find "$d" -type f 2>/dev/null | while IFS= read -r f; do
+    mv -f "$f" "$QUARANTINE/_unmatched/" 2>/dev/null || true
+  done
+  find "$d" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+done
+unmatched=$(find "$QUARANTINE/_unmatched" -type f 2>/dev/null | wc -l)
+
+summary="ROM gate: promoted ${promoted}, unmapped ${unmapped}, quarantined(unmatched) ${unmatched}"
+log "$summary"
+if [ "$promoted" -gt 0 ] || [ "$unmapped" -gt 0 ] || [ "$unmatched" -gt 0 ]; then
+  notify "$summary"
+fi
+exit 0

--- a/kubernetes/apps/downloads/rom-ingest/ks.yaml
+++ b/kubernetes/apps/downloads/rom-ingest/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rom-ingest
+  namespace: &namespace downloads
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/downloads/rom-ingest/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## What

A new `downloads/rom-ingest` app: a validate-before-promote gate that sits between downloads and the RomM library. Fills the gap where RomM catalogs a library but has no pre-flight validation step.

## How it works

- **`dat-refresh`** (weekly CronJob): git-syncs current DATs into a shared `ceph-filesystem` PVC — No-Intro + Redump via libretro `metadat/*`, plus PureDOS for DOS. Fully git-sourced, so DATs never go stale.
- **`ingest`** (hourly CronJob): runs `igir` against the SAB/qBit `roms` category, validates each file by hash against the DATs, then:
  - ✅ match → promoted to `Library/Emulation/roms/<slug>/` (RomM auto-imports)
  - ❌ no match / no-DAT platform → strict-quarantined for review
  - posts a Discord summary (optional; skips if webhook unset)

## Coverage

Cart/disc through the Xbox 360 / PS3 / Wii U era, plus DOS (PureDOS `.dosz`). Modern gens (PS4/PS5/Xbox One/Series X) and PC have no DATs and are quarantined by design. **Switch is a planned phase 2** (NX_Game_Info + titledb + prod.keys, needs a custom image).

## Validation

- `kustomize build` clean
- kubeconform: ConfigMap, ExternalSecret, HelmRelease all valid
- both gate scripts pass `sh -n`
- images pinned by digest (`node:22-alpine`, `alpine/git`); igir pinned to 5.3.0
- CronJob controllers mirror the existing `tqm` pattern

## Post-merge

- First `dat-refresh` run populates `/dats`; the hourly gate goes live after.
- Optional: add a `DISCORD_WEBHOOK_ROMGATE` field to the 1Password `discord` item for notifications.