### PR TITLE
fix(downloads): exclude digital-distribution DATs from rom-ingest

### DIFF
--- a/kubernetes/apps/downloads/rom-ingest/app/resources/dat-refresh.sh
+++ b/kubernetes/apps/downloads/rom-ingest/app/resources/dat-refresh.sh
@@ -54,6 +54,14 @@ if [ "$DOS_ENABLED" = "true" ]; then
   rm -rf "$TMP"
 fi
 
+# --- drop non-physical / digital-distribution DATs -----------------------
+# These describe multi-file digital packages and contain 0-byte and generic
+# component files with well-known hashes that false-match real ROMs (e.g. a
+# 0-byte .ARC matching a PSN DLC entry). No use for a physical-dump gate.
+for pat in '(PSN)' '(PSX2PSP)' '(UMD Music)' '(UMD Video)' '(Download Play)' '(Digital)' '(Games on Demand)' '(Title Updates)'; do
+  find "$STAGE" -name "*$pat*.dat" -type f -delete 2>/dev/null || true
+done
+
 # --- swap staged DATs into place -----------------------------------------
 found=$(find "$STAGE" -name '*.dat' | wc -l)
 echo "[dat-refresh] staged $found DAT(s)"


### PR DESCRIPTION
Follow-up to #2336.

**Found during the first live promotion:** validating 6 clean SNES ROMs, the gate *also* wrote 2 junk files into `roms/psp` — a 0-byte `.ARC` that matched a PSN 'Ghost Data DLC' entry and a `DOCUMENT.DAT` that matched a PSX2PSP entry. No-Intro's digital-distribution DATs contain 0-byte/generic component files with well-known hashes that false-match anything.

**Fix:** `dat-refresh` drops these non-physical DATs after fetch (PSN, PSX2PSP, UMD Music/Video, Download Play, Digital, Games on Demand, Title Updates). Junk already cleaned from the library.

Validated: `sh -n` + kubeconform clean.