### PR TITLE
fix(oom): memory headroom for ceph-mon and audiobookshelf

### DIFF
--- a/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
@@ -68,9 +68,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 128Mi
+                memory: 256Mi
               limits:
-                memory: 384Mi
+                memory: 1Gi
           abs-tract:
             image:
               repository: arranhs/abs-tract

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -90,7 +90,7 @@ spec:
             cpu: 50m
             memory: 1Gi
           limits:
-            memory: 2Gi
+            memory: 3Gi
         osd:
           requests:
             cpu: 500m


### PR DESCRIPTION
## What

Both `ceph-mon-c` and `audiobookshelf` were **OOMKilled once each** (Jul 19 & Jul 20). Confirmed via kernel `dmesg` (`constraint=CONSTRAINT_MEMCG` — cgroup-limit hits, **not** node pressure) and kube-state-metrics Discord alerts.

## Diagnosis

| Container | Steady-state | Spike → OOM | Old limit | Cause |
|---|---|---|---|---|
| ceph `mon` | ~440Mi | 2.04Gi | 2Gi | transient rocksdb compaction / map churn, zero headroom |
| abs `app` | ~95Mi | ~320Mi ffprobe child | 384Mi | ffprobe scanning a large file blew the tight cap |

Nodes are ~70% free, so these are limit-sizing issues, not capacity. Unrelated to the mgr bump in #2383.

## Change

- **ceph mon**: limit `2Gi` → `3Gi`
- **audiobookshelf app**: limit `384Mi` → `1Gi`, request `128Mi` → `256Mi`

## Validation

- `kustomize build` renders both kustomizations cleanly (abs via `LoadRestrictionsNone`, as Flux builds it)
- Values confirmed via `yq`

## Rollout note

The mon change rolls the three mons one at a time (quorum preserved); abs is a quick pod rollout.