### PR TITLE
feat(livingdex): bump api/web/seed to 67321ff (obtainability v1)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: fff75e876d9458416a5b6e8be8a49a292c5c08cf
+              tag: 67321ffd8826763d9544e7220318fb33324ae4ae
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: fff75e876d9458416a5b6e8be8a49a292c5c08cf
+              tag: 67321ffd8826763d9544e7220318fb33324ae4ae
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: fff75e876d9458416a5b6e8be8a49a292c5c08cf
+              tag: 67321ffd8826763d9544e7220318fb33324ae4ae
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full


### PR DESCRIPTION
Rolls livingdex onto pokemon-tracker#7 — catalogue-derived obtainability.

## Change
`kubernetes/apps/games/livingdex/app/helmrelease.yaml` — three image tags `fff75e8 → 67321ffd8826763d9544e7220318fb33324ae4ae`:

| controller | image | from → to |
|---|---|---|
| api (app) | `livingdex-api` | `fff75e8 → 67321ff` |
| web (app) | `livingdex-web` | `fff75e8 → 67321ff` |
| seed | `livingdex-api` | `fff75e8 → 67321ff` |

## What ships
Per-entry `obtainability` embedded in `GET /api/entries`: `availability[]` (wild encounters + evolution-chain derivation) plus `gmaxCapable`/`teraAvailable`/`catchableOnSwitch`/`shinyLegalSomewhere`/`shinyLockedIn`/`genderVisualDiff`. The front-end's Switch/Shiny/GMax/Tera filters + per-game availability chips light up from it (filters keep "unknown" entries rather than hiding on a guess). Both api and web move since the flatten-at-ingest + filter behaviour lives in web.

## Operational notes
- **Migration `0003`** (obtainability table) auto-applies on api boot — no SQL to run.
- **Data populates on the next seed run.** The weekly seed CronJob picks it up automatically; to see it immediately, trigger the seed job once after this rolls. The seed adds `/encounters` + `/evolution-chain` fetches per species (cached to `SEED_CACHE_DIR`, best-effort — a failed lookup can't fail the catalogue seed), so the first enriching run is a bit heavier than usual.
- No owner data touched (status/specimen untouched); the seed's `replaceObtainability` is a full-sync of catalogue-derived data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_