### PR TITLE
fix(recyclarr): block DV Profile 5 on the radarr-uhd profile actually in use

### DIFF
--- a/kubernetes/apps/downloads/recyclarr/app/config/radarr-uhd.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/config/radarr-uhd.yaml
@@ -78,9 +78,6 @@ radarr:
 
       # HDR / DV — upstream retired several boost CFs in v8; replacements noted below.
       - trash_ids:
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)  (was "DV (WEBDL)" pre-v8)
-
           # HDR10+ Boost — trash_id renamed upstream
           - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost  (was b17886cb...)
           # NOTE: The pre-v8 combined "DV HDR10+ Boost" (55a5b50c...) was retired upstream;
@@ -88,6 +85,25 @@ radarr:
           # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
         assign_scores_to:
           - name: SQP-1 (2160p)
+
+      # Dolby Vision Profile 5 block.
+      # P5 carries no HDR10 base layer, so anything that tone-maps it (Plex Web /
+      # Chrome, most browser clients) renders green/purple. Score it below the
+      # profile minimum on every profile that is actually in use.
+      #
+      # Ultra-HD is NOT listed under quality_profiles: above on purpose — recyclarr
+      # only syncs CF scores to a profile named here, it does not rewrite the
+      # profile's quality items or tiers. Ultra-HD is lossless-audio-first
+      # (TrueHD ATMOS +5000); the SQP-1 guide profile bans lossless audio
+      # (TrueHD ATMOS -10000). Do not point the quality_profiles: block at
+      # Ultra-HD or every UHD movie in the library flips to negative scoring.
+      - trash_ids:
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)  (was "DV (WEBDL)" pre-v8)
+        assign_scores_to:
+          - name: SQP-1 (2160p)
+            score: -10000
+          - name: Ultra-HD
+            score: -10000
 
       # Unwanted (based on onedr0p's config) SDR
       # Only ever use ONE of the following custom formats:


### PR DESCRIPTION
## Problem

The `DV (w/o HDR fallback)` custom format was only assigned to the **SQP-1 (2160p)** quality profile, which has **zero movies bound to it**. All 58 UHD movies use the **Ultra-HD** profile, where that CF scored **0** — so Dolby Vision Profile 5 releases passed the 4500 minimum unchallenged.

P5 carries no HDR10 base layer, so any client that tone-maps it (Plex Web / Chrome) renders green/purple.

## Evidence

Confirmed against the release that produced the Fellowship of the Ring file:

```
...2160p.MAX.WEB-DL.TrueHD.7.1.DV.H.265-FLUX
CFs: DV (w/o HDR fallback), MAX, TrueHD, WEB Tier 01
score 4450  ->  -5550 with this change   (profile minimum 4500)
```

Profile scores before this change:

| CF | SQP-1 (2160p) — 0 movies | Ultra-HD — 58 movies |
|---|---|---|
| `DV (w/o HDR fallback)` | -10000 | **0** |

## Fix

Split the DV CF into its own block, scored -10000 on **both** profiles.

`Ultra-HD` is deliberately **not** added to `quality_profiles:`. Recyclarr syncs CF scores to any profile named in `assign_scores_to` without rewriting its quality items or tiers. Pointing `quality_profiles:` at `Ultra-HD` would overwrite it with the SQP-1 guide definition, which scores `TrueHD ATMOS` at **-10000** where `Ultra-HD` scores it **+5000** — flipping the entire lossless-audio library negative.

## Known limitations

- The CF matches on **release title**, so disc remuxes tagged only `DV` (Profile 7, valid HDR10 base layer) are also caught.
- The CF's optional spec group requires source `WEBDL`/`WEBRIP`, so a P5 release that Radarr classifies as Bluray still slips past. Catching those needs mediainfo-based detection (`videoDynamicRangeType`), not custom formats.

## Validation

- `scripts/kubeconform.sh kubernetes` → `Kustomization recyclarr is valid`
- `kustomize build --load-restrictor LoadRestrictionsNone` clean; config lands in the ConfigMap
- Pre-existing unrelated failure in the suite: `Gateway external` rejects `${ENVOY_EXTERNAL_LBIP}` as a non-literal IP
