### PR TITLE
chore(container): bump book/media chain images

### DIFF
--- a/kubernetes/apps/downloads/bindery/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bindery/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
             # imports to a TEST dir so the real ABS folders are untouched.
             image:
               repository: ghcr.io/vavallee/bindery
-              tag: v1.17.0@sha256:1087b3433517e43465b1b59998060e89b235d631a1de58489a0a946663d63435
+              tag: v1.27.0@sha256:dc876fe82278654024f77a4f55cb292ee566146ad1df7bb452072ed8c723684c
             env:
               TZ: ${TIMEZONE}
               BINDERY_PORT: &port "8787"

--- a/kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/flaresolverr/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
           app:
             image:
               repository: ghcr.io/flaresolverr/flaresolverr
-              tag: v3.4.6
+              tag: v3.5.0@sha256:139dfee1c6f89249c8d665d1333a42e8ec74ec0a86bc6bb1c8461e10d3a66a47
             resources:
               requests:
                 cpu: 15m

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/prowlarr
-              tag: 2.3.7@sha256:b9557d772c974901aed9285189d904b613f1f07750fca930eecfe78544bd3d48
+              tag: 2.5.2@sha256:9dc56404214b8617d26af4af0a2df93ceb73fb4f2e1cb5383f5c2154f5fd98a2
             env:
               PROWLARR__APP_INSTANCENAME: Prowlarr
               PROWLARR__APP__THEME: dark

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/qbittorrent
-              tag: 5.1.4@sha256:bb82ad6668f8eda1d0fcce6c1341498bfa879155bb1295cd9d314a2c35c07a01
+              tag: 5.2.3@sha256:4fcf15b7f265c2c8d7bc2a7e13240a07e0593c326f3cf3b5b9bb69eec5b79299
             env:
               TZ: ${TIMEZONE}
               QBT_WEBUI_PORT: &port 80

--- a/kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
           app:
             image:
               repository: ghcr.io/recyclarr/recyclarr
-              tag: 8.6.0@sha256:3c38ceeb54438dd8327e4e65c9b48ba601a6d20fff833342d93c9b0bc4b1930b
+              tag: 8.7.0@sha256:2d6107f758d882a59fe9d646aa54fa8a5a4fb7a40995125fade575652a3f7871
             env:
               TZ: ${TIMEZONE}
             envFrom:

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/sabnzbd
-              tag: 5.0.3@sha256:53064020792b2e21305c892c11aaa1eb32af2141cbd59119b52df226d664cd05
+              tag: 5.0.4@sha256:457be5fad7b83c338a981f1945e1ecae2dedd0cc81cdd2992673b0dc84fc2890
             env:
               TZ: ${TIMEZONE}
               SABNZBD__PORT: &port 80

--- a/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
           app:
             image:
               repository: ghcr.io/advplyr/audiobookshelf
-              tag: 2.34.0@sha256:4143292c530f6ac6700afd13360c04f477e4f1a81c1c97c4224b1c7e4330c5c4
+              tag: 2.35.1@sha256:1eef6716183c52abafe5405e7d6be8390248ecd59c7488c44af871757ac8fc4d
             env:
               AUDIOBOOKSHELF_UID: 568
               AUDIOBOOKSHELF_GID: 568


### PR DESCRIPTION
Brings the book/media pipeline images current. All digests resolved authoritatively from GHCR.

| App | From | To |
|-----|------|----|
| **bindery** | v1.17.0 | **v1.27.0** |
| audiobookshelf | 2.34.0 | 2.35.1 |
| prowlarr | 2.3.7 | 2.5.2 |
| qbittorrent | 5.1.4 | 5.2.3 |
| sabnzbd | 5.0.3 | 5.0.4 |
| flaresolverr | v3.4.6 | v3.5.0 (+ digest) |
| recyclarr | 8.6.0 | 8.7.0 |

### Notes
- **bindery** is the significant one: v1.17 -> v1.27 crosses DB migrations (incl. migration 062 `locked_fields`) and ships **manual genre override + field locks** (#1446 / #1507). It auto-migrates on the existing config PVC; this is the `_bindery-test` spike deployment, so blast radius is minimal.
- **flaresolverr** was unpinned (no digest) — now pinned.
- **recyclarr** supersedes Renovate PR #2388 (safe to close).
- calibre-web-automated already at latest (v4.0.6), unchanged.

### Why manual (not Renovate)
Renovate's PR concurrency limit is saturated by the ~60-PR backlog, so it could not queue these. Draining the backlog would let it resume automatically.
