### PR TITLE
fix(flux): re-enable StrictPostBuildSubstitutions with per-resource exemptions

### DIFF
--- a/kubernetes/apps/database/mariadb/app/helmrelease.yaml
+++ b/kubernetes/apps/database/mariadb/app/helmrelease.yaml
@@ -4,6 +4,10 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: &app mariadb
+  annotations:
+    # ${*_MARIADB_PASSWORD} tokens in the initdb script are runtime shell
+    # vars, not Flux postBuild variables - exempt from strict substitution.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 spec:
   interval: 30m
   chartRef:

--- a/kubernetes/apps/downloads/bazarr-foreign/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/bazarr-foreign/app/kustomization.yaml
@@ -15,3 +15,7 @@ configMapGenerator:
       - subcleaner.sh=./resources/subcleaner.sh
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    # Shell/config-syntax ${VARS} inside these files are NOT Flux postBuild
+    # variables — exempt the generated ConfigMap from strict substitution.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/downloads/bazarr-uhd/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/bazarr-uhd/app/kustomization.yaml
@@ -15,3 +15,7 @@ configMapGenerator:
       - subcleaner.sh=./resources/subcleaner.sh
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    # Shell/config-syntax ${VARS} inside these files are NOT Flux postBuild
+    # variables — exempt the generated ConfigMap from strict substitution.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/downloads/bazarr/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/bazarr/app/kustomization.yaml
@@ -15,3 +15,7 @@ configMapGenerator:
       - subcleaner.sh=./resources/subcleaner.sh
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    # Shell/config-syntax ${VARS} inside these files are NOT Flux postBuild
+    # variables — exempt the generated ConfigMap from strict substitution.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -143,15 +143,3 @@ spec:
             target:
               kind: Deployment
               name: kustomize-controller
-          - # kustomize-controller 1.9 (Flux 2.9) enables StrictPostBuildSubstitutions
-            # by default, which fails builds on ${VARS} that are shell syntax inside
-            # scripts/configmaps (bazarr subcleaner, kopia cronjobs, mariadb initdb,
-            # NUT upsd.users) rather than Flux substitution vars. Keep legacy
-            # leave-unset-vars-as-is behavior.
-            patch: |-
-              - op: add
-                path: /spec/template/spec/containers/0/args/-
-                value: --feature-gates=StrictPostBuildSubstitutions=false
-            target:
-              kind: Deployment
-              name: kustomize-controller

--- a/kubernetes/apps/observability/network-ups-tools/app/kustomization.yaml
+++ b/kubernetes/apps/observability/network-ups-tools/app/kustomization.yaml
@@ -17,3 +17,7 @@ configMapGenerator:
       - ./config/upsmon.conf
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    # Shell/config-syntax ${VARS} inside these files are NOT Flux postBuild
+    # variables — exempt the generated ConfigMap from strict substitution.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/storage/kopia/sync/cronjob-b2.yaml
+++ b/kubernetes/apps/storage/kopia/sync/cronjob-b2.yaml
@@ -3,6 +3,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  annotations:
+    # ${VARS} in this job's shell script are runtime env vars, not Flux
+    # postBuild variables - exempt from strict substitution.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
   name: kopia-sync-b2
 spec:
   schedule: "0 2 * * *"

--- a/kubernetes/apps/storage/kopia/sync/cronjob-maintenance.yaml
+++ b/kubernetes/apps/storage/kopia/sync/cronjob-maintenance.yaml
@@ -3,6 +3,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  annotations:
+    # ${VARS} in this job's shell script are runtime env vars, not Flux
+    # postBuild variables - exempt from strict substitution.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
   name: kopia-maintenance
 spec:
   schedule: "30 */6 * * *"

--- a/kubernetes/apps/storage/kopia/sync/cronjob-r2.yaml
+++ b/kubernetes/apps/storage/kopia/sync/cronjob-r2.yaml
@@ -3,6 +3,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  annotations:
+    # ${VARS} in this job's shell script are runtime env vars, not Flux
+    # postBuild variables - exempt from strict substitution.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
   name: kopia-sync-r2
 spec:
   schedule: "0 3 * * *"


### PR DESCRIPTION
Follow-up to #2425: removes the cluster-wide `StrictPostBuildSubstitutions=false` opt-out and instead annotates the six offending resources with `kustomize.toolkit.fluxcd.io/substitute: disabled` (their `${VARS}` are runtime shell/config syntax, verified to contain zero legitimate Flux variables).

- bazarr ×3 + network-ups-tools: annotation via `generatorOptions.annotations` on the generated ConfigMaps
- kopia sync-b2/sync-r2/maintenance CronJobs: resource annotations
- mariadb HelmRelease: resource annotation (initdb passwords)

Verified: `kustomize build --load-restrictor LoadRestrictionsNone` clean for all four generator apps, annotation present on rendered ConfigMaps; kubeconform valid on the five directly-edited manifests.