### PR TITLE
fix(livingdex): bump api image to f7af80f (sprite-serve crash fix)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 07d10ecb80e0ad5c761f64dc5205fbb02616cc05
+              tag: f7af80f504ce6c7fbf4cc5e6f2a8d93e7d5eb679
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 07d10ecb80e0ad5c761f64dc5205fbb02616cc05
+              tag: f7af80f504ce6c7fbf4cc5e6f2a8d93e7d5eb679
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full


### PR DESCRIPTION
Deploys the api crash fix from [pokemon-tracker#3](https://github.com/gavinmcfall/pokemon-tracker/pull/3) (merged, image built + pushed by CI).

## Why
The api was CrashLoopBackOff-ing after the sprite mirror populated: serving a mirrored sprite handed a Node `fs` stream to the HTTP layer, which threw `ERR_INVALID_STATE` in a microtask (uncatchable) and crashed the process whenever a client aborted an `<img>` request mid-flight — routine with hundreds of lazy-loaded tiles. The fix serves sprite bytes directly (no stream).

## Change
Bumps the **api + seed** image tag `07d10ec → f7af80f`. **web is unchanged** (that PR only touched api code), so it stays on `07d10ec`.

## After merge
Flux reconciles and the api rolls to the fixed image; the crashloop stops and mirrored sprites serve cleanly. RollingUpdate + the RWX sprite PVC (from #2356) means no volume hand-off stall.

```bash
flux reconcile kustomization livingdex -n games --with-source
kubectl -n games get pods -l app.kubernetes.io/name=livingdex   # api Running/Ready, no restarts climbing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_