### PR TITLE
feat(livingdex): uniform sprite sizing + decluttered tiles (31e4a6b)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
+              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
+              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
+              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
+              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi
@@ -218,7 +218,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: b04f1d19ce901760bf9e5ab28f264dcaa04207c6
+              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
             command: ["node", "dist/supplement/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps all five livingdex image tag references (`api`, `web`, `seed`, `mirror`, `supplement`) from `b04f1d1` → `31e4a6b` to deploy pokemon-tracker#23.

## What ships
- **Uniform sprite sizing**: sprites are normalized client-side — cropped to their opaque bounding box and rescaled to fill the tile box, crisp (no smoothing), bottom-aligned on a common baseline. Classic pixel sprites no longer drown in transparent padding next to frame-filling mega/gmax art.
- **Decluttered tile header**: top row is number + type dots only; gender mark rides with the name; specimen badges + hints get their own row.

## Post-merge
Nothing to run — front-end only. Hard-refresh after rollout.

## Source
pokemon-tracker#23 — commit `31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2`; main CI completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_