### PR TITLE
fix(livingdex): use internal-dns annotation for LAN route

### DIFF
--- a/kubernetes/apps/games/livingdex/app/httproute.yaml
+++ b/kubernetes/apps/games/livingdex/app/httproute.yaml
@@ -5,7 +5,11 @@ kind: HTTPRoute
 metadata:
   name: livingdex
   annotations:
-    external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+    # internal-dns (UniFi/LAN) — NOT external-dns (Cloudflare). Using the
+    # external-dns key here publishes a proxied public CNAME to the
+    # non-resolvable internal origin → Cloudflare 1016. LAN-only, matching
+    # weave-gitops / blackbox-exporter.
+    internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
 spec:
   # LAN-only: the app has no auth (single-owner v1). Everything goes to the web
   # (nginx) service, which proxies /api to livingdex-api internally (one origin,


### PR DESCRIPTION
Follow-up to #2353 (already merged), so this is a fresh PR rather than a reopen.

## Problem
`livingdex.nerdz.cloud` returned **Cloudflare Error 1016 (Origin DNS error)**. The HTTPRoute used `external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}`. The Cloudflare external-dns instance matches that annotation key (`--annotation-filter=external-dns.alpha.kubernetes.io/target`) and runs `--cloudflare-proxied`, so it published a **proxied public CNAME → internal.nerdz.cloud** — an origin Cloudflare can't resolve publicly → 1016.

## Fix
Switch to `internal-dns.alpha.kubernetes.io/target`, which the UniFi (LAN) external-dns consumes — matching `weave-gitops` and `blackbox-exporter`. livingdex stays LAN-only (no auth on the app), reachable via UniFi split-horizon DNS on-network.

One-line annotation change (plus an explanatory comment).

## After merge
- Flux reconciles; the UniFi external-dns creates the LAN record.
- External-dns `policy: sync` should remove the stale Cloudflare `livingdex` record automatically now that it no longer matches the Cloudflare filter — verify in the dashboard and delete manually if it lingers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_