### PR TITLE
fix(livingdex): sprite-mirror key collision — HOME renders mirror for real (8b1c01b)

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
+              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
+              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
+              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
+              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi
@@ -218,7 +218,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 4b32c094f91e3d70ff911b4cc067478516e3460b
+              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
             command: ["node", "dist/supplement/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps all five livingdex image tag references from `4b32c09` → `8b1c01b` to deploy pokemon-tracker#26.

## What it fixes
The HOME renders share URL basenames with the old pixel sprites (`pokemon/6.png` vs `pokemon/other/home/6.png`), and the mirror keyed files by basename — so it instantly reported "Mirrored ✓" without downloading anything and kept serving the old pixel files. Keys now encode the path variant (`other-home-6.png`); existing default pixel files stay valid, no migration.

## Post-merge
1. Let Flux roll the api pod.
2. **Click Mirror in the UI once** — this time it genuinely downloads the ~2,300 HOME renders (~300–600 MB onto the 2 Gi sprite PVC; button shows progress).
3. Hard-refresh.

No seed re-run — the DB sprite URLs are already correct from the previous run.

## Source
pokemon-tracker#26 — commit `8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c`; main CI completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_