### PR TITLE
feat(livingdex): gender preference — All vs Distinct only (9928173)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad
+              tag: 9928173c6c5ced9486255cfaaba2c763ad3a4481
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad
+              tag: 9928173c6c5ced9486255cfaaba2c763ad3a4481
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad
+              tag: 9928173c6c5ced9486255cfaaba2c763ad3a4481
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: ecf04904bcdaa4ae0ad7560bbb7516dc8cc4c1ad
+              tag: 9928173c6c5ced9486255cfaaba2c763ad3a4481
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps the four livingdex controller image tags (`api`, `web`, `seed`, `mirror`) from `ecf0490` → `9928173` to deploy pokemon-tracker#18.

## What ships
- **GENDERS preference** — one shared setting with chips in both the dex VIEW row and the planner GOAL row: **All** (default, current behaviour) or **Distinct only**, which collapses each ♂/♀ pair into one slot except the ~101 visually gender-dimorphic species (`has_gender_differences` from the games' data). At the Everything goal: ~2,675 → ~1,970 slots.
- `?gender=all|distinct` on `/api/plan` + `/api/acquire`.

## Post-merge
Nothing to run — front-end + API only, no seed re-run, no schema changes.

## Source
pokemon-tracker#18 — commit `9928173c6c5ced9486255cfaaba2c763ad3a4481`; main CI completed successfully (api + web images published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_