### PR TITLE
fix(influxdb3): request at-home license instead of expired trial

### DIFF
--- a/kubernetes/apps/database/influxdb3/app/helmrelease.yaml
+++ b/kubernetes/apps/database/influxdb3/app/helmrelease.yaml
@@ -52,6 +52,13 @@ spec:
               - --disable-authz=health
             env:
               AWS_ALLOW_HTTP: "true"
+              # Without this the server requests a TRIAL license, which
+              # expired 2026-07 (license server 402s, pod crashloops).
+              # `home` = free at-home tier: no expiry, 2-CPU limit,
+              # activates via verification email to the wired
+              # INFLUXDB3_ENTERPRISE_LICENSE_EMAIL, then persists the
+              # license into object storage.
+              INFLUXDB3_ENTERPRISE_LICENSE_TYPE: home
             envFrom:
               # OBC-generated creds: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
               - secretRef:


### PR DESCRIPTION
influxdb3 has crashlooped since ~2026-07-21: it requests a **trial** license (never told otherwise), the trial for this email/instance expired, and the license server 402s. `INFLUXDB3_ENTERPRISE_LICENSE_TYPE=home` switches to the free at-home tier using the `INFLUXDB3_ENTERPRISE_LICENSE_EMAIL` already wired via the ExternalSecret. Per InfluxData docs, activation sends a verification email — **click the link when it arrives**, then the license auto-persists into object storage. Unblocks the `observability/otel-collector` dependency chain (and the already-merged otel chart bumps).