### PR TITLE
fix(immich): split ML preload env vars for v3

### DIFF
--- a/kubernetes/apps/entertainment/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/immich/app/helmrelease.yaml
@@ -114,9 +114,15 @@ spec:
               # ML cache folder paths
               MACHINE_LEARNING_CACHE_FOLDER: "/cache"
               TRANSFORMERS_CACHE: "/cache"
-              # Preload models on startup for faster first requests
-              MACHINE_LEARNING_PRELOAD__CLIP: "ViT-B-32__openai"
-              MACHINE_LEARNING_PRELOAD__FACIAL_RECOGNITION: "buffalo_l"
+              # Preload models on startup for faster first requests.
+              # v3 split the preload vars into per-task variants — the old
+              # unsplit names fail pydantic parsing and crash the pod.
+              # Also aligned CLIP preload with the model search actually
+              # uses (was warming ViT-B-32__openai for nothing).
+              MACHINE_LEARNING_PRELOAD__CLIP__TEXTUAL: "ViT-SO400M-16-SigLIP2-384__webli"
+              MACHINE_LEARNING_PRELOAD__CLIP__VISUAL: "ViT-SO400M-16-SigLIP2-384__webli"
+              MACHINE_LEARNING_PRELOAD__FACIAL_RECOGNITION__DETECTION: "buffalo_l"
+              MACHINE_LEARNING_PRELOAD__FACIAL_RECOGNITION__RECOGNITION: "buffalo_l"
               IMMICH_MEDIA_LOCATION: *mediaLocation
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
Second v3 config break (predicted in the upgrade research): the machine-learning pod crashloops with `SettingsError: error parsing value for field "preload"` because v3 split the preload env vars into per-task variants. Renames both, and aligns the CLIP preload with the model the config actually uses for search. Server pod is already healthy on v3 (UI 200) — this completes the ML rollout.