### PR TITLE
feat(livingdex): transfer backlog + honest modern-game how/where (0761641)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee
+              tag: 07616417a64f756b0a4cb2a82fce025e2beef80e
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee
+              tag: 07616417a64f756b0a4cb2a82fce025e2beef80e
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee
+              tag: 07616417a64f756b0a4cb2a82fce025e2beef80e
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5593fb91bf5b3f73bbb73a864f710ecb2bd4dfee
+              tag: 07616417a64f756b0a4cb2a82fce025e2beef80e
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps the four livingdex controller image tags (`api`, `web`, `seed`, `mirror`) from `5593fb9` → `0761641` to deploy pokemon-tracker#21.

## What ships
- **Transfer backlog**: catches carry an `inHome` state (default true — existing HOME-imported data stays truthful). Quick-ticked session catches are in-transit; the planner shows a TRANSFER BACKLOG grouped by origin game with the HOME route and per-game bulk "Mark transferred"; detail sheet gets an In-HOME toggle; CSV round-trips the flag.
- **how/where copy fix**: BDSP/PLA/SV/ZA rows read "catchable here (no location data for this game)" instead of the "method unconfirmed" flood (upstream has no encounter tables for those games).

## Post-merge
Nothing to run — migration 0007 (`status.in_home`) applies automatically on API boot; no seed re-run.

## Source
pokemon-tracker#21 — commit `07616417a64f756b0a4cb2a82fce025e2beef80e`; main CI completed successfully (api + web images published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_