### PR TITLE
fix(livingdex): RWX sprite PVC + RollingUpdate (drop broken Recreate)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -34,9 +34,10 @@ spec:
     controllers:
       # ---- API (Hono) -------------------------------------------------------
       api:
-        # Recreate, not RollingUpdate: the api owns the RWO sprite PVC, so the
-        # old pod must release it before the new one mounts.
-        strategy: Recreate
+        # RollingUpdate is fine because the sprite PVC is ReadWriteMany (CephFS)
+        # — a rolling update's brief two-pod overlap can share it. (Recreate is
+        # avoided: app-template 4.4.0 emits an invalid rollingUpdate block with it.)
+        strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
@@ -208,11 +209,12 @@ spec:
               - path: /cache
       # Offline sprite mirror target — populated on demand via the UI "Mirror"
       # button (POST /api/sprites/mirror). Re-fetchable, so no volsync backup.
+      # ReadWriteMany (CephFS) so the api can roll without a volume hand-off stall.
       sprites:
         type: persistentVolumeClaim
-        accessMode: ReadWriteOnce
+        accessMode: ReadWriteMany
         size: 2Gi
-        storageClass: ceph-block
+        storageClass: ceph-filesystem
         advancedMounts:
           api:
             app:


### PR DESCRIPTION
Fixes the failed rollout from #2355.

## Root cause
The api Deployment used `strategy: Recreate`, but **app-template 4.4.0 renders an invalid `rollingUpdate` block alongside `type: Recreate`**:

```
Helm upgrade failed: Deployment.apps "livingdex-api" is invalid:
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy type is 'Recreate'
```

So every upgrade attempt failed and Helm rolled back (3×) — the new pods appeared for a second and vanished while the old release kept serving. Images and the PVC provisioning were all fine.

## Fix
`Recreate` was only there to hand the **RWO** sprite volume between pods on a rolling update. Instead, make the sprite PVC **ReadWriteMany (`ceph-filesystem`)** — a rolling update's brief two-pod overlap can share it — and keep the normal `RollingUpdate` strategy. No Recreate, no chart quirk.

## One manual step before/at reconcile
The previous release provisioned an **RWO `ceph-block`** PVC, and a bound PVC's storageClass/accessMode are immutable — so the old one must be removed before the RWX one can be created. It's empty (the mirror never ran), so this is safe:

```bash
kubectl -n games get pvc                      # find the livingdex sprite PVC (named "livingdex")
kubectl -n games delete pvc livingdex          # safe: empty, mirror never ran
flux reconcile kustomization livingdex -n games --with-source
```

Then verify:
```bash
kubectl -n games get pods -l app.kubernetes.io/name=livingdex   # api + web Running/Ready
flux get hr -n games livingdex                                   # READY=True
```

Once green, click **Mirror** in the header to populate the sprites (~1500, a couple minutes). Idempotent afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_