### PR TITLE
feat(livingdex): flush card bottoms in the dex grid (5adce99)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
+              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
+              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
+              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
+              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi
@@ -218,7 +218,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 31e4a6b81e0c7e8f1be6ac3fb021cfd8a0be6fd2
+              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
             command: ["node", "dist/supplement/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps all five livingdex image tag references from `31e4a6b` → `5adce99` to deploy pokemon-tracker#24: tiles stretch to their grid row's height and the form-label line is reserved, so card bottoms stay flush.

Front-end only — nothing to run post-rollout; hard-refresh after Flux reconciles.

Source: pokemon-tracker#24 — commit `5adce9937f96e018ebf07aa8f796a69aea2e0f70`; main CI completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_