### PR TITLE
fix(rook-ceph): raise mgr memory limit 2500Mi -> 4Gi

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -84,7 +84,7 @@ spec:
             cpu: 100m
             memory: 1Gi
           limits:
-            memory: 2500Mi
+            memory: 4Gi
         mon:
           requests:
             cpu: 50m


### PR DESCRIPTION
## Why

The active Ceph `mgr` daemon (`rook-ceph-mgr-b`) was **OOMKilled** on 08 Jul after ~37 days uptime, brushing its `2500Mi` memory limit. Standby `mgr-a` took over and `mgr-b` recovered — Ceph stayed `HEALTH_OK` throughout — but this is the well-known slow mgr memory creep (prometheus / progress / pg_autoscaler modules) and recurs roughly every 6 weeks.

At the time of writing the active mgr is already back to ~1.18Gi at 7 days uptime and climbing.

## Change

`resources.mgr.limits.memory`: `2500Mi` -> `4Gi`

Request stays at 1Gi. Plenty of node headroom — OSD limit is already 8Gi and mon 2Gi on the same control-plane nodes.

## Verification
- `kubeconform` clean (HelmRelease CRD schema skipped as expected)
- Ceph currently `HEALTH_OK`, 3/3 OSDs up+in, 169/169 PGs active+clean