### PR TITLE
feat(livingdex): bump api/web/seed/mirror to 5c07790 (acquisition planner)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 37b81b230142a3762b0dd4d4388a2beb0440bb44
+              tag: 5c07790b098a5c6da168d840c82044728b84999f
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 37b81b230142a3762b0dd4d4388a2beb0440bb44
+              tag: 5c07790b098a5c6da168d840c82044728b84999f
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 37b81b230142a3762b0dd4d4388a2beb0440bb44
+              tag: 5c07790b098a5c6da168d840c82044728b84999f
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 37b81b230142a3762b0dd4d4388a2beb0440bb44
+              tag: 5c07790b098a5c6da168d840c82044728b84999f
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
## Summary

Bumps all four livingdex controllers — `api`, `web`, `seed`, `mirror` — to `5c07790b098a5c6da168d840c82044728b84999f` (pokemon-tracker #14).

Reframes the Planner as an **acquisition plan** — the ordered shopping list of games/services to acquire so you can catch everything you're missing:
- **api** — `GET /api/acquire?mode=&rank=` (demand-based greedy set-cover → the shopping list, with `covered`/`alreadyReady`/`leftover`).
- **web** — the Planner view now leads with the shopping list + two selectors: **Acquire** (cartridge-only / emulator-only / emu-first / cartridge-first) and **Order** (fewest-games / fewest-consoles / oldest-gen). Each step tagged EMULATE / BUY CART / INSTALL / SUBSCRIBE.

### Image tags
| controller | old | new |
| --- | --- | --- |
| api | `37b81b2…` | `5c07790b098a5c6da168d840c82044728b84999f` |
| web | `37b81b2…` | `5c07790b098a5c6da168d840c82044728b84999f` |
| seed | `37b81b2…` | `5c07790b098a5c6da168d840c82044728b84999f` |
| mirror | `37b81b2…` | `5c07790b098a5c6da168d840c82044728b84999f` |

CI on `main` for `5c07790` is green — both `livingdex-api` and `livingdex-web` images built and pushed to ghcr.

## Note
No schema change. The plan's accuracy depends on obtainability data being populated (`pokeapi-mirror` → `livingdex-seed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_