### PR TITLE
fix(volsync): decouple mover cache size from app PVC capacity

### DIFF
--- a/kubernetes/components/volsync/nfs-truenas-relaxed/replicationsource.yaml
+++ b/kubernetes/components/volsync/nfs-truenas-relaxed/replicationsource.yaml
@@ -13,7 +13,7 @@ spec:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
     cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
     compression: zstd-fastest
     copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}

--- a/kubernetes/components/volsync/nfs-truenas/replicationdestination.yaml
+++ b/kubernetes/components/volsync/nfs-truenas/replicationdestination.yaml
@@ -14,7 +14,7 @@ spec:
       - ${VOLSYNC_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
     cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
     capacity: ${VOLSYNC_CAPACITY:=5Gi}
     cleanupCachePVC: true

--- a/kubernetes/components/volsync/nfs-truenas/replicationsource.yaml
+++ b/kubernetes/components/volsync/nfs-truenas/replicationsource.yaml
@@ -13,7 +13,7 @@ spec:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
     cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
     compression: zstd-fastest
     copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}

--- a/scripts/volsync-cache-sweep.sh
+++ b/scripts/volsync-cache-sweep.sh
@@ -52,6 +52,15 @@ while read -r ns name; do
         continue
     fi
 
+    # Never delete on a missing or malformed target size. An empty $want means the
+    # API call failed or the source is not on kopia -- either way it would compare
+    # unequal to $have and delete a cache we have no instruction to touch.
+    if ! [[ "$want" =~ ^[0-9]+(Mi|Gi|Ti)$ ]]; then
+        echo -e "  ${YELLOW}!${NC} $ns/$name: could not read a valid cacheCapacity (got '${want}') — skipping"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
     if [[ "$want" == "$have" ]]; then
         skipped=$((skipped + 1))
         continue

--- a/scripts/volsync-cache-sweep.sh
+++ b/scripts/volsync-cache-sweep.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# VolSync Kopia cache PVC sweep
+#
+# Deletes NFS-side VolSync cache PVCs whose size does not match the size their
+# ReplicationSource now requests. VolSync recreates them at the correct size on
+# the next sync.
+#
+# Why this is needed: cache PVCs live on openebs-hostpath, which does not support
+# volume expansion. Any change to a cache PVC's requested size wedges the mover with
+#   "forbidden: only dynamically provisioned pvc can be resized and the
+#    storageclass that provisions the pvc must support resize"
+# and the only remedy is to delete the PVC so it gets recreated.
+#
+# Run this immediately after merging a change to cacheCapacity in
+# components/volsync/nfs-truenas*/replicationsource.yaml.
+#
+# Deleting a cache PVC loses no backup data — the Kopia repository lives on
+# NFS/B2. The next sync re-downloads index/metadata and so runs slower once.
+#
+# Usage: ./volsync-cache-sweep.sh [--apply]     (default is a dry run)
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+APPLY=false
+[[ "${1:-}" == "--apply" ]] && APPLY=true
+
+if [[ "$APPLY" == false ]]; then
+    echo -e "${YELLOW}DRY RUN${NC} — pass --apply to actually delete. Nothing will be changed."
+fi
+echo ""
+
+deleted=0
+skipped=0
+
+# Only NFS-side sources. The -b2 sources already use VOLSYNC_CACHE_CAPACITY and
+# their caches are correctly sized, so they are deliberately left alone — they are
+# also the safety net that keeps backups running during this sweep.
+while read -r ns name; do
+    [[ "$name" == *-b2 ]] && continue
+
+    want=$(kubectl get replicationsource "$name" -n "$ns" -o jsonpath='{.spec.kopia.cacheCapacity}' 2>/dev/null || true)
+    pvc="volsync-src-${name}-cache"
+    have=$(kubectl get pvc "$pvc" -n "$ns" -o jsonpath='{.spec.resources.requests.storage}' 2>/dev/null || true)
+
+    if [[ -z "$have" ]]; then
+        echo -e "  ${YELLOW}-${NC} $ns/$pvc: no cache PVC yet, nothing to do"
+        continue
+    fi
+
+    if [[ "$want" == "$have" ]]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    echo -e "  ${RED}✗${NC} $ns/$pvc: has $have, source wants $want"
+    if [[ "$APPLY" == true ]]; then
+        # A mover pod may hold the PVC; the pvc-protection finalizer clears once it exits.
+        kubectl delete pvc "$pvc" -n "$ns" --wait=false >/dev/null
+        echo -e "    ${GREEN}→${NC} deleted, will be recreated at $want on next sync"
+    fi
+    deleted=$((deleted + 1))
+done < <(kubectl get replicationsource -A --no-headers -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name')
+
+echo ""
+echo "Already correct: $skipped"
+if [[ "$APPLY" == true ]]; then
+    echo -e "${GREEN}Deleted: $deleted${NC} — run scripts/volsync-drift-check.sh after the next sync cycle to confirm."
+else
+    echo -e "${YELLOW}Would delete: $deleted${NC} — re-run with --apply."
+fi

--- a/scripts/volsync-drift-check.sh
+++ b/scripts/volsync-drift-check.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# VolSync drift check
+#
+# Catches the classes of VolSync failure that are silent — the ones where Flux
+# reports "applied" and the dashboards look fine, but a restore would fail or a
+# backup has quietly stopped running.
+#
+# Checks:
+#   1. Mover drift        — any RS/RD not on the kopia mover (pre-migration restic leftovers)
+#   2. Dead repo secret   — RS/RD pointing at a repository secret that no longer exists
+#   3. Orphan RDs         — a ReplicationDestination with no matching ReplicationSource
+#                           (app removed/replaced; the RD and its snapshots linger)
+#   4. Cache size drift   — cache PVC size != the size its RS requests. openebs-hostpath
+#                           cannot expand, so this wedges the mover permanently.
+#   5. Stale sources      — RS in Error, or no successful sync in over 24h
+#
+# Exit code is non-zero if anything is found, so this is safe to wire into CI or a
+# CronJob later.
+#
+# Usage: ./volsync-drift-check.sh
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+findings=0
+note() { echo -e "  ${RED}✗${NC} $1"; findings=$((findings + 1)); }
+
+echo "=== VOLSYNC DRIFT CHECK ==="
+echo "Generated: $(date)"
+echo ""
+
+# ---------------------------------------------------------------------------
+echo "1. Mover drift (expect kopia everywhere)"
+for kind in replicationsource replicationdestination; do
+    while read -r ns name; do
+        # .spec.kopia is absent if the live object is still on restic/rsync.
+        if ! kubectl get "$kind" "$name" -n "$ns" -o jsonpath='{.spec.kopia}' 2>/dev/null | grep -q .; then
+            mover=$(kubectl get "$kind" "$name" -n "$ns" -o jsonpath='{.spec.restic}' 2>/dev/null | grep -q . && echo restic || echo unknown)
+            note "$ns/$name ($kind) is on mover '$mover', not kopia"
+        fi
+    done < <(kubectl get "$kind" -A --no-headers -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name' 2>/dev/null)
+done
+[[ $findings -eq 0 ]] && echo -e "  ${GREEN}✓${NC} all sources and destinations on kopia"
+echo ""
+
+# ---------------------------------------------------------------------------
+before=$findings
+echo "2. Dead repository secrets"
+for kind in replicationsource replicationdestination; do
+    while read -r ns name; do
+        secret=$(kubectl get "$kind" "$name" -n "$ns" -o jsonpath='{.spec.kopia.repository}' 2>/dev/null || true)
+        [[ -z "$secret" ]] && continue
+        if ! kubectl get secret "$secret" -n "$ns" >/dev/null 2>&1; then
+            note "$ns/$name ($kind) references missing secret '$secret'"
+        fi
+    done < <(kubectl get "$kind" -A --no-headers -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name' 2>/dev/null)
+done
+[[ $findings -eq $before ]] && echo -e "  ${GREEN}✓${NC} all repository secrets exist"
+echo ""
+
+# ---------------------------------------------------------------------------
+before=$findings
+echo "3. Orphan ReplicationDestinations"
+while read -r ns name; do
+    # RDs are named <app>-dst and pair with an RS named <app>.
+    app="${name%-dst}"
+    if ! kubectl get replicationsource "$app" -n "$ns" >/dev/null 2>&1; then
+        snaps=$(kubectl get volumesnapshot -n "$ns" --no-headers 2>/dev/null | grep -c "volsync-${app}-dst" || true)
+        note "$ns/$name has no matching ReplicationSource '$app' (${snaps} snapshot(s) held)"
+    fi
+done < <(kubectl get replicationdestination -A --no-headers -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name' 2>/dev/null)
+[[ $findings -eq $before ]] && echo -e "  ${GREEN}✓${NC} every destination has a live source"
+echo ""
+
+# ---------------------------------------------------------------------------
+before=$findings
+echo "4. Cache size drift (openebs-hostpath cannot expand)"
+while read -r ns name; do
+    want=$(kubectl get replicationsource "$name" -n "$ns" -o jsonpath='{.spec.kopia.cacheCapacity}' 2>/dev/null || true)
+    pvc="volsync-src-${name}-cache"
+    have=$(kubectl get pvc "$pvc" -n "$ns" -o jsonpath='{.spec.resources.requests.storage}' 2>/dev/null || true)
+    [[ -z "$have" || -z "$want" ]] && continue
+    if [[ "$want" != "$have" ]]; then
+        note "$ns/$pvc is $have but source wants $want — mover will wedge; run scripts/volsync-cache-sweep.sh"
+    fi
+done < <(kubectl get replicationsource -A --no-headers -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name' 2>/dev/null)
+[[ $findings -eq $before ]] && echo -e "  ${GREEN}✓${NC} all cache PVCs match their source"
+echo ""
+
+# ---------------------------------------------------------------------------
+before=$findings
+echo "5. Stale or failing sources"
+now=$(date -u +%s)
+while read -r ns name; do
+    reason=$(kubectl get replicationsource "$name" -n "$ns" -o jsonpath='{.status.conditions[?(@.type=="Synchronizing")].reason}' 2>/dev/null || true)
+    msg=$(kubectl get replicationsource "$name" -n "$ns" -o jsonpath='{.status.conditions[?(@.type=="Synchronizing")].message}' 2>/dev/null || true)
+    last=$(kubectl get replicationsource "$name" -n "$ns" -o jsonpath='{.status.lastSyncTime}' 2>/dev/null || true)
+
+    if [[ "$reason" == "Error" ]]; then
+        note "$ns/$name is in Error: $msg"
+        continue
+    fi
+
+    if [[ -n "$last" ]]; then
+        lastEpoch=$(date -u -d "$last" +%s 2>/dev/null || echo 0)
+        if [[ "$lastEpoch" -gt 0 ]]; then
+            age=$(( (now - lastEpoch) / 3600 ))
+            # -b2 sources run daily; NFS sources run far more often. 24h is a
+            # deliberately loose threshold that both should always beat.
+            if [[ "$age" -gt 24 ]]; then
+                note "$ns/$name last synced ${age}h ago"
+            fi
+        fi
+    else
+        note "$ns/$name has never completed a sync"
+    fi
+done < <(kubectl get replicationsource -A --no-headers -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name' 2>/dev/null)
+[[ $findings -eq $before ]] && echo -e "  ${GREEN}✓${NC} all sources synced within 24h"
+echo ""
+
+# ---------------------------------------------------------------------------
+echo "=========================================="
+if [[ $findings -eq 0 ]]; then
+    echo -e "${GREEN}No drift found.${NC}"
+else
+    echo -e "${RED}${findings} issue(s) found.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Why

`nfs-truenas` and `nfs-truenas-relaxed` used `${VOLSYNC_CAPACITY}` for **both** the app's data PVC size and the Kopia mover's `cacheCapacity`. So growing an app's volume also tried to grow its cache PVC — which lives on `openebs-hostpath`, a storage class with no expansion support. The mover then wedges permanently:

```
persistentvolumeclaims "volsync-src-<app>-cache" is forbidden: only dynamically
provisioned pvc can be resized and the storageclass that provisions the pvc
must support resize
```

This silently stopped **plex** NFS backups for two days after its config PVC was grown 40Gi→60Gi (#2384). It fired `VolSyncVolumeOutOfSync`. The `-b2` sources were unaffected because `s3-backblaze` already uses a separate `VOLSYNC_CACHE_CAPACITY:=8Gi`.

Backups were never lost — the Kopia repo is intact and B2 dailies ran throughout. Only the NFS side stopped taking new snapshots.

**53 apps** (50 on `volsync-standard`, 3 on `volsync-critical`) were one capacity bump away from the same silent breakage.

## What

Use `VOLSYNC_CACHE_CAPACITY:=8Gi` on the NFS side, matching `s3-backblaze`. 8Gi is proven sufficient: no app overrides it, and every `-b2` cache has run at 8Gi — plex included, against a 39.7GB dataset. The RD's restore `capacity` still tracks `VOLSYNC_CAPACITY`, as it should.

Plex itself is already fixed and re-synced (`Successful`, first NFS backup in two days).

## ⚠️ Merging requires an immediate follow-up

RSes are **not** `ssa: IfNotPresent`, so Flux pushes 8Gi to all 53 NFS sources at once. Every cache PVC not already 8Gi (52 of them) then hits the same resize refusal until deleted and recreated. So merge and sweep run back to back:

```bash
flux reconcile source git flux-system
bash scripts/volsync-cache-sweep.sh          # dry run
bash scripts/volsync-cache-sweep.sh --apply
```

B2 dailies keep running throughout, and syncs are staggered by `VOLSYNC_MINUTE`, so there's no thundering herd on the NFS share. Deleting a cache loses no data — the next sync re-downloads index/metadata and runs slower once.

## Scripts

**`volsync-cache-sweep.sh`** — deletes NFS cache PVCs whose size no longer matches their source. Dry run by default. Refuses to act on an unreadable target size.

**`volsync-drift-check.sh`** — guards the *silent* failures, i.e. the ones where Flux says "applied" and dashboards look fine but a restore would fail:
1. restic movers left after the Kopia migration
2. RS/RDs pointing at deleted repo secrets (the dead `*-r2-secret` class)
3. orphan RDs holding snapshots
4. cache size drift (this bug)
5. stale/failing sources

Exits non-zero, so it can be wired into CI or a CronJob later.

## Verification

- `task kubernetes:kubeconform` — baseline-compared against `main`: both show exactly 1 failure, the pre-existing envoy `${ENVOY_EXTERNAL_LBIP}` schema complaint. No new failures.
- `kustomize build` of the plex app renders all three sources at `${VOLSYNC_CACHE_CAPACITY:=8Gi}`, with the RD's restore `capacity` still on `${VOLSYNC_CAPACITY}`.
- `volsync-drift-check.sh` runs **clean** against the live cluster (also re-verifies the restic→Kopia sweep: zero restic, no dead secrets, no orphan RDs).
- Both scripts tested against a stubbed `kubectl` replaying a synthetic drifted cluster: all 5 checks fire, exit 1, no false positives on healthy apps.