### PR TITLE
feat(livingdex): bump to completion-itinerary planner (17887db)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5c07790b098a5c6da168d840c82044728b84999f
+              tag: 17887db0c75c14a281a8c3b100332ff3243d1f6d
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 5c07790b098a5c6da168d840c82044728b84999f
+              tag: 17887db0c75c14a281a8c3b100332ff3243d1f6d
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5c07790b098a5c6da168d840c82044728b84999f
+              tag: 17887db0c75c14a281a8c3b100332ff3243d1f6d
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5c07790b098a5c6da168d840c82044728b84999f
+              tag: 17887db0c75c14a281a8c3b100332ff3243d1f6d
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps the four livingdex controller image tags (`api`, `web`, `seed`, `mirror`) from `5c07790` → `17887db` to deploy the completion-itinerary planner.

## What ships
- Planner reframed as an **ordered completion itinerary**: missing species grouped into gen-ordered catch stops instead of a flat buy-list.
- Games you **own stay as stops** (flagged owned) — you still have to play them — with un-owned stops carrying a BUY CART / EMULATE / INSTALL / SUBSCRIBE badge driven by the acquisition mode.
- **Bank + chain prereqs** are emitted before any chain-only catch stop.
- Mode selector (cartridge-only / emulator-only / emu-first / cartridge-first) and rank selector (fewest-games / oldest-gen).

## Source
pokemon-tracker#15 — commit `17887db0c75c14a281a8c3b100332ff3243d1f6d`. Main CI for that SHA built and published both `livingdex-api` and `livingdex-web` images successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_