### PR TITLE
chore(livingdex): SEED_PRUNE one-shot complete — back to warn-only

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -163,10 +163,6 @@ spec:
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
-              # One-shot: prune the 15 fixed-gender phantom slots already seeded
-              # (cap Pikachu ♀, cosplay ♂, Ash-Greninja ♀). Safe to revert to off
-              # after the next successful seed run.
-              SEED_PRUNE: "1"
               SEED_CACHE_DIR: /cache
               SEED_CONCURRENCY: "8"
             envFrom: *envFrom


### PR DESCRIPTION
The one-shot prune from #2399 ran successfully on 2026-07-17: all **16** fixed-gender phantom slots were deleted (6 costume-Pikachu ♂, 8 cap-Pikachu ♀, Ash-Greninja + Battle Bond ♀), entries 2,675 → 2,659, `unmatched=0`.

This removes `SEED_PRUNE` from the seed CronJob env, returning the weekly seed to its protective default: stale slots are logged, never deleted, so a future catalogue hiccup can't silently drop catch data.

No image changes — env only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_