### PR TITLE
feat(livingdex): bump api/web/seed/mirror to a74add2 (per-release game list)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: d5ffc08d6fe7a729853b8549b279af2d4264ba23
+              tag: a74add2abb70aeaa45fa22a0dd5d2610882e6115
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: d5ffc08d6fe7a729853b8549b279af2d4264ba23
+              tag: a74add2abb70aeaa45fa22a0dd5d2610882e6115
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: d5ffc08d6fe7a729853b8549b279af2d4264ba23
+              tag: a74add2abb70aeaa45fa22a0dd5d2610882e6115
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: d5ffc08d6fe7a729853b8549b279af2d4264ba23
+              tag: a74add2abb70aeaa45fa22a0dd5d2610882e6115
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
## Summary

Bumps all four livingdex controllers — `api`, `web`, `seed`, `mirror` — to `a74add2abb70aeaa45fa22a0dd5d2610882e6115` (pokemon-tracker #11).

That change makes the **"My Games"** list track **individual releases** — Red and Blue are separate cartridges/ROMs, not a collated "Red/Blue". It touches:
- **api** — `GET /api/games` now returns the per-release list (each with its `versionGroup`), and `POST /api/ownership` validates against release slugs (e.g. `red`).
- **web** — the My Games modal lists individual releases.

Obtainability availability is unchanged (still version-group level); owning either half of a pair lights up that group's availability. No schema change (the earlier `0004_game_ownership` migration is unaffected — `game_id` now just holds a release slug).

### Image tags
| controller | old | new |
| --- | --- | --- |
| api | `d5ffc08…` | `a74add2abb70aeaa45fa22a0dd5d2610882e6115` |
| web | `d5ffc08…` | `a74add2abb70aeaa45fa22a0dd5d2610882e6115` |
| seed | `d5ffc08…` | `a74add2abb70aeaa45fa22a0dd5d2610882e6115` |
| mirror | `d5ffc08…` | `a74add2abb70aeaa45fa22a0dd5d2610882e6115` |

CI on `main` for `a74add2` is fully green — both `livingdex-api` and `livingdex-web` images built and pushed to ghcr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_