### PR TITLE
feat(livingdex): bump to honest planner data + goal scopes (16da2ae)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 17887db0c75c14a281a8c3b100332ff3243d1f6d
+              tag: 16da2ae4aa58fe6930bac235d701b334d1bd3568
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 17887db0c75c14a281a8c3b100332ff3243d1f6d
+              tag: 16da2ae4aa58fe6930bac235d701b334d1bd3568
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 17887db0c75c14a281a8c3b100332ff3243d1f6d
+              tag: 16da2ae4aa58fe6930bac235d701b334d1bd3568
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 17887db0c75c14a281a8c3b100332ff3243d1f6d
+              tag: 16da2ae4aa58fe6930bac235d701b334d1bd3568
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps the four livingdex controller image tags (`api`, `web`, `seed`, `mirror`) from `17887db` → `16da2ae` to deploy pokemon-tracker#16.

## What ships
- **Legends: Z-A availability** — `legends-za` + `mega-dimension` version groups mapped; ZA becomes a native HOME catch stop and Diancie/Hoopa/Volcanion gain their real in-game route.
- **Mythical curation** — event-only dex listings dropped, still-working routes added (GO Special Research / Mystery Box, Keldeo's Crown Tundra quest), 8 truly event-only mythicals now render as Event-only instead of catch stops.
- **Goal scopes** — Species / +Regional / Everything / Phased (default) selector in the planner, `?scope=` on `/api/plan` + `/api/acquire`, dex grid follows the scope with PHASE n/3 progress.
- **Bank reality warning** when the itinerary needs a Bank you don't own.

## Post-merge
⚠️ **Re-run the seed job after rollout** — the ZA + mythical availability changes are seed-computed data. The scope selector works immediately; the new availability appears once the seed has re-run against the existing mirror.

## Source
pokemon-tracker#16 — commit `16da2ae4aa58fe6930bac235d701b334d1bd3568`; main CI completed successfully (api + web images published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_