### PR TITLE
fix(talos): sweep terminated pods with gc-threshold 50

### DIFF
--- a/kubernetes/bootstrap/talos/patches/controller/cluster.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/cluster.yaml
@@ -14,6 +14,11 @@ cluster:
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
+      # Default is 12500 — a homelab never reaches it, so Deployment pods
+      # left in Succeeded by node power events linger forever and wedge
+      # later helm upgrades (2026-05-25 event left 72 such pods; see
+      # concept StaleSucceededPodsWedgeHelmUpgrades). Sweep them promptly.
+      terminated-pod-gc-threshold: "50"
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Incident follow-up: default 12,500 threshold is unreachable in a homelab; 50 sweeps power-event orphans promptly. Git-only until next talhelper genconfig+apply (Talos 1.13 window). Upstream only fixed StatefulSets (k8s #121389).