### PR TITLE
feat(renovate): track gateway-api CRD release URL

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -15,6 +15,9 @@
         // # renovate: datasource=docker depName=ghcr.io/foo/bar
         // FOOBAR_VERSION=v1.0.0
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)",
+        // # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+        // - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s*- https://github\\.com/[^/]+/[^/]+/releases/download/(?<currentValue>[^/]+)/",
       ],
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
     },

--- a/kubernetes/apps/network/gateway-api/app/kustomization.yaml
+++ b/kubernetes/apps/network/gateway-api/app/kustomization.yaml
@@ -2,6 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # Must stay >= the Gateway API version envoy-gateway bundles — its v1.5+
+  # safe-upgrades ValidatingAdmissionPolicy denies older CRD applies.
+  # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
   - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 patches:
   # k8s-gateway v0.4.0 requires v1alpha2.GRPCRoute which was removed in Gateway API v1.1.0+


### PR DESCRIPTION
Incident follow-up (Gateway API VAP): the `gateway-api` ks pins an upstream release-download URL Renovate couldn't parse, so it drifted to v1.4.0 while envoy-gateway 1.8 bundled v1.5.1 + a ValidatingAdmissionPolicy denying older applies. Adds a `releases/download/<version>/` matchString to the existing annotated-dependency custom manager and annotates the pin. Regex verified against the file (captures v1.5.1); kustomize build clean.

Note: full single-CRD-owner separation was researched but deferred — gateway-helm 1.8.3 only exposes an all-or-nothing `crds.enabled`, and disabling it would remove envoy's own CRDs. Coexistence is safe while versions match, which this PR keeps true automatically.