### PR TITLE
feat(livingdex): bump api/web/seed/mirror to d5ffc08 (game ownership)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b
+              tag: d5ffc08d6fe7a729853b8549b279af2d4264ba23
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 67321ffd8826763d9544e7220318fb33324ae4ae
+              tag: d5ffc08d6fe7a729853b8549b279af2d4264ba23
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b
+              tag: d5ffc08d6fe7a729853b8549b279af2d4264ba23
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 8fd8a74ce0dcdb93ebc7c2659e63fc7df0461f4b
+              tag: d5ffc08d6fe7a729853b8549b279af2d4264ba23
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
## Summary

Bumps **all four** livingdex controllers — `api`, `web`, `seed`, `mirror` — to `d5ffc08d6fe7a729853b8549b279af2d4264ba23` (pokemon-tracker #10, Phase 3: per-game ownership tracking).

This phase touches both sides of the app:
- **api** — new `GET /api/games` + `POST /api/ownership` endpoints and migration `0004_game_ownership` (auto-applied on boot).
- **web** — the **"My Games"** modal (track which games you own via cartridge/emulator/romhack) and the **"in a game I own"** obtainability signal.

So unlike the last few bumps (which left `web` alone), this one moves the web image too — the first `web` bump since the obtainability front-end work.

### Image tags
| controller | old | new |
| --- | --- | --- |
| api | `8fd8a74…` | `d5ffc08d6fe7a729853b8549b279af2d4264ba23` |
| web | `67321ff…` | `d5ffc08d6fe7a729853b8549b279af2d4264ba23` |
| seed | `8fd8a74…` | `d5ffc08d6fe7a729853b8549b279af2d4264ba23` |
| mirror | `8fd8a74…` | `d5ffc08d6fe7a729853b8549b279af2d4264ba23` |

CI on `main` for `d5ffc08` is fully green — both `livingdex-api` and `livingdex-web` images built and pushed to ghcr.

## Notes
- No schema/secret changes beyond the app's own migration (applied by the api on boot).
- No manual jobs needed for this feature — game ownership is written live via the UI. (The earlier obtainability repopulate — `pokeapi-mirror` then `livingdex-seed` — is independent and already handled.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_