### PR TITLE
feat(livingdex): zone-grouped checklists + collapsible mobile header + ALL gens view

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
+              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
+              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
+              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
+              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi
@@ -218,7 +218,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: 8b1c01b9e8d9a65d478edfa796b610bb9bf75c6c
+              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
             command: ["node", "dist/supplement/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps all five livingdex image tags (api, web, seed, mirror, supplement) from `8b1c01b` to pokemon-tracker `e5e8a48` (CI green, pokemon-tracker PR #27).

What this rollout brings:
- **Planner:** tapping a game stop now shows a hunt route grouped by zone (biggest zones first; evolve/breed and no-data buckets sink to the end), with planned + opportunistic catches merged and an ALSO pill on the bonus ones. A "By dex" toggle keeps the old layout.
- **Mobile:** the sticky header no longer fills the phone screen — gen/status/type/obtainability filters collapse behind one Filters toggle (with active-filter count). Search and Planner stay visible.
- **Dex:** new ALL chip in the generation row — browse and search the entire national dex at once.

Front-end + API image only; **no seed/mirror/supplement re-run needed**. After Flux rolls it out, a hard refresh picks up the new UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_