### PR TITLE
feat(tqm): flat 30-day seed rule for all trackers

### DIFF
--- a/kubernetes/apps/downloads/tqm/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/tqm/app/externalsecret.yaml
@@ -42,87 +42,13 @@ spec:
                 # Remove unregistered torrents (after 1 day grace period)
                 - IsUnregistered() && AddedDays >= 1
 
-                # Tracker-specific removal rules based on seed ratio/time
-                # aither - no requirements
-                - TrackerName contains "aither.cc" && (Ratio > 0 || SeedingDays >= 0.1)
-
-                # alpharatio - 1.01 ratio or 7.1 days
-                - TrackerName contains "alpharatio.cc" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # anthelion - 1.01 ratio or 7.1 days
-                - TrackerName contains "anthelion.me" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # animetosho - 1.01 ratio or 7.1 days
-                - TrackerName contains "animetosho.org" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # avistaz - 0.91 ratio or 7.1 days (size-based HnR, using safe defaults)
-                - TrackerName contains "avistaz.to" && (Ratio > 0.91 || SeedingDays >= 7.1)
-
-                # exoticaz - 0.91 ratio or 7.1 days (size-based HnR, using safe defaults)
-                - TrackerName contains "exoticaz.to" && (Ratio > 0.91 || SeedingDays >= 7.1)
-
-                # pussytorrents - 0.41 ratio or 3.1 days (0.4 ratio or 60 hours within 72 hours)
-                - TrackerName contains "pussytorrents.org" && (Ratio > 0.41 || SeedingDays >= 3.1)
-
-                # beyond-hd - no requirements
-                - TrackerName contains "beyond-hd.me" && (Ratio > 0 || SeedingDays >= 0.1)
-
-                # blutopia - 0 ratio or 7.1 days
-                - (TrackerName contains "blutopia.cc" || TrackerName contains "blutopia.xyz") && (Ratio > 0 || SeedingDays >= 7.1)
-
-                # fearnopeer - 1.01 ratio or 7.1 days
-                - TrackerName contains "fearnopeer.com" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # filelist - 1.01 ratio or 2.1 days
-                - (TrackerName contains "filelist.io" || TrackerName contains "flro.org") && (Ratio > 1.01 || SeedingDays >= 2.1)
-
-                # hd-space - 0 ratio or 2.1 days
-                - TrackerName contains "hd-space.pw" && (Ratio > 0 || SeedingDays >= 2.1)
-
-                # hd-torrents - 1.01 ratio or 3.1 days
-                - TrackerName contains "hdts-announce.ru" && (Ratio > 1.01 || SeedingDays >= 3.1)
-
-                # iptorrents - 1.01 ratio or 14.1 days
-                - (TrackerName contains "bgp.technology" || TrackerName contains "empirehost.me" || TrackerName contains "stackoverflow.tech") && (Ratio > 1.01 || SeedingDays >= 14.1)
-
-                # myanonamouse - EXCLUDED from auto-removal (2026-07-28): the 3.0-day rule
-                # fired on qBittorrent's seed clock, which runs ahead of MAM's own
-                # 72h satisfied clock, hit-and-running the tail of every batch. Book
-                # torrents also deliberately seed for weeks for ratio. MAM cleanup is
-                # manual-only now; do not re-add a MAM rule here.
-
-                # milkie - 1.01 ratio or 7.1 days
-                - TrackerName contains "milkie.cc" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # morethantv - 1.01 ratio or 7.1 days
-                - TrackerName contains "morethantv.me" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # nebulance - 0 ratio or 5.1 days
-                - TrackerName contains "nebulance.io" && (Ratio > 0 || SeedingDays >= 5.1)
-
-                # passthepopcorn - 1.01 ratio or 7.1 days
-                - TrackerName contains "passthepopcorn.me" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # privatehd - 0.91 ratio or 14.1 days
-                - TrackerName contains "privatehd.to" && (Ratio > 0.91 || SeedingDays >= 14.1)
-
-                # reelflix - 1.01 ratio or 7.1 days
-                - TrackerName contains "reelflix.xyz" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # scenetime - 1.01 ratio or 3.1 days
-                - TrackerName contains "scenetime.com" && (Ratio > 1.01 || SeedingDays >= 3.1)
-
-                # torrentday - 1.01 ratio or 3.1 days
-                - (TrackerName contains "jumbohostpro.eu" || TrackerName contains "td-peers.com") && (Ratio > 1.01 || SeedingDays >= 3.1)
-
-                # torrentleech - 1.01 ratio or 6.1 days
-                - (TrackerName contains "tleechreload.org" || TrackerName contains "torrentleech.org") && (Ratio > 1.01 || SeedingDays >= 6.1)
-
-                # torrentseeds - 1.01 ratio or 7.1 days
-                - TrackerName contains "torrentseeds.org" && (Ratio > 1.01 || SeedingDays >= 7.1)
-
-                # uhdbits - 1.01 ratio or 7.1 days
-                - TrackerName contains "uhdbits.org" && (Ratio > 1.01 || SeedingDays >= 7.1)
+                # Flat 30-day seed rule for ALL trackers (2026-07-29): every torrent
+                # seeds a full 30 days before removal, regardless of ratio. This
+                # guarantees solid seed ratios everywhere and dwarfs every
+                # tracker's H&R requirement (max was 14d), so qB-vs-tracker seed
+                # clock skew can never cause a hit-and-run again. Trade-off:
+                # completed torrents occupy /complete for 30 days.
+                - SeedingDays >= 30.0
 
               tag:
                 # Tag unregistered torrents


### PR DESCRIPTION
Follow-up to #2472 per discussion: instead of MAM-only exclusion + per-tracker thresholds, every torrent now seeds a flat **30 days** before tqm removes it (ratio early-exits dropped — the point is guaranteed long seeds for ratio building).

- `remove:` is now just unregistered-cleanup + `SeedingDays >= 30.0`
- All ignore guards unchanged (downloading, tracker down, 1-day grace, `manual` label)
- 30 qB-days dwarfs every tracker requirement (max was 14d) → the clock-skew hit-and-run class from #2472 is structurally impossible
- Trade-off: completed torrents occupy /complete for 30 days (sonarr/radarr churn included)

tqm is still triple-suspended in-cluster from the incident. After merging, resume with:
```
flux resume kustomization tqm -n downloads
flux resume helmrelease tqm -n downloads
kubectl patch cronjob tqm -n downloads -p '{"spec":{"suspend":false}}'
```