### PR TITLE
feat(livingdex): bump web image to 953785d (detail sheet + obtainability)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 07d10ecb80e0ad5c761f64dc5205fbb02616cc05
+              tag: 953785d6f676b2d7a411cf1788b127b657bf122a
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:


### PR DESCRIPTION
Deploys the v2 front-end from [pokemon-tracker#4](https://github.com/gavinmcfall/pokemon-tracker/pull/4) (merged; `livingdex-web:953785d` built + pushed by CI).

## What ships
The per-entry **detail sheet** — a `⋯`/long-press opens a **My Catch** editor (caught toggle + Game / Method / Notes, saved via `POST /api/status`). The **obtainability** zone + filters are present but stay hidden until the API returns enrichment fields, so nothing changes there yet.

## Change
Web-only: **livingdex-web** `07d10ec → 953785d`. The api + seed image is unchanged (that PR only touched `web/public/`), so they stay on `f7af80f`.

## After merge
Flux reconciles and only the **web** pod rolls (nginx, quick). No api restart, no DB/schema/secret changes.

```bash
flux reconcile kustomization livingdex -n games --with-source
kubectl -n games get pods -l app.kubernetes.io/controller=web   # rolled to 953785d, Running
```
Then hard-refresh `livingdex.nerdz.cloud` and the `⋯` detail sheet is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_