### PR TITLE
fix(gateway-api): bump CRDs v1.4.0 -> v1.5.1

### DIFF
--- a/kubernetes/apps/network/gateway-api/app/kustomization.yaml
+++ b/kubernetes/apps/network/gateway-api/app/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 patches:
   # k8s-gateway v0.4.0 requires v1alpha2.GRPCRoute which was removed in Gateway API v1.1.0+
   # Use JSON patch to ADD v1alpha2 version without replacing existing v1


### PR DESCRIPTION
envoy-gateway 1.8.3 (#1849) installed Gateway API v1.5.1 CRDs including the safe-upgrades ValidatingAdmissionPolicy, which denies applying CRD versions <v1.5.0. Our gateway-api ks pins v1.4.0 → server-side dry-run denied → ks stuck ProgressingWithRetry with envoy-gateway/envoy-gateway-config/wings-cert-sync blocked on the dependency chain.

Aligns the pin to v1.5.1. `kustomize build` verified locally incl. the v1alpha2 GRPCRoute append patch (k8s-gateway compat).