### PR TITLE
feat(livingdex): UX overhaul — companion-first mobile + desktop power pass

### DIFF
--- a/kubernetes/apps/games/livingdex/app/helmrelease.yaml
+++ b/kubernetes/apps/games/livingdex/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
+              tag: cabcb53f9692e26f129018a3580f1148f806f75d
             env:
               PORT: "8080"
               SPRITE_DIR: /sprites # enables the offline sprite mirror
@@ -116,7 +116,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-web
-              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
+              tag: cabcb53f9692e26f129018a3580f1148f806f75d
             env:
               API_UPSTREAM: livingdex-api.games.svc.cluster.local:8080
             probes:
@@ -159,7 +159,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
+              tag: cabcb53f9692e26f129018a3580f1148f806f75d
             command: ["node", "dist/seed/run.js"]
             env:
               SEED_TIER: full
@@ -189,7 +189,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
+              tag: cabcb53f9692e26f129018a3580f1148f806f75d
             command: ["node", "dist/mirror/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi
@@ -218,7 +218,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/livingdex-api
-              tag: e5e8a48e468b597c3b77034d54b7024f16e8a2ba
+              tag: cabcb53f9692e26f129018a3580f1148f806f75d
             command: ["node", "dist/supplement/run.js"]
             env:
               MIRROR_SCHEMA: pokeapi


### PR DESCRIPTION
Bumps all five livingdex image tags (api, web, seed, mirror, supplement) from `e5e8a48` to pokemon-tracker `cabcb53` — the full three-phase UX overhaul (pokemon-tracker #28, #29, #30, all CI-green).

What lands with this rollout:

**Mobile (the big one):**
- Search works: full-width, no iOS zoom-on-focus, and a typed query searches the whole national dex regardless of the pinned generation.
- Bottom nav — **Dex / Hunt / Plan**. Hunt is the per-game catch checklist as its own screen: zone headers with caught/total progress, cleared zones auto-collapse, "Remaining only" toggle, and it remembers the game you're playing across reloads.
- Filters are a bottom sheet with a live "SHOW N ENTRIES" button; My Games/Export/Import/Mirror/Theme live behind ⋯.
- Undo on every catch toggle, 44px touch targets, no grid reflow under your finger, ticks update in place without scroll jumps.

**Desktop:**
- `/` focuses search, arrows walk the grid, `i` opens details; the detail sheet docks right with ‹ › stepping while the grid stays interactive; the header condenses on scroll; the planner is two-column on wide screens.

**Both:** one status lexicon — Caught / Catchable now / Need a game; Own means games only. Bulk "Mark transferred" needs a confirming second tap.

Front-end + api image only; **no seed/mirror/supplement re-run needed**. After Flux rolls it out: hard refresh (and on the phone it'll drop you into the new bottom-nav layout immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSQk51GCjrhGMJzwMEjmv)_