### PR TITLE
fix(tqm): exclude myanonamouse from auto-removal rules

### DIFF
--- a/kubernetes/apps/downloads/tqm/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/tqm/app/externalsecret.yaml
@@ -85,8 +85,11 @@ spec:
                 # iptorrents - 1.01 ratio or 14.1 days
                 - (TrackerName contains "bgp.technology" || TrackerName contains "empirehost.me" || TrackerName contains "stackoverflow.tech") && (Ratio > 1.01 || SeedingDays >= 14.1)
 
-                # myanonamouse - 1.01 ratio or 3.0 days
-                - TrackerName contains "myanonamouse.net" && (Ratio > 1.01 || SeedingDays >= 3.0)
+                # myanonamouse - EXCLUDED from auto-removal (2026-07-28): the 3.0-day rule
+                # fired on qBittorrent's seed clock, which runs ahead of MAM's own
+                # 72h satisfied clock, hit-and-running the tail of every batch. Book
+                # torrents also deliberately seed for weeks for ratio. MAM cleanup is
+                # manual-only now; do not re-add a MAM rule here.
 
                 # milkie - 1.01 ratio or 7.1 days
                 - TrackerName contains "milkie.cc" && (Ratio > 1.01 || SeedingDays >= 7.1)
@@ -153,7 +156,6 @@ spec:
                     - (TrackerName contains "filelist.io" || TrackerName contains "flro.org") && (Ratio >= 1.01 || SeedingDays >= 2.1)
                     - TrackerName contains "hdts-announce.ru" && (Ratio >= 1.01 || SeedingDays >= 3.1)
                     - (TrackerName contains "bgp.technology" || TrackerName contains "empirehost.me" || TrackerName contains "stackoverflow.tech") && (Ratio >= 1.01 || SeedingDays >= 14.1)
-                    - TrackerName contains "myanonamouse.net" && (Ratio >= 1.01 || SeedingDays >= 3.0)
                     - TrackerName contains "milkie.cc" && (Ratio >= 1.01 || SeedingDays >= 7.1)
                     - TrackerName contains "morethantv.me" && (Ratio >= 1.01 || SeedingDays >= 7.1)
                     - TrackerName contains "passthepopcorn.me" && (Ratio >= 1.01 || SeedingDays >= 7.1)


### PR DESCRIPTION
tqm's hourly clean removed MAM torrents (with data) at qB-measured SeedingDays >= 3.0. qBittorrent's seed clock runs ahead of MAM's own 72h satisfied clock, so the tail of every batch was removed short of requirement and flagged hit-and-run (60 torrents across 27-28 Jul, all since re-seeded). Book torrents are also deliberately seeded long-term for ratio.

This removes MAM from both the `clean` filter and the `expired` tag filter — MAM cleanup becomes manual-only.

Note: the tqm ks/hr/cronjob are currently suspended in-cluster (emergency stop mid-incident). After merge, resume with:
```
flux resume kustomization tqm -n downloads
flux resume helmrelease tqm -n downloads
kubectl patch cronjob tqm -n downloads -p '{"spec":{"suspend":false}}'
```