### PR TITLE
feat(livingdex): bump api/web/seed/mirror to 37b81b2 (living-dex planner)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 4202656c2b1ab255fdec31ae165bff298a4036c4
+              tag: 37b81b230142a3762b0dd4d4388a2beb0440bb44
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 4202656c2b1ab255fdec31ae165bff298a4036c4
+              tag: 37b81b230142a3762b0dd4d4388a2beb0440bb44
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 4202656c2b1ab255fdec31ae165bff298a4036c4
+              tag: 37b81b230142a3762b0dd4d4388a2beb0440bb44
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 4202656c2b1ab255fdec31ae165bff298a4036c4
+              tag: 37b81b230142a3762b0dd4d4388a2beb0440bb44
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
## Summary

Bumps all four livingdex controllers — `api`, `web`, `seed`, `mirror` — to `37b81b230142a3762b0dd4d4388a2beb0440bb44` (pokemon-tracker #13, Phase 4b).

Ships the **living-dex planner**:
- **api** — `GET /api/plan` (per-species verdict `have`/`ready`/`need-game`/`unknown`/`event-only` from owned games + Bank status, plus a ranked best-next-acquisitions buy-list).
- **web** — a **Planner** view (summary tiles, buy-list, filterable species list) and an ownership-aware "YOUR PLAN" line in the detail sheet.
- **Services** — Pokémon Bank + HOME Premium are now trackable in My Games; Bank status gates the pre-Switch routes. Romhack-only ownership is excluded from HOME routes.

### Image tags
| controller | old | new |
| --- | --- | --- |
| api | `4202656…` | `37b81b230142a3762b0dd4d4388a2beb0440bb44` |
| web | `4202656…` | `37b81b230142a3762b0dd4d4388a2beb0440bb44` |
| seed | `4202656…` | `37b81b230142a3762b0dd4d4388a2beb0440bb44` |
| mirror | `4202656…` | `37b81b230142a3762b0dd4d4388a2beb0440bb44` |

CI on `main` for `37b81b2` is fully green — both `livingdex-api` and `livingdex-web` images built and pushed to ghcr.

## Note
No schema change (services reuse the `game_ownership` table). The planner's per-species accuracy depends on obtainability data being populated — run the `pokeapi-mirror` → `livingdex-seed` jobs if that hasn't been done since the obtainability-v2 rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_