### PR TITLE
fix(immich): rename libopus to opus in accepted audio codecs

### DIFF
--- a/kubernetes/apps/entertainment/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/entertainment/immich/app/externalsecret.yaml
@@ -32,7 +32,9 @@ spec:
             acceptedAudioCodecs:
               - aac
               - mp3
-              - libopus
+              # v3 renamed the accepted value libopus -> opus; the old name
+              # fails Zod config validation and blocks server startup.
+              - opus
             acceptedContainers:
               - mov
               - ogg


### PR DESCRIPTION
Immich v3.0.3 (#2331) fails startup on config validation: `[ffmpeg.acceptedAudioCodecs.2] Invalid option: expected one of "mp3"|"aac"|"opus"|"pcm_s16le"` — v3 renamed `libopus` → `opus`. Rest of the templated config audited against the v3 schema; this was the only invalid value. ES re-render + Reloader restart completes the v3 rollout.