### PR TITLE
fix(multus): mount ServiceAccount token under republished chart

### DIFF
--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -28,6 +28,11 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    # Chart 7.0.0 was republished on app-template/common v5, which defaults
+    # automountServiceAccountToken to false — the thick daemon then has no
+    # API token and exits instantly with no log output (2026-07-25 flap).
+    defaultPodOptions:
+      automountServiceAccountToken: true
     controllers:
       # The chart ships `test` + `uninstall` hook controllers. They
       # break `flux-local test` because with 2 ServiceAccounts in the


### PR DESCRIPTION
Final piece of the multus flap: chart 7.0.0 was republished on common/app-template v5, which (a) auto-creates a `multus-default` SA and (b) defaults `automountServiceAccountToken: false`. Every post-republish render produced a tokenless thick daemon that exits instantly with zero log output — image version irrelevant (both 4.2.4 and 4.3.0 crashed identically). Diff evidence: crashing pods lack the `kube-api-access` volume that surviving old-template pods have.

Sets `defaultPodOptions.automountServiceAccountToken: true` (same class of fix as kait in #2432). Combined with #2435's 15m timeout this should let one upgrade converge. HR currently suspended; will resume after merge.