### PR TITLE
fix(dragonfly): grant operator configmaps RBAC for v1.6

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/rbac.yaml
+++ b/kubernetes/apps/database/dragonfly/app/rbac.yaml
@@ -28,6 +28,11 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Operator v1.6+ runs a cluster-scoped ConfigMap informer; without this
+  # the manager's cache never syncs and it crashloops on startup.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]


### PR DESCRIPTION
Wave-D regression finally surfaced: dragonfly-operator v1.6.1 (#2222) adds a cluster-scoped ConfigMap informer; our repo-managed ClusterRole (predates it) lacks `configmaps`, so the cache never syncs and the manager exits — 190 restarts since the bump, hidden behind a misleading `*v1.NetworkPolicy: timed out waiting for cache to be synced` shutdown message (real error: `configmaps is forbidden ... at the cluster scope`). DF pods kept serving throughout. Once the operator is healthy it will finally roll the dragonfly v1.39.0 image from #1829 — will watch that rollout.