### PR TITLE
feat(games): add livingdex National Living Dex tracker

### DIFF
--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   # - ./dune-awakening/ks.yaml   # SHELVED — manifests kept under ./dune-awakening/;
   #   re-add this line to redeploy. Operator-free hit the FLS battlegroup-registration
   #   wall; images remain in zot. See dune-awakening/PORT-NOTES.md + memory.
+  - ./livingdex/ks.yaml
   - ./pelican/ks.yaml
   - ./pelican-dev/ks.yaml
   - ./romm/ks.yaml

--- a/kubernetes/apps/games/livingdex/app/externalsecret.yaml
+++ b/kubernetes/apps/games/livingdex/app/externalsecret.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: livingdex
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: livingdex-secret
+    template:
+      engineVersion: v2
+      data:
+        # App + seed connect through the shared cluster's pgbouncer pooler.
+        DATABASE_URL: >-
+          postgres://{{ .LIVINGDEX_POSTGRES_USER }}:{{ .LIVINGDEX_POSTGRES_PASSWORD }}@postgres18-cluster-pooler.database.svc.cluster.local:5432/livingdex
+        # postgres-init (initContainer) bootstraps the role + database against
+        # the primary, using the shared cluster's superuser password.
+        INIT_POSTGRES_DBNAME: livingdex
+        INIT_POSTGRES_HOST: postgres18-cluster-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .LIVINGDEX_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .LIVINGDEX_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    # 1Password item `livingdex` must provide: LIVINGDEX_POSTGRES_USER,
+    # LIVINGDEX_POSTGRES_PASSWORD (use a URL-safe password — it is embedded in
+    # DATABASE_URL). `cloudnative-pg` provides POSTGRES_SUPER_PASS.
+    - extract:
+        key: livingdex
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -1,0 +1,209 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: livingdex
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    controllers:
+      # ---- API (Hono) -------------------------------------------------------
+      api:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Creates the `livingdex` role + database in the shared cluster before
+          # the API starts (which then runs its own migrations on boot).
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6.0@sha256:86a1992d46273c58fd4ad95b626081dfaabfe16bd56944675169e406d1a660dd
+            envFrom: &envFrom
+              - secretRef:
+                  name: livingdex-secret
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gavinmcfall/livingdex-api
+              tag: 704f144ac8061f6b27020b8feba7593e839bd2b4
+            env:
+              PORT: "8080"
+            envFrom: *envFrom
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /healthz, port: 8080 }
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /readyz, port: 8080 }
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /healthz, port: 8080 }
+                  initialDelaySeconds: 3
+                  periodSeconds: 3
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+      # ---- Web (nginx static SPA + /api proxy) ------------------------------
+      web:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # Stock nginx binds :80 and writes its pid/cache/templated conf at
+        # runtime, so this controller runs as root with a writable rootfs. The
+        # `games` namespace is pod-security: privileged, so this is permitted.
+        # Hardening follow-up: switch the web image to unprivileged nginx (:8080).
+        pod:
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            fsGroup: 0
+            seccompProfile: { type: RuntimeDefault }
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gavinmcfall/livingdex-web
+              tag: 704f144ac8061f6b27020b8feba7593e839bd2b4
+            env:
+              API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /healthz, port: 80 }
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /healthz, port: 80 }
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+                add: ["CHOWN", "SETGID", "SETUID", "NET_BIND_SERVICE", "DAC_OVERRIDE"]
+
+      # ---- Seed (weekly catalogue refresh from PokéAPI) ---------------------
+      seed:
+        type: cronjob
+        cronjob:
+          schedule: "0 3 * * 1" # Monday 03:00 — picks up new species/forms/games
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gavinmcfall/livingdex-api
+              tag: 704f144ac8061f6b27020b8feba7593e839bd2b4
+            command: ["node", "dist/seed/run.js"]
+            env:
+              SEED_TIER: full
+              SEED_CACHE_DIR: /cache
+              SEED_CONCURRENCY: "8"
+            envFrom: *envFrom
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      api:
+        controller: api
+        ports:
+          http:
+            port: 8080
+      web:
+        controller: web
+        ports:
+          http:
+            port: 80
+
+    persistence:
+      # readOnlyRootFilesystem needs writable scratch; the seed also caches
+      # PokéAPI responses here (ephemeral per run — no PVC for v1).
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          api:
+            app:
+              - path: /tmp
+          seed:
+            app:
+              - path: /tmp
+      cache:
+        type: emptyDir
+        advancedMounts:
+          seed:
+            app:
+              - path: /cache

--- a/kubernetes/apps/games/livingdex/app/httproute.yaml
+++ b/kubernetes/apps/games/livingdex/app/httproute.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: livingdex
+  annotations:
+    external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+spec:
+  # LAN-only: the app has no auth (single-owner v1). Everything goes to the web
+  # (nginx) service, which proxies /api to livingdex-api internally (one origin,
+  # no CORS). Switch parentRefs to the `external` gateway to publish it.
+  hostnames:
+    - livingdex.${SECRET_DOMAIN}
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: livingdex-web
+          port: 80

--- a/kubernetes/apps/games/livingdex/app/kustomization.yaml
+++ b/kubernetes/apps/games/livingdex/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/games/livingdex/ks.yaml
+++ b/kubernetes/apps/games/livingdex/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app livingdex
+  namespace: &namespace games
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/games/livingdex/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_PATH: /healthz
+      GATUS_STATUS: "200"


### PR DESCRIPTION
Deploys the **livingdex** app (from [gavinmcfall/pokemon-tracker](https://github.com/gavinmcfall/pokemon-tracker), PR #1 merged) into the `games` namespace, following the `romm`/`mempalace` conventions.

## What's here

`kubernetes/apps/games/livingdex/`
- **`ks.yaml`** — Flux Kustomization, `dependsOn` external-secrets-stores.
- **`app/externalsecret.yaml`** — `onepassword-connect`; builds `DATABASE_URL` (shared cluster's pgbouncer pooler) + `INIT_POSTGRES_*` for bootstrap.
- **`app/helmrelease.yaml`** — app-template 4.4.0, three controllers:
  - **api** (`ghcr.io/gavinmcfall/livingdex-api`) — Hono; migrates on boot; `/healthz`+`/readyz` probes; a `postgres-init` initContainer creates the role + DB in `postgres18-cluster`.
  - **web** (`ghcr.io/gavinmcfall/livingdex-web`) — nginx static SPA; proxies `/api` → `livingdex-api` (one origin, no CORS).
  - **seed** — weekly `CronJob` (Mon 03:00), full-tier catalogue refresh from PokéAPI.
- **`app/httproute.yaml`** — **internal** gateway, `livingdex.${SECRET_DOMAIN}` (LAN-only — the app is single-owner with no auth).
- Registered in `kubernetes/apps/games/kustomization.yaml`.

Images are pinned to the merge-commit sha tag `704f144…` (already built + pushed by pokemon-tracker CI).

## Operator steps before this will go healthy

1. **Create the 1Password item `livingdex`** with fields:
   - `LIVINGDEX_POSTGRES_USER` (e.g. `livingdex`)
   - `LIVINGDEX_POSTGRES_PASSWORD` — **use a URL-safe password**, it's embedded in `DATABASE_URL`.
   (The `cloudnative-pg` item already provides `POSTGRES_SUPER_PASS`.)
2. **Make the GHCR packages public** — `ghcr.io/gavinmcfall/livingdex-api` and `livingdex-web` (same as `mempalace`/`lighthouse`; no pull secret is wired). Otherwise: `ImagePullBackOff`.
3. **Initial catalogue seed** — the CronJob is weekly; for the first load, once the api is up:
   ```
   kubectl -n games create job --from=cronjob/livingdex-seed livingdex-seed-init
   kubectl -n games logs -f job/livingdex-seed-init
   ```
   (~1025 species → ~2675 entries, a few minutes.)
4. Browse `https://livingdex.${SECRET_DOMAIN}` and import your existing sheet via the UI's **Import** button.

## Notes / follow-ups

- **web runs as root** with a writable rootfs (stock nginx binds `:80`, templates its conf at runtime). The `games` namespace is pod-security `privileged`, so this is allowed. Hardening follow-up: switch the web image to unprivileged nginx on `:8080` (planned alongside the sprite-mirror change).
- Seed cache is an `emptyDir` (ephemeral per run) — no PVC/volsync for v1. Weekly re-fetch stays within PokéAPI etiquette (concurrency ≤ 8, backoff).
- To publish externally instead of LAN-only, switch `httproute.yaml` `parentRefs` to the `external` gateway — but the app has no auth, so internal is the safer default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_