### PR TITLE
feat(livingdex): dex VIEW control decoupled from planner goal scope (ecf0490)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 16da2ae4aa58fe6930bac235d701b334d1bd3568
+              tag: ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 16da2ae4aa58fe6930bac235d701b334d1bd3568
+              tag: ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 16da2ae4aa58fe6930bac235d701b334d1bd3568
+              tag: ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 16da2ae4aa58fe6930bac235d701b334d1bd3568
+              tag: ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps the four livingdex controller image tags (`api`, `web`, `seed`, `mirror`) from `16da2ae` → `ecf0490` to deploy pokemon-tracker#17.

## What ships
- The dex grid returns to showing **every slot by default** (pre-#16 behaviour) with a new `VIEW:` control beside the grid — `Every slot / One per species / + Regional forms` — so consolidation is an explicit, dex-local choice.
- The planner's GOAL scope (Species / +Regional / Everything / Phased) now shapes the **plan only** and never filters the grid.
- Fixes a phone-viewport tap-interception issue the mobile e2e lane caught (VIEW row moved out of the sticky header).

## Post-merge
Nothing to run — front-end only, no seed re-run, no schema changes.

## Source
pokemon-tracker#17 — commit `ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad`; main CI completed successfully (api + web images published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_