### PR TITLE
fix(calibre-web-automated): raise app memory limit 1Gi->3Gi

### DIFF
--- a/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
@@ -107,7 +107,7 @@ spec:
                 cpu: 50m
                 memory: 256Mi
               limits:
-                memory: 1Gi
+                memory: 3Gi
           # Headless Calibre Content Server (the API Readarr integrates with).
           # Same image (calibre-server is at /app/calibre/calibre-server), same
           # library volume. Runs as 568 (the NFS file owner) so writes stay


### PR DESCRIPTION
Third OOMKill of the CWA app container (restart #12 today, `lastState: OOMKilled`), this time during a bulk `ebook-meta` metadata pass over staged files; previously the July ingest influx. Same treatment as audiobookshelf in #2499.

Docs-adjacent context: the metadata-cleanup phase (see nerdz-reading) runs periodic batch bakes through this container, so headroom matters beyond the incident.