### PR TITLE
fix(volsync): self-delete successful kopia maintenance jobs

### DIFF
--- a/kubernetes/components/volsync/s3-backblaze/kopiamaintenance.yaml
+++ b/kubernetes/components/volsync/s3-backblaze/kopiamaintenance.yaml
@@ -25,7 +25,10 @@ spec:
     schedule: "${VOLSYNC_B2_MINUTE:=0} 4 * * *"
   cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=8Gi}
   cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
-  successfulJobsHistoryLimit: 1
+  # 0 = successful maintenance jobs (and their Completed pods) self-delete;
+  # ~51 of these across the cluster otherwise leave a daily pod graveyard.
+  # Failures stay visible below for debugging.
+  successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 2
   podSecurityContext:
     runAsUser: ${VOLSYNC_UID:=568}


### PR DESCRIPTION
`successfulJobsHistoryLimit: 1` across the ~51 templated KopiaMaintenance CRs leaves ~54 Completed `kopia-maint-*` pods sitting cluster-wide every day (just swept manually). Setting 0 lets successful jobs and their pods self-delete; `failedJobsHistoryLimit: 2` unchanged so failures remain inspectable. Applies to all CRs via the s3-backblaze component on next reconcile.