### PR TITLE
fix(plex): expand config PVC 40Gi -> 60Gi

### DIFF
--- a/kubernetes/apps/entertainment/plex/ks.yaml
+++ b/kubernetes/apps/entertainment/plex/ks.yaml
@@ -29,7 +29,7 @@ spec:
     substitute:
       APP: *app
       GATUS_PATH: /web/index.html
-      VOLSYNC_CAPACITY: 40Gi
+      VOLSYNC_CAPACITY: 60Gi
       VOLSYNC_MINUTE: "23"
       VOLSYNC_B2_MINUTE: "46"
 ---


### PR DESCRIPTION
## Why

The Plex **config** PVC (`plex`, ceph-block) hit **~97% full** and fired `KubePersistentVolumeFillingUp` (critical, 2.987% free) on 15 Jul.

Usage breakdown (of 39G used): Metadata 19G, databases ~9G, Media 8.8G — all legit and growing with the library. 40Gi is simply undersized now. (Separately, ~4.8G of stale Plex DB backups were pruned in-pod to clear the immediate critical, bringing it to ~86% — this PR is the durable fix.)

## Change

`VOLSYNC_CAPACITY`: `40Gi` -> `60Gi`

- ceph-block has `allowVolumeExpansion: true` → online, in-place expansion, no downtime.
- Ceph pool has **4.4 TiB free**.

## Verification
- `kubeconform` clean (Flux Kustomization CRDs skipped as expected)

## Follow-up (not in this PR)
The VolSync destination PVC (`volsync-plex-dst-dest`) is 30Gi — smaller than the source. Worth aligning to avoid a restore-size mismatch, but tracked separately.