### PR TITLE
fix(downloads): make rom-ingest scripts brace-free for Flux substitution

### DIFF
--- a/kubernetes/apps/downloads/rom-ingest/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/rom-ingest/app/helmrelease.yaml
@@ -45,8 +45,12 @@ spec:
               HOME: /tmp
               # Sources (see dat-refresh.sh): libretro metadat/* = cart+disc DATs,
               # PureDOS = DOS games. All git repos, so refresh stays automatic.
+              # Scripts are brace-free, so every var must be defined here.
+              LIBRETRO_REPO: "https://github.com/libretro/libretro-database.git"
               LIBRETRO_SUBDIRS: "metadat/no-intro metadat/redump"
               DOS_ENABLED: "true"
+              DOS_REPO: "https://github.com/PureDOS/DAT.git"
+              DOS_FILES: "PureDOSDAT.xml"
             resources:
               requests:
                 cpu: 25m

--- a/kubernetes/apps/downloads/rom-ingest/app/resources/dat-refresh.sh
+++ b/kubernetes/apps/downloads/rom-ingest/app/resources/dat-refresh.sh
@@ -4,28 +4,23 @@
 # ingest gate always validates against current data. Two sources:
 #   1. libretro-database  metadat/{no-intro,redump}  — cart + optical DATs
 #   2. PureDOS/DAT        PureDOSDAT.xml              — DOS games (DOSBox-Pure)
-# All sources are git repos so this stays fully automatic. igir parses Logiqx
-# and clrmamepro regardless of file extension; PureDOS's .xml is copied as .dat.
+#
+# IMPORTANT: this script is intentionally BRACE-FREE (use $VAR, not the
+# dollar-brace form). Flux post-build substitution rewrites dollar-brace
+# tokens inside the ConfigMap and would blank our shell variables. All config
+# comes from the HelmRelease env.
 set -u
 
-DEST="/dats"
-TMP="/tmp/dat-src"
-STAGE="$DEST/.new"
-
-# --- source config (override via env) ------------------------------------
-LIBRETRO_REPO="${LIBRETRO_REPO:-https://github.com/libretro/libretro-database.git}"
-# metadat/* holds the real hash-bearing No-Intro/Redump DATs (not top-level dat/).
-LIBRETRO_SUBDIRS="${LIBRETRO_SUBDIRS:-metadat/no-intro metadat/redump}"
-DOS_ENABLED="${DOS_ENABLED:-true}"
-DOS_REPO="${DOS_REPO:-https://github.com/PureDOS/DAT.git}"
-DOS_FILES="${DOS_FILES:-PureDOSDAT.xml}"
+DEST=/dats
+TMP=/tmp/dat-src
+STAGE=$DEST/.new
 
 mkdir -p "$DEST"
 rm -rf "$STAGE"; mkdir -p "$STAGE"
 
 # --- source 1: libretro (sparse dirs). Use `git -C` — never cd into $TMP,
 #     so a later `rm -rf $TMP` can't pull the shell's CWD out from under it.
-echo "[dat-refresh] libretro: ${LIBRETRO_REPO} (${LIBRETRO_SUBDIRS})"
+echo "[dat-refresh] libretro: $LIBRETRO_REPO ($LIBRETRO_SUBDIRS)"
 rm -rf "$TMP"
 if git clone --depth 1 --no-checkout --filter=tree:0 "$LIBRETRO_REPO" "$TMP" \
   && git -C "$TMP" sparse-checkout init --cone \
@@ -42,13 +37,13 @@ rm -rf "$TMP"
 
 # --- source 2: PureDOS (root files, copied as .dat) ----------------------
 if [ "$DOS_ENABLED" = "true" ]; then
-  echo "[dat-refresh] PureDOS: ${DOS_REPO} (${DOS_FILES})"
+  echo "[dat-refresh] PureDOS: $DOS_REPO ($DOS_FILES)"
   rm -rf "$TMP"
   if git clone --depth 1 "$DOS_REPO" "$TMP"; then
     for f in $DOS_FILES; do
       if [ -f "$TMP/$f" ]; then
         base=$(basename "$f" | sed 's/\.[Xx][Mm][Ll]$//')
-        cp -f "$TMP/$f" "$STAGE/${base}.dat"
+        cp -f "$TMP/$f" "$STAGE/$base.dat"
       else
         echo "[dat-refresh] WARN: PureDOS file '$f' not found"
       fi
@@ -61,7 +56,7 @@ fi
 
 # --- swap staged DATs into place -----------------------------------------
 found=$(find "$STAGE" -name '*.dat' | wc -l)
-echo "[dat-refresh] staged ${found} DAT(s)"
+echo "[dat-refresh] staged $found DAT(s)"
 if [ "$found" -eq 0 ]; then
   echo "[dat-refresh] ERROR: no DATs fetched — leaving existing set untouched"
   rm -rf "$STAGE"; exit 1
@@ -71,4 +66,4 @@ mv -f "$STAGE"/*.dat "$DEST/" 2>/dev/null || true
 rm -rf "$STAGE"
 
 total=$(find "$DEST" -maxdepth 1 -name '*.dat' | wc -l)
-echo "[dat-refresh] done — ${total} DAT(s) available in ${DEST}"
+echo "[dat-refresh] done — $total DAT(s) available in $DEST"

--- a/kubernetes/apps/downloads/rom-ingest/app/resources/ingest.sh
+++ b/kubernetes/apps/downloads/rom-ingest/app/resources/ingest.sh
@@ -6,14 +6,16 @@
 # promoted files automatically.
 set -u
 
-IGIR_VERSION="${IGIR_VERSION:-5.3.0}"
-DATS_GLOB="/dats/**/*.dat"
+# BRACE-FREE (use $VAR, not the dollar-brace form): Flux post-build
+# substitution rewrites dollar-brace tokens inside the ConfigMap.
+# IGIR_VERSION/DISCORD_WEBHOOK come from env.
+DATS_GLOB="/dats/*.dat"
 LIBRARY="/media/Library/Emulation/roms"
 BASE="/media/Downloads/rom-ingest"
 WORK="$BASE/work"
 QUARANTINE="$BASE/quarantine"
 STAGING="/media/Downloads/sabnzbd/complete/roms /media/Downloads/qbittorrent/complete/roms"
-WEBHOOK="${DISCORD_WEBHOOK:-}"
+WEBHOOK="$DISCORD_WEBHOOK"
 
 log() { echo "[rom-ingest] $*"; }
 
@@ -47,11 +49,11 @@ if [ -z "$INPUTS" ]; then
 fi
 
 # --- validate + move matched ROMs into WORK, organised by DAT name -------
-log "validating staged ROMs against DATs (igir ${IGIR_VERSION})..."
+log "validating staged ROMs against DATs (igir $IGIR_VERSION)..."
 # igir moves recognised ROMs to --output (extracting them from any archive);
 # anything it does not recognise is left in the input dirs (swept to
 # quarantine below).
-npx --yes "igir@${IGIR_VERSION}" move extract report \
+npx --yes "igir@$IGIR_VERSION" move extract report \
   --dat "$DATS_GLOB" \
   $INPUTS \
   --output "$WORK" \
@@ -98,12 +100,12 @@ for sysdir in "$WORK"/*/; do
     mkdir -p "$LIBRARY/$slug"
     find "$sysdir" -mindepth 1 -maxdepth 1 -exec mv -f {} "$LIBRARY/$slug/" \; 2>/dev/null || true
     promoted=$((promoted + n))
-    log "promoted ${n} file(s): ${name} -> roms/${slug}"
+    log "promoted $n file(s): $name -> roms/$slug"
   else
     mkdir -p "$QUARANTINE/_unmapped/$name"
     find "$sysdir" -mindepth 1 -maxdepth 1 -exec mv -f {} "$QUARANTINE/_unmapped/$name/" \; 2>/dev/null || true
     unmapped=$((unmapped + n))
-    log "no slug mapping for '${name}' -> quarantine/_unmapped (${n} file(s))"
+    log "no slug mapping for '$name' -> quarantine/_unmapped ($n file(s))"
   fi
   rmdir "$sysdir" 2>/dev/null || true
 done
@@ -119,7 +121,7 @@ for d in $STAGING; do
 done
 unmatched=$(find "$QUARANTINE/_unmatched" -type f 2>/dev/null | wc -l)
 
-summary="ROM gate: promoted ${promoted}, unmapped ${unmapped}, quarantined(unmatched) ${unmatched}"
+summary="ROM gate: promoted $promoted, unmapped $unmapped, quarantined(unmatched) $unmatched"
 log "$summary"
 if [ "$promoted" -gt 0 ] || [ "$unmapped" -gt 0 ] || [ "$unmatched" -gt 0 ]; then
   notify "$summary"


### PR DESCRIPTION
Follow-up to #2332/#2333.

**Root cause:** Flux post-build variable substitution rewrites `${...}` tokens *inside the ConfigMap-embedded scripts*, blanking shell variables. Bare `$VAR` refs are untouched (that's why libretro DATs landed but the DOS basename `${base}` blanked → PureDOS silently dropped, and all log output showed empty).

**Fix:** every dollar-brace expansion → bare `$VAR`; all source config moved to HelmRelease env so nothing relies on shell defaults. Validated: no braces remain, `sh -n` clean, kubeconform clean.