### PR TITLE
fix(paperless-gpt): move gdocai creds mount out of /app

### DIFF
--- a/kubernetes/apps/home/paperless/paperless-gpt/externalsecret.yaml
+++ b/kubernetes/apps/home/paperless/paperless-gpt/externalsecret.yaml
@@ -17,7 +17,7 @@ spec:
         PAPERLESS_API_TOKEN: "{{ .PAPERLESS_API_TOKEN }}" #Generated here: https://paperless.{SECRET_DOMAIN}/config
         GOOGLE_PROJECT_ID: "{{ .GOOGLE_PROJECT_ID }}"
         GOOGLE_LOCATION: "{{ .GOOGLE_LOCATION_ID }}"
-        GOOGLE_APPLICATION_CREDENTIALS: "/app/gdocai-credentials.json"
+        GOOGLE_APPLICATION_CREDENTIALS: "/secrets/gdocai-credentials.json"
         GOOGLE_PROCESSOR_ID: "{{ .GOOGLE_PROCESSOR_ID }}"
         #Secret file
         gdocai-credentials.json: |

--- a/kubernetes/apps/home/paperless/paperless-gpt/helmrelease.yaml
+++ b/kubernetes/apps/home/paperless/paperless-gpt/helmrelease.yaml
@@ -89,6 +89,8 @@ spec:
         type: secret
         name: paperless-gpt-secret
         globalMounts:
-          - path: /app/gdocai-credentials.json
+          # Outside /app: the v0.26+ rootless entrypoint chowns /app recursively
+          # and exits fatally on this read-only secret mount if placed there.
+          - path: /secrets/gdocai-credentials.json
             subPath: gdocai-credentials.json
             readOnly: true


### PR DESCRIPTION
v0.27.0 (merged in #2347) crashloops: the rootless entrypoint chowns /app recursively and dies on the read-only secret mount (`chown: /app/gdocai-credentials.json: Read-only file system`). Moves the mount to `/secrets/` and updates `GOOGLE_APPLICATION_CREDENTIALS` in the ExternalSecret template to match. kubeconform: both files valid.