### PR TITLE
feat(entertainment): add bookorbit reading hub (trial)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -90,6 +90,31 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: &app cloudnative-pg-postgres18-bookorbit
+  namespace: &namespace database
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: database
+  path: ./kubernetes/apps/database/cloudnative-pg/postgres18-bookorbit
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: &app cloudnative-pg-postgres18-cluster
   namespace: &namespace database
 spec:

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-bookorbit/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-bookorbit/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./postgres18-bookorbit.yaml

--- a/kubernetes/apps/database/cloudnative-pg/postgres18-bookorbit/postgres18-bookorbit.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/postgres18-bookorbit/postgres18-bookorbit.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres18-bookorbit
+  namespace: database
+spec:
+  # TRIAL POSTURE: single instance, no pgBackRest. BookOrbit is being evaluated
+  # as the reading hub; its DB holds re-derivable scan metadata plus early user
+  # state. Before promoting to production: bump instances to 3 and wire the
+  # pgbackrest plugin + stanza/pluginconfig/scheduledbackups (mirror
+  # postgres18-immich).
+  instances: 1
+  # BookOrbit requires the uuid-ossp, pg_trgm, and vector (pgvector) extensions.
+  # The vectorchord image ships vector 0.8.1 + contrib (verified against the
+  # running postgres18-immich cluster); same pinned image as postgres18-immich.
+  # renovate: datasource=docker depName=ghcr.io/tensorchord/cloudnative-vectorchord versioning=loose enabled=false
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:18.0-0.5.3@sha256:267f6cbb32af6e109e138a143c7e9dd5d44d68433ec2303f0c30e745c788d1a9
+  primaryUpdateStrategy: unsupervised
+
+  storage:
+    size: 10Gi
+    storageClass: openebs-hostpath
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cloudnative-pg-secret
+
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: 256MB
+
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 2Gi
+
+  monitoring:
+    enablePodMonitor: true
+
+  bootstrap:
+    initdb:
+      database: bookorbit
+      owner: bookorbit
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS "uuid-ossp" CASCADE
+        - CREATE EXTENSION IF NOT EXISTS pg_trgm CASCADE
+        - CREATE EXTENSION IF NOT EXISTS vector CASCADE

--- a/kubernetes/apps/entertainment/bookorbit/app/externalsecret.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/externalsecret.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bookorbit
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: bookorbit-secret
+    template:
+      engineVersion: v2
+      data:
+        # postgres-init: ensure the bookorbit role/database exist on the
+        # dedicated CNPG cluster with the 1Password-managed password.
+        # (CNPG initdb bootstrap creates them on first cluster start; the init
+        # container makes the password match 1Password and heals drift.)
+        INIT_POSTGRES_DBNAME: bookorbit
+        INIT_POSTGRES_HOST: postgres18-bookorbit-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .BOOKORBIT_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .BOOKORBIT_POSTGRES_PASS }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        # BookOrbit's own database connection (compose-style discrete parts)
+        POSTGRES_HOST: postgres18-bookorbit-rw.database.svc.cluster.local
+        POSTGRES_PORT: "5432"
+        POSTGRES_DB: bookorbit
+        POSTGRES_USER: "{{ .BOOKORBIT_POSTGRES_USER }}"
+        POSTGRES_PASSWORD: "{{ .BOOKORBIT_POSTGRES_PASS }}"
+        # App secrets
+        JWT_SECRET: "{{ .BOOKORBIT_JWT_SECRET }}"
+        SETUP_BOOTSTRAP_TOKEN: "{{ .BOOKORBIT_SETUP_BOOTSTRAP_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: bookorbit
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
@@ -1,0 +1,139 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app bookorbit
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      bookorbit:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.4.0@sha256:ebd9d30add17acdf935d73eb004758c7dfd9388aaa605fda70ad74378ab92aec
+            envFrom:
+              - secretRef:
+                  name: bookorbit-secret
+        containers:
+          app:
+            # BookOrbit TRIAL as the family reading hub: library + web readers,
+            # OPDS server, KOSync endpoints, KOReader/Kobo sync, annotations hub,
+            # Hardcover/StoryGraph sync. The library is mounted READ-ONLY while
+            # the CWA-vs-BookOrbit metadata-in-file question is decided — its
+            # scanner works, but nothing can bake metadata into the files yet.
+            image:
+              repository: ghcr.io/bookorbit/bookorbit
+              tag: 2.5.0@sha256:e131834be597819000e44d580cbe16c168895a6334315ba4101963c028c29b0e
+            env:
+              TZ: ${TIMEZONE}
+              NODE_ENV: production
+              PORT: &port 3000
+              APP_URL: https://bookorbit.${SECRET_DOMAIN}
+              # Run as the cluster-standard app UID; ownership is managed by the
+              # NFS exports and fsGroup, not by the container entrypoint.
+              PUID: "568"
+              PGID: "568"
+              BOOKORBIT_FIX_PERMISSIONS: "false"
+              # Scope the in-app library folder picker to the mounted library
+              LIBRARY_BROWSE_ROOT: /books
+              # pocket-id's issuer resolves to the internal gateway LB (private
+              # IP) from inside the cluster; without this the OIDC discovery
+              # SSRF guard refuses it.
+              OIDC_ALLOW_LOCAL_ISSUERS: "true"
+              NODE_MAX_OLD_SPACE_SIZE: "3072"
+            envFrom:
+              - secretRef:
+                  name: bookorbit-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/health
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: bookorbit
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 10Gi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /data
+      # Same single NFS export as audiobookshelf/CWA, sub-pathed to the family
+      # genre-tree library. READ-ONLY for the trial: BookOrbit's file-write
+      # pipeline (metadata baking, renames) stays inert until the
+      # CWA-vs-BookOrbit metadata-management decision is made.
+      books:
+        type: nfs
+        server: citadel.internal
+        path: /mnt/storage0/media
+        globalMounts:
+          - path: /books
+            subPath: Library/Books
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/entertainment/bookorbit/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/entertainment/bookorbit/ks.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bookorbit
+  namespace: &namespace entertainment
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-postgres18-bookorbit
+      namespace: database
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/entertainment/bookorbit/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/entertainment/kustomization.yaml
+++ b/kubernetes/apps/entertainment/kustomization.yaml
@@ -10,6 +10,7 @@ components:
 resources:
   # Applications
   - ./audiobookshelf/ks.yaml
+  - ./bookorbit/ks.yaml
   - ./immich/ks.yaml
   - ./kavita/ks.yaml
   - ./komf/ks.yaml


### PR DESCRIPTION
## What

Deploys **[BookOrbit](https://bookorbit.app)** v2.5.0 as a trial of the family reading hub, per the reading-stack redesign findings (nerdz-reading `docs/reading-stack-holistic-findings.md`). One app covering: library + web readers (ebooks/PDF/comics/audiobooks), OPDS server, standard KOSync endpoints, first-party KOReader plugin with two-way annotation sync, native Kobo sync protocol, per-user annotations hub with web UI, and per-user Hardcover/Readwise/StoryGraph sync.

## Pieces

| Piece | Choice | Why |
|---|---|---|
| Database | Dedicated CNPG cluster `postgres18-bookorbit`, vectorchord image (same pinned digest as immich) | BookOrbit requires `vector` (pgvector) + `pg_trgm` + `uuid-ossp`; verified live on the immich cluster that this image ships all three. Stock `postgres18-cluster` image has no pgvector. |
| DB posture | **1 instance, no pgBackRest** | Trial data only. Promotion checklist in the Cluster manifest comment (3 instances + stanza/pluginconfig/scheduledbackups, mirror immich). |
| Library mount | NFS `citadel.internal:/mnt/storage0/media` subPath `Library/Books` at `/books`, **readOnly: true** | The CWA-vs-BookOrbit metadata-in-file question is deliberately unresolved; RO keeps its baking/rename pipeline inert while the scanner + readers + sync are evaluated. |
| App data | 10Gi ceph-block at `/data` | Covers, caches, app state. |
| Route | internal (`bookorbit.${SECRET_DOMAIN}`) | Match CWA posture for now; external exposure is a later, deliberate step. |
| Security | 568/non-root, read-only rootfs, cap-drop ALL, `BOOKORBIT_FIX_PERMISSIONS=false`, PUID/PGID 568 | Upstream compose runs read-only with cap adds for self-chown; we disable self-chown and let fsGroup/NFS handle ownership instead. |
| OIDC | `OIDC_ALLOW_LOCAL_ISSUERS=true` env pre-set | pocket-id's issuer resolves to the internal gateway LB from in-cluster; BookOrbit's discovery SSRF guard would refuse the private IP otherwise. Actual provider setup happens in-app after deploy. |

## Before merge (manual steps)

1. **1Password item `bookorbit`** with fields: `BOOKORBIT_POSTGRES_USER`, `BOOKORBIT_POSTGRES_PASS`, `BOOKORBIT_JWT_SECRET`, `BOOKORBIT_SETUP_BOOTSTRAP_TOKEN` (generate the last two with `openssl rand -hex 32`).
2. After first reconcile, initial admin bootstrap uses the `/auth/setup` endpoint with the `SETUP_BOOTSTRAP_TOKEN` (`x-setup-token` header).

## After deploy (configuration phase, tracked separately)

- pocket-id: create OIDC client, family groups, wire group→permission mappings in BookOrbit
- Point scanner at `/books` (genre tree; note `.calibre/` dir is visible inside it — exclude from library roots in-app)
- KOReader plugin on the Boox devices; KOSync + OPDS smoke tests
- Hardcover token (per user) and annotations-hub walkthrough
- **Assess checkpoint**: metadata management decision (CWA bakes vs BookOrbit bakes → flips the RO mount), ABS overlap, external exposure

## Validation

`kubectl kustomize` builds clean for `entertainment`, `entertainment/bookorbit/app`, `database`, and the new cluster dir; `cloudnative-pg/ks.yaml` parses as 5 Flux Kustomizations. Image digest fetched from GHCR (`2.5.0@sha256:e13183...`); pgvector availability verified by querying the running vectorchord image on `postgres18-immich`.

Depends on nothing in #2544 (independent branches), but reviews well alongside it.