### PR TITLE
fix(multus): raise helm timeout to 15m

### DIFF
--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -6,6 +6,11 @@ metadata:
   name: multus
 spec:
   interval: 30m
+  # The DS rolls serially (maxUnavailable 1) and the republished 7.0.0 chart
+  # changes the ServiceAccount name, so a full roll doesn't fit helm's 5m
+  # default — timeouts mid-roll left pods and the ClusterRoleBinding on
+  # different SAs (RBAC desync flap, 2026-07-25).
+  timeout: 15m
   chart:
     spec:
       chart: multus


### PR DESCRIPTION
The angelnu multus chart was republished under the same 7.0.0 version with a different ServiceAccount layout (and appVersion 4.3.0 metadata). Every helm upgrade therefore rolls the DaemonSet; with maxUnavailable=1 the serial roll exceeds helm's 5m default wait, remediation rolls back mid-flight, and pods desync from the ClusterRoleBinding's SA — a crashloop flap we hit repeatedly today. 15m gives one attempt room to converge. (Live cluster currently stabilized with the HR suspended + both SAs bound; will resume after merge.)