### PR TITLE
fix(kait): keep ServiceAccount token mounted under app-template v5

### DIFF
--- a/kubernetes/apps/observability/kait/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kait/app/helmrelease.yaml
@@ -50,6 +50,9 @@ spec:
                 drop:
                   - ALL
     defaultPodOptions:
+      # app-template v5 defaults automountServiceAccountToken to false;
+      # kait watches the cluster via its ServiceAccount and needs the token.
+      automountServiceAccountToken: true
       securityContext:
         runAsUser: 65534
         runAsGroup: 65534


### PR DESCRIPTION
Prep for #1910 (app-template 4.6.2→5.0.1): v5 defaults `automountServiceAccountToken` to false. kait is the one app in #1910's scope that talks to the k8s API via its ServiceAccount — without this it silently loses API access on the chart bump. Inert on 4.x (current default is true). kubeconform valid.