### PR TITLE
feat(livingdex): high-res Pokémon HOME sprite renders (4b32c09)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
+              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
+              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
+              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
+              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi
@@ -218,7 +218,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 5adce9937f96e018ebf07aa8f796a69aea2e0f70
+              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
             command: ["node", "dist/supplement/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps all five livingdex image tag references from `5adce99` → `4b32c09` to deploy pokemon-tracker#25.

## What ships
**2,302 of 2,659 slots** switch to the 512px Pokémon HOME renders (smooth-downscaled, 2× retina canvases); the remaining **357 keep per-form pixel sprites by design** — cosmetic multi-pattern sets (Alcremie ×63, Vivillon/Scatterbug/Spewpa ×40 each, Unown ×28, Furfrou ×20, Arceus ×19, Silvally ×18, …) where a per-pokémon HOME render can't show the variant.

## Post-merge, in order
1. **Re-run the seed** — rewrites the ~2,300 sprite URLs (expect a large `updated=` count; no other data changes):
   ```bash
   kubectl -n games delete job livingdex-seed-manual --ignore-not-found
   kubectl -n games create job livingdex-seed-manual --from=cronjob/livingdex-seed
   ```
2. **Click "Mirror" in the UI header** — pulls the new renders onto the sprite PVC (~300–600 MB; the 2 Gi CephFS volume has room). Until then, tiles fall back to GitHub directly — nothing breaks in between.
3. Hard-refresh.

## Source
pokemon-tracker#25 — commit `4b32c094f91e3d70ff911b4cc067478516e3460b`; main CI completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_