### PR TITLE
feat(livingdex): bump api/seed/mirror to 8fd8a74 (obtainability v2)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: d5f0aac459d5501c854c648249e931a91b3c9998
+              tag: 8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: d5f0aac459d5501c854c648249e931a91b3c9998
+              tag: 8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: d5f0aac459d5501c854c648249e931a91b3c9998
+              tag: 8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
## Summary

Bumps the livingdex `api`, `seed`, and `mirror` controllers to `8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b` (obtainability v2, merged as pokemon-tracker #9). The `web` image is unchanged.

This ships **obtainability sourced from the local PokéAPI mirror** via pokédex membership (the accurate per-game regional-dex signal), replacing the earlier per-species encounter/evolution HTTP fetches. On the full mirror this yields availability for 1022/1025 species (99.7%); the remaining three (Diancie/Hoopa/Volcanion) are Gen-6 event-only mythicals with no game-specific regional dex — correctly left "unknown" rather than guessed.

### Image tags
| controller | old | new |
| --- | --- | --- |
| api | `8fd8a74…` (was pre-v2) | `8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b` |
| seed | ↑ | `8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b` |
| mirror | ↑ | `8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b` |
| web | `67321ff…` | unchanged |

CI for `8fd8a74` is green on `main` — the image is published to ghcr.

## Post-merge ops
Once Flux reconciles, repopulate obtainability by running the mirror first, then the seed:

```
kubectl -n games create job pokeapi-mirror-manual --from=cronjob/livingdex-mirror
# wait for it to complete, then:
kubectl -n games create job livingdex-seed-manual  --from=cronjob/livingdex-seed
```

The mirror job no-ops if the upstream CSVs are unchanged; the seed reads pokédex membership from the `pokeapi` schema to compute obtainability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_