### PR TITLE
fix(oom): give plex memory headroom for HEVC transcodes

### DIFF
--- a/kubernetes/apps/entertainment/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/plex/app/helmrelease.yaml
@@ -87,7 +87,7 @@ spec:
                 memory: 1500Mi
               limits:
                 gpu.intel.com/i915: 1
-                memory: 3Gi
+                memory: 8Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Plex was OOM killed tonight (18:19 NZT) at its 3Gi cgroup limit during an HEVC software transcode — the tone-mapping path bypasses the iGPU and balloons RAM (transcoder ~575MB + software hevc decoder ~335MB on top of PMS baseline). Node had plenty of headroom (25% used); this was purely the pod limit.

Raises the memory limit 3Gi → 8Gi. Requests unchanged at 1500Mi.

Same pattern as #2410 (ceph-mon / audiobookshelf headroom).