### PR TITLE
feat(livingdex): bump api/web/seed to fff75e8 (HOME specimen enrichment)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: d444ec82582a2e6f0ef7ad6854755ed02597693b
+              tag: fff75e876d9458416a5b6e8be8a49a292c5c08cf
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 953785d6f676b2d7a411cf1788b127b657bf122a
+              tag: fff75e876d9458416a5b6e8be8a49a292c5c08cf
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: d444ec82582a2e6f0ef7ad6854755ed02597693b
+              tag: fff75e876d9458416a5b6e8be8a49a292c5c08cf
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full


### PR DESCRIPTION
Rolls livingdex onto pokemon-tracker#6 — HOME-derived per-mon enrichment.

## Change
`kubernetes/apps/games/livingdex/app/helmrelease.yaml` — three image tags → `fff75e876d9458416a5b6e8be8a49a292c5c08cf`:

| controller | image | from | to |
|---|---|---|---|
| api (app) | `livingdex-api` | `d444ec8` | `fff75e8` |
| web (app) | `livingdex-web` | `953785d` | `fff75e8` |
| seed | `livingdex-api` | `d444ec8` | `fff75e8` |

**Why web moves two versions:** it was never bumped by the #5 roll (that was api-only), so it's still the pre-specimen build at `953785d`. The shiny/event/6IV tile badges and the detail-sheet "Best Specimen" zone live in the web bundle, so it has to move for the UI to appear.

## What ships
- `specimen` table (migration `0002`, auto-applies on api boot) + FK cascade to `entries`
- `POST /api/specimens` full-sync ingest; `GET /api/entries` embeds `specimen`
- front-end: badges on caught tiles + Best Specimen detail zone (origin, IVs, Tera, ribbons, ball/nature, nickname/OT)

## Operational notes
- **No seed job, no SQL** — the catalogue is unchanged from the current deploy; only app code moves.
- Rolling update; sprite PVC is RWX CephFS so the api rolls without a volume hand-off stall (unchanged from prior rolls).
- After Flux reconciles `fff75e8`, the HOME importer POSTs its `specimens.json` to `/api/specimens` (replace-all) to populate the enrichment — data-plane step, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_