### PR TITLE
feat(livingdex): companion checklist — how/where hints + quick tick-off (5593fb9)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: e1f4b8d58b5e1590a0541f7ec83a98451601ea90
+              tag: 5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: e1f4b8d58b5e1590a0541f7ec83a98451601ea90
+              tag: 5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: e1f4b8d58b5e1590a0541f7ec83a98451601ea90
+              tag: 5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: e1f4b8d58b5e1590a0541f7ec83a98451601ea90
+              tag: 5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps the four livingdex controller image tags (`api`, `web`, `seed`, `mirror`) from `e1f4b8d` → `5593fb9` to deploy pokemon-tracker#20.

## What ships
- **Companion checklist**: tapping a planner stop shows the assigned species plus an "ALSO CATCHABLE HERE" section, each row with how/where — wild locations + encounter methods (Gen 1→SwSh, from the mirror), `evolve from <prevo>` with TRADE EVO flags.
- **Quick tick-off** on checklist rows, recording the stop's game as the catch's origin.
- Detail sheet gains an EVOLVE FROM line and location hints on availability chips.
- New `obtainability.evolve_from` column (migration 0006, applied automatically on boot).

## Post-merge
**Re-run the seed job** after rollout (normal run, no flags) — it populates the new location/evolve-from data. The checklist UI works immediately; the how/where lines show "method unconfirmed" until the seed has re-run.

## Source
pokemon-tracker#20 — commit `5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee`; main CI completed successfully (api + web images published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_