### PR TITLE
feat(livingdex): fixed-gender forms + one-shot SEED_PRUNE (e1f4b8d)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 9928173c6c5ced9486255cfaaba2c763ad3a4481
+              tag: e1f4b8d58b5e1590a0541f7ec83a98451601ea90
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 9928173c6c5ced9486255cfaaba2c763ad3a4481
+              tag: e1f4b8d58b5e1590a0541f7ec83a98451601ea90
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,10 +159,14 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 9928173c6c5ced9486255cfaaba2c763ad3a4481
+              tag: e1f4b8d58b5e1590a0541f7ec83a98451601ea90
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
+              # One-shot: prune the 15 fixed-gender phantom slots already seeded
+              # (cap Pikachu ♀, cosplay ♂, Ash-Greninja ♀). Safe to revert to off
+              # after the next successful seed run.
+              SEED_PRUNE: "1"
               SEED_CACHE_DIR: /cache
               SEED_CONCURRENCY: "8"
             envFrom: *envFrom
@@ -189,7 +193,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 9928173c6c5ced9486255cfaaba2c763ad3a4481
+              tag: e1f4b8d58b5e1590a0541f7ec83a98451601ea90
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps the four livingdex controller image tags (`api`, `web`, `seed`, `mirror`) from `9928173` → `e1f4b8d` to deploy pokemon-tracker#19, and sets **`SEED_PRUNE: "1"`** on the seed CronJob (marked one-shot in a comment).

## What ships
- Curated `FIXED_GENDER_FORMS`: all 8 cap Pikachu are ♂-only, Cosplay Pikachu + 5 costumes ♀-only, Ash-Greninja/Battle Bond ♂-only (Bulbapedia-verified) — the catalogue stops producing 15 impossible slots.
- `SEED_PRUNE=1` lets the seed delete already-seeded slots the catalogue no longer produces (cascade removes their status/specimen/obtainability rows).

## Post-merge
1. Let Flux roll out, then **trigger the seed job** (usual repopulate). Expect the log line `seed: pruned 15 stale entries` listing each key (`0025-original_cap-female`, `0025-cosplay-male`, `0658-ash-female`, …).
2. After a successful pruning run I'll open a follow-up PR reverting `SEED_PRUNE` to off, so the weekly seed goes back to warn-only on stale slots.

## Source
pokemon-tracker#19 — commit `e1f4b8d58b5e1590a0541f7ec83a98451601ea90`; main CI completed successfully (api + web images published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_