### PR TITLE
feat(livingdex): Serebii location supplement CronJob + bump to b04f1d1

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 07616417a64f756b0a4cb2a82fce025e2beef80e
+              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 07616417a64f756b0a4cb2a82fce025e2beef80e
+              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 07616417a64f756b0a4cb2a82fce025e2beef80e
+              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,10 +189,40 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 07616417a64f756b0a4cb2a82fce025e2beef80e
+              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi
+            envFrom: *envFrom
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+      # ---- Serebii location supplement (monthly; locations for the games ------
+      # ---- PokéAPI has no encounter data for: SV, Z-A, PLA, BDSP) --------------
+      supplement:
+        type: cronjob
+        cronjob:
+          schedule: "0 5 2 * *" # monthly — content-hashed, so unchanged pages write nothing
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gavinmcfall/livingdex-api
+              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
+            command: ["node", "dist/supplement/run.js"]
+            env:
+              MIRROR_SCHEMA: pokeapi
+              SUPPLEMENT_SCHEMA: supplement
             envFrom: *envFrom
             resources:
               requests:


### PR DESCRIPTION
Deploys pokemon-tracker#22: locations for the four games PokéAPI has no encounter data for (SV, Legends: Z-A, Legends: Arceus, BDSP), sourced politely from Serebii.

## Changes
- Bumps `api` / `web` / `seed` / `mirror` image tags `0761641` → `b04f1d1`.
- **New `supplement` CronJob** (5th controller): monthly (2nd @ 05:00), `node dist/supplement/run.js`, same image/envFrom/security posture as the mirror job. Fetches ≤2 Serebii pages per relevant species at ≥1.1 s intervals with an identifying UA; per-species content hashes make refreshes no-ops when pages haven't changed. Writes `supplement.serebii_locations`; the seed merges it as gap-fill only (mirror data always wins).

## Post-merge, one time (in order)
```bash
kubectl -n games create job livingdex-supplement-manual --from=cronjob/livingdex-supplement
# wait for "supplement: done — fetched=… updated=…" (~20–25 min; it's deliberately slow)
kubectl -n games create job livingdex-seed-manual --from=cronjob/livingdex-seed
```
Then hard-refresh: SV/Z-A/PLA/BDSP checklist rows show real areas (`catchable — Wild Zone 20`, `catchable — Obsidian Fieldlands: …`).

## Source
pokemon-tracker#22 — commit `b04f1d19ce901760bf9e5ab28f264dcaa04207c6`; main CI completed successfully (api + web images published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_