### PR TITLE
feat(livingdex): add pokeapi-mirror CronJob + bump api/seed to d5f0aac

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 67321ffd8826763d9544e7220318fb33324ae4ae
+              tag: d5f0aac459d5501c854c648249e931a91b3c9998
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -159,12 +159,40 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 67321ffd8826763d9544e7220318fb33324ae4ae
+              tag: d5f0aac459d5501c854c648249e931a91b3c9998
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
               SEED_CACHE_DIR: /cache
               SEED_CONCURRENCY: "8"
+            envFrom: *envFrom
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+      # ---- PokéAPI mirror (daily upstream-CSV sync into the `pokeapi` schema) --
+      mirror:
+        type: cronjob
+        cronjob:
+          schedule: "0 2 * * *" # daily 02:00 — no-ops unless the upstream CSVs changed
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gavinmcfall/livingdex-api
+              tag: d5f0aac459d5501c854c648249e931a91b3c9998
+            command: ["node", "dist/mirror/run.js"]
+            env:
+              MIRROR_SCHEMA: pokeapi
             envFrom: *envFrom
             resources:
               requests:
@@ -199,6 +227,9 @@ spec:
             app:
               - path: /tmp
           seed:
+            app:
+              - path: /tmp
+          mirror:
             app:
               - path: /tmp
       cache:


### PR DESCRIPTION
Deploys pokemon-tracker#8 — the self-syncing PokéAPI CSV mirror (obtainability v2's data foundation).

## Change
`kubernetes/apps/games/livingdex/app/helmrelease.yaml`:

- **New `mirror` cronjob controller** — daily 02:00, api image, `node dist/mirror/run.js`, `MIRROR_SCHEMA=pokeapi`, `envFrom livingdex-secret`, `/tmp` scratch mount. It **self-skips** when the upstream CSV commit is unchanged (so most nights it does nothing); on a game/DLC release it reloads every PokéAPI CSV into the `pokeapi` schema in one transaction.
- **Image bump** `67321ff → d5f0aac`:

| controller | image | tag |
|---|---|---|
| api (app) | `livingdex-api` | → `d5f0aac` |
| seed | `livingdex-api` | → `d5f0aac` |
| **mirror** (new) | `livingdex-api` | `d5f0aac` |
| web (app) | `livingdex-web` | `67321ff` (unchanged — #8 was backend-only) |

## Operational notes
- Creates the `pokeapi` schema **inside the existing livingdex database** (the `livingdex` role owns its DB, so it can create schemas) — **no new infra, no new secret**.
- **Nothing consumes the mirror yet** — this just populates `pokeapi.*` tables. pokemon-tracker Phase 2 rewrites the seed to source obtainability from them.
- To populate immediately after this rolls (instead of waiting for 02:00), trigger it once:
  ```bash
  kubectl -n games create job pokeapi-mirror-manual --from=cronjob/livingdex-mirror
  ```
  First run loads the full dataset; subsequent runs no-op until upstream changes. Needs egress to `api.github.com` + `raw.githubusercontent.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_