### PR TITLE
fix(secrets): remove stray space in UPS_CITADEL_PASSWORD key

### DIFF
--- a/kubernetes/flux/vars/cluster-secrets.sops.yaml
+++ b/kubernetes/flux/vars/cluster-secrets.sops.yaml
@@ -16,7 +16,7 @@ stringData:
     LONGITUDE: ENC[AES256_GCM,data:VAxHwY9il+ao,iv:dbpIuFaH5VFWGIRBbNhLmyd5gQCpsqeA6gyY5uFsUbk=,tag:YkbKxJBZ6ABagF0Ls/thvQ==,type:str]
     #ENC[AES256_GCM,data:qp9iHn3tAZHdb0BqySyWOYo4,iv:fwt1F6TLc8E4CkmjUx4ZRz9VjduB64vORPOxwGS8EM8=,tag:B9oQoZoZ9b+tnwb+CD8DDw==,type:comment]
     UPS_CITADEL_USERNAME: ENC[AES256_GCM,data:1pEiXHPA,iv:2XAEUt5Zr0L6wupVr2Iv4tWNl8OrV6tYEXWs5rIqt/Y=,tag:mSS78lo3IrxrvFAS/O+v2Q==,type:str]
-    UPS_CITADEL_PA SSWORD: ENC[AES256_GCM,data:RTXyiD0tf2/TUg==,iv:nnbwRZlE6O1yuPyIpakcdE93fr23TsjnmjfpsObXUBU=,tag:U9Y3pPmTcnWjTxhwdNW3OA==,type:str]
+    UPS_CITADEL_PASSWORD: ENC[AES256_GCM,data:RTXyiD0tf2/TUg==,iv:nnbwRZlE6O1yuPyIpakcdE93fr23TsjnmjfpsObXUBU=,tag:U9Y3pPmTcnWjTxhwdNW3OA==,type:str]
     #ENC[AES256_GCM,data:ig+8PvySttNGaQ==,iv:0YrH/w8y3LKHYLh609bUXCexqW8sSXpYaNTBSrHa6UE=,tag:wJJPZgqxjd1lOLgI7aKDDg==,type:comment]
     MINECRAFT_ADMIN: ENC[AES256_GCM,data:f2/tS9BNVwS5K04d7cOo08ljYfKG7pby,iv:+Xwp1ya4YpiB+sZ89u3F9J0F31rc3CfoGPjDAEdqX7E=,tag:8KJ4NLuGGnSHuLDV9MlSeg==,type:str]
     MINECRAFT_WHITELIST: ENC[AES256_GCM,data:aYOZrIjdSKDtcJ9DIkX1FVLYhY8bRZhu2+2wqQjOut4cTRe44cM0/YzPqwMj83lQTnUYP4FfAdvU4JodcQ==,iv:/v3vYoo9kiw1bm5yFbEu32xU0pZhgjL1q2r8Jvw/biM=,tag:z73HktWZZKXST736MR5rxg==,type:str]


### PR DESCRIPTION
## What

`kubernetes/flux/vars/cluster-secrets.sops.yaml` line 19 — the key name had a stray space: `UPS_CITADEL_PA SSWORD` → `UPS_CITADEL_PASSWORD`. One character; the encrypted value is untouched.

## Why it happened

`git blame` → commit `ab25e9c` ("chore(secrets): update cluster secrets"). Its diff for this file changed **only** that line, and the `ENC[...]` value is byte-for-byte identical before/after — so it was a pure key-name typo, not a secret rotation.

## Why it's safe to fix by hand (no `sops`/age key)

SOPS computes its MAC over the decrypted **values**, not key names. Evidence: the current (typo'd) file still **decrypts** — the failure surfaces only downstream at `envsubst` (`var name is invalid`), which runs *after* SOPS decryption succeeds. So renaming the key back leaves the MAC valid and the file decryptable. The diff is 1 line; the `sops.mac`/`lastmodified` footer is untouched.

## Impact

- **CI:** unblocks `Flux Local - Test` / `Flux Local - Success`, which were failing on **every** PR (the flux-local build runs `envsubst` over the whole cluster and chokes on the invalid var name — surfaced under `actions-runner-controller`, the only consumer of this var).
- **Cluster:** restores var substitution for `actions-runner-controller`. Worth a `flux get kustomization actions-runner-controller` after merge to confirm it recovers.

Unrelated to livingdex #2377 — that PR is independently mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_