### PR TITLE
fix(downloads): rom-ingest dat-refresh cwd bug + resilient discord secret

### DIFF
--- a/kubernetes/apps/downloads/rom-ingest/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/rom-ingest/app/externalsecret.yaml
@@ -13,9 +13,10 @@ spec:
     template:
       engineVersion: v2
       data:
-        # Add a DISCORD_WEBHOOK_ROMGATE field to the 1Password "discord" item.
-        # Renders empty (notifications skipped) until that field exists.
-        DISCORD_WEBHOOK: "{{ .DISCORD_WEBHOOK_ROMGATE }}"
+        # Add a DISCORD_WEBHOOK_ROMGATE field to the 1Password "discord" item to
+        # enable notifications. `index`+`default` tolerates the field being absent
+        # (renders empty -> script skips notify) instead of failing the sync.
+        DISCORD_WEBHOOK: '{{ index . "DISCORD_WEBHOOK_ROMGATE" | default "" }}'
   dataFrom:
     - extract:
         key: discord

--- a/kubernetes/apps/downloads/rom-ingest/app/resources/dat-refresh.sh
+++ b/kubernetes/apps/downloads/rom-ingest/app/resources/dat-refresh.sh
@@ -23,18 +23,22 @@ DOS_FILES="${DOS_FILES:-PureDOSDAT.xml}"
 mkdir -p "$DEST"
 rm -rf "$STAGE"; mkdir -p "$STAGE"
 
-# --- source 1: libretro (sparse dirs) ------------------------------------
+# --- source 1: libretro (sparse dirs). Use `git -C` — never cd into $TMP,
+#     so a later `rm -rf $TMP` can't pull the shell's CWD out from under it.
 echo "[dat-refresh] libretro: ${LIBRETRO_REPO} (${LIBRETRO_SUBDIRS})"
 rm -rf "$TMP"
-git clone --depth 1 --no-checkout --filter=tree:0 "$LIBRETRO_REPO" "$TMP" \
-  && cd "$TMP" \
-  && git sparse-checkout init --cone \
-  && git sparse-checkout set $LIBRETRO_SUBDIRS \
-  && git checkout || { echo "[dat-refresh] ERROR: libretro fetch failed"; exit 1; }
-for sub in $LIBRETRO_SUBDIRS; do
-  [ -d "$TMP/$sub" ] || { echo "[dat-refresh] WARN: missing $sub"; continue; }
-  find "$TMP/$sub" -name '*.dat' -exec cp -f {} "$STAGE/" \;
-done
+if git clone --depth 1 --no-checkout --filter=tree:0 "$LIBRETRO_REPO" "$TMP" \
+  && git -C "$TMP" sparse-checkout init --cone \
+  && git -C "$TMP" sparse-checkout set $LIBRETRO_SUBDIRS \
+  && git -C "$TMP" checkout; then
+  for sub in $LIBRETRO_SUBDIRS; do
+    [ -d "$TMP/$sub" ] || { echo "[dat-refresh] WARN: missing $sub"; continue; }
+    find "$TMP/$sub" -name '*.dat' -exec cp -f {} "$STAGE/" \;
+  done
+else
+  echo "[dat-refresh] ERROR: libretro fetch failed"
+fi
+rm -rf "$TMP"
 
 # --- source 2: PureDOS (root files, copied as .dat) ----------------------
 if [ "$DOS_ENABLED" = "true" ]; then
@@ -52,6 +56,7 @@ if [ "$DOS_ENABLED" = "true" ]; then
   else
     echo "[dat-refresh] WARN: PureDOS fetch failed (continuing without DOS)"
   fi
+  rm -rf "$TMP"
 fi
 
 # --- swap staged DATs into place -----------------------------------------
@@ -59,11 +64,11 @@ found=$(find "$STAGE" -name '*.dat' | wc -l)
 echo "[dat-refresh] staged ${found} DAT(s)"
 if [ "$found" -eq 0 ]; then
   echo "[dat-refresh] ERROR: no DATs fetched — leaving existing set untouched"
-  rm -rf "$STAGE" "$TMP"; exit 1
+  rm -rf "$STAGE"; exit 1
 fi
 rm -f "$DEST"/*.dat 2>/dev/null || true
 mv -f "$STAGE"/*.dat "$DEST/" 2>/dev/null || true
-rm -rf "$STAGE" "$TMP"
+rm -rf "$STAGE"
 
 total=$(find "$DEST" -maxdepth 1 -name '*.dat' | wc -l)
 echo "[dat-refresh] done — ${total} DAT(s) available in ${DEST}"


### PR DESCRIPTION
Follow-up to #2332.

- **dat-refresh**: replaced `cd "$TMP"` with `git -C "$TMP"` so the later `rm -rf "$TMP"` can't delete the shell's CWD mid-run (that aborted the PureDOS/DOS fetch). Libretro DATs (112) already land fine; this restores the DOS source.
- **externalsecret**: `index . "DISCORD_WEBHOOK_ROMGATE" | default ""` so the sync succeeds when that optional 1Password field isn't set yet (ESO templating is strict on missing keys).

Validated: kubeconform clean, `sh -n` clean.