### PR TITLE
fix(audiobookshelf): redirect bare /login to /audiobookshelf/login for OIDC

### DIFF
--- a/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
@@ -110,6 +110,27 @@ spec:
             namespace: network
             sectionName: https
         rules:
+          # ABS >=2.31 serves the web client under /audiobookshelf and its OIDC
+          # callback validation rejects callbacks outside that base path, so a
+          # login page loaded at the bare /login path 400s on the SSO button.
+          # Send browsers to the canonical prefixed login page. GET-only so the
+          # mobile app's POST /login (local auth API) is untouched.
+          - matches:
+              - path:
+                  type: Exact
+                  value: /login
+                method: GET
+              - path:
+                  type: Exact
+                  value: /login/
+                method: GET
+            filters:
+              - type: RequestRedirect
+                requestRedirect:
+                  path:
+                    type: ReplaceFullPath
+                    replaceFullPath: /audiobookshelf/login/
+                  statusCode: 302
           - backendRefs:
               - identifier: app
                 port: *port


### PR DESCRIPTION
## Problem
Clicking **Login with Pocket ID** on the Audiobookshelf web login page returns `400 {"message":"Invalid callback URL - must be same-origin"}`. Pocket-ID logs confirm no ABS authorize request has arrived in over a week — the flow dies before ever leaving ABS.

## Root cause
ABS ≥2.31 hard-codes a default `ROUTER_BASE_PATH=/audiobookshelf` (verified in `prod.js` for v2.31–v2.36) and its OIDC callback validation (`OidcAuthStrategy.isValidWebCallbackUrl`) requires the callback **path** to start with `/audiobookshelf/`. The login page loaded at the bare `https://books.<domain>/login/` sends `callback=location.href`, whose path fails that check. Live log proof:
```
WARN: [OidcAuth] Rejected same-origin callback URL outside router base path: https://books.<domain>/login
```
Setting `ROUTER_BASE_PATH=""` is **not** viable — the client bundle in the image is built with `/audiobookshelf` baked into its router/asset base. v2.36.0 keeps the same validation, so no upstream fix.

## Fix
Gateway-level 302: `GET /login` and `GET /login/` → `/audiobookshelf/login/`, the canonical login page from which the button verifiably 302s into `id.nerdz.cloud/authorize` with the already-registered `redirect_uri`. GET-only match so the mobile app's `POST /login` local-auth API is untouched.

## Safety
Route-only change — the Deployment spec is unchanged, so **no pod restart**; safe to merge while the current ABS batch job is running. Rendered with app-template 4.4.0 (`helm template`) and kubeconform-validated.