### PR TITLE
fix(plane): disable chart-managed ingress

### DIFF
--- a/kubernetes/apps/plane/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/plane/plane/app/helmrelease.yaml
@@ -25,6 +25,7 @@ spec:
   values:
     planeVersion: v1.0.0
     ingress:
+      enabled: false
       appHost: plane.${SECRET_DOMAIN}
 
     redis:


### PR DESCRIPTION
plane-ce 1.6.0 (bumped in #1824) renders Traefik IngressRoute/Middleware CRDs by default (`ingressClass: traefik`). This cluster has no Traefik — plane is routed via its own HTTPRoute — so the upgrade failed with "no matches for kind IngressRoute" and Flux rolled back to 1.4.1.

Sets `ingress.enabled: false` so the 1.6.0 upgrade can proceed. kubeconform: valid.