### PR TITLE
fix(audiobookshelf): raise app memory limit 1Gi->3Gi

### DIFF
--- a/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
@@ -68,9 +68,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 256Mi
+                memory: 512Mi
               limits:
-                memory: 1Gi
+                memory: 3Gi
           abs-tract:
             image:
               repository: arranhs/abs-tract


### PR DESCRIPTION
Library scans across 15 book libraries OOMKilled the ABS app container at the 1Gi limit (alert fired 2026-07-31 10:54 NZT, container restart confirmed). Raises limit to 3Gi and request to 512Mi so concurrent and large library scans have headroom.

Normal idle usage is ~72Mi; this only widens the burst ceiling for scans.