### PR TITLE
fix(volsync): pin every retention key + give B2 repos a working maintainer

### DIFF
--- a/kubernetes/components/volsync/nfs-truenas-relaxed/replicationsource.yaml
+++ b/kubernetes/components/volsync/nfs-truenas-relaxed/replicationsource.yaml
@@ -23,8 +23,15 @@ spec:
       fsGroup: ${VOLSYNC_GID:=568}
     parallelism: 2
     repository: ${APP}-volsync-secret
+    # Every key must be set explicitly. Kopia inherits its own global defaults
+    # (monthly 24, yearly 3, weekly 4, latest 10) for any key omitted here, so a
+    # partial block silently retains ~3 years rather than the week it appears to.
     retain:
       hourly: 4
       daily: 7
+      weekly: 4
+      monthly: 3
+      yearly: 0
+      latest: 4
     storageClassName: ${VOLSYNC_STORAGECLASS:=ceph-block}
     volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=csi-ceph-block}

--- a/kubernetes/components/volsync/nfs-truenas/replicationsource.yaml
+++ b/kubernetes/components/volsync/nfs-truenas/replicationsource.yaml
@@ -23,8 +23,15 @@ spec:
       fsGroup: ${VOLSYNC_GID:=568}
     parallelism: 2
     repository: ${APP}-volsync-secret
+    # Every key must be set explicitly. Kopia inherits its own global defaults
+    # (monthly 24, yearly 3, weekly 4, latest 10) for any key omitted here, so a
+    # partial block silently retains ~3 years rather than the week it appears to.
     retain:
       hourly: 24
       daily: 7
+      weekly: 4
+      monthly: 3
+      yearly: 0
+      latest: 4
     storageClassName: ${VOLSYNC_STORAGECLASS:=ceph-block}
     volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=csi-ceph-block}

--- a/kubernetes/components/volsync/s3-backblaze/kopiamaintenance.yaml
+++ b/kubernetes/components/volsync/s3-backblaze/kopiamaintenance.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/volsync.backube/kopiamaintenance_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: KopiaMaintenance
+metadata:
+  name: "${APP}-b2"
+spec:
+  # Kopia permits only the single designated maintenance owner to run maintenance.
+  # Every B2 repo had its owner stamped as the ephemeral mover pod that first
+  # connected (e.g. nobody@volsync-src-plex-b2-nrk52) -- a pod that no longer
+  # exists, so maintenance could never run and had never run once. This controller
+  # claims ownership under the stable identity maintenance@volsync, then runs quick
+  # (index compaction) and full (snapshot GC) maintenance.
+  #
+  # The NFS repo does not need one of these: it is a single shared repo already
+  # covered by the kopia-maintenance CronJob in storage, whose NFS mount is injected
+  # by the volsync-mover-nfs MutatingAdmissionPolicy -- that policy matches jobs
+  # named volsync-* with label created-by, and would NOT match this controller's
+  # kopia-maint-* / managed-by jobs. S3 needs no mount, so this only applies here.
+  repository:
+    repository: "${APP}-volsync-b2-secret"
+  trigger:
+    # Backups run at ${VOLSYNC_B2_MINUTE} past midnight; maintain a few hours later
+    # so the two do not contend for the repository lock.
+    schedule: "${VOLSYNC_B2_MINUTE:=0} 4 * * *"
+  cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
+  cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  podSecurityContext:
+    runAsUser: ${VOLSYNC_UID:=568}
+    runAsGroup: ${VOLSYNC_GID:=568}
+    fsGroup: ${VOLSYNC_GID:=568}
+    runAsNonRoot: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 256Mi
+    limits:
+      memory: 2Gi

--- a/kubernetes/components/volsync/s3-backblaze/kustomization.yaml
+++ b/kubernetes/components/volsync/s3-backblaze/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - ./externalsecret.yaml
+  - ./kopiamaintenance.yaml
   - ./replicationsource.yaml

--- a/kubernetes/components/volsync/s3-backblaze/replicationsource.yaml
+++ b/kubernetes/components/volsync/s3-backblaze/replicationsource.yaml
@@ -23,7 +23,17 @@ spec:
       fsGroup: ${VOLSYNC_GID:=568}
     parallelism: 2
     repository: ${APP}-volsync-b2-secret
+    # Every key must be set explicitly. Kopia inherits its own global defaults for
+    # any key omitted here, so `daily: 14` alone silently retained ~3 years.
+    # hourly is 0 deliberately: this source syncs once a day, so each snapshot
+    # lands in its own hourly bucket and the inherited hourly:48 was holding ~48
+    # daily snapshots on top of everything below.
     retain:
+      hourly: 0
       daily: 14
+      weekly: 4
+      monthly: 3
+      yearly: 0
+      latest: 3
     storageClassName: ${VOLSYNC_STORAGECLASS:=ceph-block}
     volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=csi-ceph-block}


### PR DESCRIPTION
Follow-on from #2389. Two silent faults, both found while chasing a kopia log warning that turned out to be harmless.

## 1. Retention was never what the config said

VolSync's `retain:` block **only sets the keys you list** — kopia inherits its own global defaults for the rest. Proven against live repos with `kopia policy show`:

```
Annual snapshots:    3   inherited from (global)
Monthly snapshots:  24   inherited from (global)
Weekly snapshots:    4   inherited from (global)
Daily snapshots:    14   (defined for this target)   <- the only one we set
Hourly snapshots:   48   inherited from (global)
Latest snapshots:   10   inherited from (global)
```

So `daily: 14` on B2 actually retained **~3 years**, with monthly snapshots back to 2025-12-31. NFS inherits identically. Now every key is pinned → **~3 months max**, both sides.

**`hourly: 0` on B2 is deliberate:** that source syncs once daily, so each snapshot lands in its own hourly bucket — the inherited `hourly: 48` was holding ~48 daily snapshots on top of everything else. Visible in the tags: `2026-07-15 ... (latest-2, hourly-2, daily-2)`.

**Existing hourly/daily preserved per component.** `nfs-truenas` keeps `hourly: 24` (critical apps — mariadb, pocket-id, n8n — shouldn't lose granularity); `nfs-truenas-relaxed` keeps `hourly: 4`. Only the silently-inherited keys change.

Explicit `0` survives the whole chain — verified against v0.17.11 source, not assumed: retain fields are `*int32` (pointer-to-zero serializes), the controller guards on `!= nil` not `> 0`, `entry.sh` guards on `[[ -n "$VAR" ]]` (string test, `"0"` passes), and kopia treats `0` and `'inherit'` as distinct values.

## 2. B2 maintenance had never run once, and could not

Kopia permits only the designated **maintenance owner** to run maintenance. Every B2 repo's owner was the ephemeral mover pod that first connected:

```
plex      -> nobody@volsync-src-plex-b2-nrk52
pocket-id -> nobody@volsync-src-pocket-id-b2-wljdc
```

Those pods are long dead → no client is ever the owner → `Recent Maintenance Runs:` empty, `Quick Cycle: scheduled: false`. **No index compaction, ever.** NFS is immune because its CronJob pins `--override-username=kopia --override-hostname=maintenance`.

**Measured on plex-b2:** 86.7GB / 6249 objects, of which GC found **41.2GB (89,174 contents) unreferenced — 47% garbage** that could never be collected.

### Piloted before fanning out

Applied a single CR to plex-b2 first:

```
INFO: Current maintenance owner: nobody@volsync-src-plex-b2-nrk52
INFO: Attempting to claim maintenance ownership...
Setting maintenance owner to maintenance@volsync
INFO:  Successfully claimed maintenance ownership
INFO: Enabling quick cycle scheduling...
Running quick maintenance... Compacting an eligible uncompacted epoch...
GC found 89174 unused contents (41.2 GB)
INFO: OPERATION_RESULT: SUCCESS / EXIT_CODE: 0
```

After: `Owner: maintenance@volsync`, `Quick Cycle: scheduled: true, interval 1h`, `Full Cycle: interval 24h`. Objects 6249 → 5684, 617 logs cleaned.

**Space does not return immediately** — kopia's GC marks on the first pass and defers blob deletion behind an epoch safety window, so the prefix actually ticked up slightly (86.7 → 87.3GB) before it shrinks. Expect reclaim over the next few daily cycles. Pilot CR has been deleted; this component recreates it as `${APP}-b2`.

### Why the component, and why B2 only

Templating into `s3-backblaze` covers all ~54 B2 repos with no hardcoded prefix list. **NFS deliberately gets none:** it's one shared repo already covered by the `kopia-maintenance` CronJob, and the `volsync-mover-nfs` MutatingAdmissionPolicy matches jobs named `volsync-*` with label `created-by` — it would **not** match this controller's `kopia-maint-*` / `managed-by` jobs, so the mount wouldn't inject. S3 needs no mount, so the gap only closes here.

## Rollout note

Unlike #2389 this needs **no follow-up sweep** — RSes update in place and the retention policy is re-applied by the mover on every sync. The tighter retention takes effect on each app's next sync; the freed space follows once maintenance GCs it.

⚠️ **Irreversible:** once retention tightens and maintenance runs, the old monthlies/annuals are gone. That's intended (Gavin: "years of retention isn't valuable"), but stating it plainly.

## Verification

- `task kubernetes:kubeconform` — 1 invalid, identical to `main`'s pre-existing envoy `${ENVOY_EXTERNAL_LBIP}` failure. No regression.
- `kustomize build` of plex renders `hourly: 0` / `yearly: 0` **present, not dropped** — the exact thing that would have made this a silent no-op.
- KopiaMaintenance behaviour proven live on plex-b2 before templating.