### PR TITLE
fix(flux): opt out of StrictPostBuildSubstitutions

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -143,3 +143,15 @@ spec:
             target:
               kind: Deployment
               name: kustomize-controller
+          - # kustomize-controller 1.9 (Flux 2.9) enables StrictPostBuildSubstitutions
+            # by default, which fails builds on ${VARS} that are shell syntax inside
+            # scripts/configmaps (bazarr subcleaner, kopia cronjobs, mariadb initdb,
+            # NUT upsd.users) rather than Flux substitution vars. Keep legacy
+            # leave-unset-vars-as-is behavior.
+            patch: |-
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --feature-gates=StrictPostBuildSubstitutions=false
+            target:
+              kind: Deployment
+              name: kustomize-controller


### PR DESCRIPTION
Flux 2.9 (from #2000/#1999/#1840) ships kustomize-controller 1.9, which enables `StrictPostBuildSubstitutions` by default — postBuild now FAILS on any unset `${VAR}` instead of leaving it untouched.

Six kustomizations broke because their manifests embed shell/config syntax never meant for Flux substitution:
- bazarr / bazarr-foreign / bazarr-uhd — `subcleaner.sh` uses `${PLEX_TOKEN}`
- kopia — sync cronjob scripts use `${KOPIA_PASSWORD}`
- mariadb — initdb uses `${BOOKSTACK_MARIADB_PASSWORD}`
- network-ups-tools — `upsd.users` uses `${NUT_PASSWORD}`

This adds `--feature-gates=StrictPostBuildSubstitutions=false` to kustomize-controller via the FluxInstance patch list, restoring legacy behavior. Follow-up (optional, proper fix): annotate those resources with `kustomize.toolkit.fluxcd.io/substitute: disabled` or escape as `$${VAR}`, then re-enable strict mode.

kubeconform: valid.