### PR TITLE
revert(multus): roll back to v4.2.4

### DIFF
--- a/bootstrap/templates/kubernetes/apps/network/multus/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/multus/app/helmrelease.yaml.j2
@@ -29,7 +29,7 @@ spec:
           multus:
             image:
               repository: ghcr.io/k8snetworkplumbingwg/multus-cni
-              tag: v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
+              tag: v4.2.4-thick@sha256:3c20900b5381fac7f9cbbdfac8370ea10a2f6ed7fbecc678384a9db57047abb1
         initContainers:
           cni-installer:
             image:

--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           multus:
             image:
               repository: ghcr.io/k8snetworkplumbingwg/multus-cni
-              tag: v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
+              tag: v4.2.4-thick@sha256:3c20900b5381fac7f9cbbdfac8370ea10a2f6ed7fbecc678384a9db57047abb1
         initContainers:
           cni-installer:
             image:


### PR DESCRIPTION
Reverts #2211. multus-cni v4.3.0-thick daemon crashes on start with no log output on all 3 nodes (init containers pass, main container exits immediately). RBAC verified correct; chart values unchanged. DaemonSet was 0/3 ready and the HR stuck in an upgrade/rollback retry loop. Rolling back to v4.2.4 until 4.3.0's breaking change is identified. Secondary-attachment impact only — cilium primary CNI unaffected (pod creation verified working).