### PR TITLE
feat(livingdex): bump api/web/seed/mirror to 4202656 (transfer topology + game fixes)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: a74add2abb70aeaa45fa22a0dd5d2610882e6115
+              tag: 4202656c2b1ab255fdec31ae165bff298a4036c4
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: a74add2abb70aeaa45fa22a0dd5d2610882e6115
+              tag: 4202656c2b1ab255fdec31ae165bff298a4036c4
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: a74add2abb70aeaa45fa22a0dd5d2610882e6115
+              tag: 4202656c2b1ab255fdec31ae165bff298a4036c4
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: a74add2abb70aeaa45fa22a0dd5d2610882e6115
+              tag: 4202656c2b1ab255fdec31ae165bff298a4036c4
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
## Summary

Bumps all four livingdex controllers — `api`, `web`, `seed`, `mirror` — to `4202656c2b1ab255fdec31ae165bff298a4036c4` (pokemon-tracker #12, Phase 4a).

Ships:
- **HOME transfer topology** — `GET /api/transfer` + a "TO POKÉMON HOME" route line in the detail sheet (native / via Bank / via the Gen-3/4 transfer chain / GO).
- **Platform-aware ownership methods** — Pokémon GO now a single "Playing" toggle; **migration `0005`** moves `game_ownership` from three boolean columns to a `methods` list (auto-applies on api boot, backfills existing rows).
- **Catalogue additions** — Legends: Z-A (HOME-native), Winds/Waves (Gen 10, Switch 2, transfer `unknown` until launch).

### Image tags
| controller | old | new |
| --- | --- | --- |
| api | `a74add2…` | `4202656c2b1ab255fdec31ae165bff298a4036c4` |
| web | `a74add2…` | `4202656c2b1ab255fdec31ae165bff298a4036c4` |
| seed | `a74add2…` | `4202656c2b1ab255fdec31ae165bff298a4036c4` |
| mirror | `a74add2…` | `4202656c2b1ab255fdec31ae165bff298a4036c4` |

CI on `main` for `4202656` is fully green — both `livingdex-api` and `livingdex-web` images built and pushed to ghcr.

## Note
Migration `0005` is backward-safe (add column → backfill → drop the three bool columns) and runs automatically when the new api boots. No manual jobs, no reseed needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_