### PR TITLE
fix(livingdex): bump api image to d444ec8 (Pichu/Genesect default slot + import dryRun)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: f7af80f504ce6c7fbf4cc5e6f2a8d93e7d5eb679
+              tag: d444ec82582a2e6f0ef7ad6854755ed02597693b
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: f7af80f504ce6c7fbf4cc5e6f2a8d93e7d5eb679
+              tag: d444ec82582a2e6f0ef7ad6854755ed02597693b
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full


### PR DESCRIPTION
Bumps livingdex api + seed image f7af80f -> d444ec8 (pokemon-tracker#5). Ships: seed fix (empty form_name among named siblings -> formSlug default, isCosmetic false) adding 0172-default (Pichu) + 0649-default-genderless (Genesect) which were mis-slugged cosmetic; plus import dryRun mode. Web unchanged. After merge: Flux deploys, then livingdex-seed CronJob must run to add the new default slots; then the HOME import re-runs (idempotent) to migrate Pichu 0172-pichu -> 0172-default and the 2 orphan slots are pruned via cascade DELETE (runbook).