### PR TITLE
feat(rook-ceph): bump operator+cluster charts to v1.19.7

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.3
+    tag: v1.19.7
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.3
+    tag: v1.19.7
   url: oci://ghcr.io/rook/rook-ceph-cluster


### PR DESCRIPTION
Rook 1.20 prerequisite (Phase 1): the official upgrade guide gates 1.20.x behind >=1.19.5 ("critical update"). Bumps both operator and cluster charts 1.19.3 → 1.19.7 (latest 1.19.x). Same-minor: no CRD changes, CSI still operator-managed. Phase 2 (1.20.2 + the ceph-csi-drivers chart migration) is a separate planned session. Supersedes the version step in #1955/#1956 without replacing them.