### PR TITLE
fix(rook-ceph): bump cluster chart version pin to v1.19.7

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: v1.19.3
+      version: v1.19.7
       sourceRef:
         kind: HelmRepository
         name: rook-ceph-charts


### PR DESCRIPTION
Completes #2442 (Rook 1.20 Phase-1 prerequisite): the cluster HR uses a HelmRepository + `version:` pin rather than the OCIRepository, so bumping only the ocirepository files upgraded the operator but left the cluster chart at v1.19.3. Ceph HEALTH_OK throughout.