### PR TITLE
feat(home): nightly metadata embed CronJob (embed-nightly)

### DIFF
--- a/docs/ai-context/nerdz-reading-stack.md
+++ b/docs/ai-context/nerdz-reading-stack.md
@@ -7,7 +7,7 @@ categories: ["Gestalt[90%]", "Reference[10%]"]
 
 # Nerdz Reading Stack
 
-The family ebook + audiobook platform: four services around one NFS folder tree. **Bindery** acquires, **qBittorrent** downloads and seeds forever, **CWA/Calibre** is the metadata workbench, **Audiobookshelf (ABS)** serves readers/listeners (13+ per-genre libraries, multi-user incl. children with restricted library access). The disk tree — not any app database — is the integration contract: every service reads or writes `Books/{Genre}/{Author}/{Series}/{NN - Title}/` and they compose only because they all respect that shape.
+The family ebook + audiobook platform: five services around one NFS folder tree. **Bindery** acquires, **qBittorrent** downloads and seeds forever, **CWA/Calibre** is the metadata workbench, **Audiobookshelf (ABS)** serves readers/listeners (13+ per-genre libraries, multi-user incl. children with restricted library access), and **BookOrbit** (trial) is the reading hub — web reader, KOSync/KOReader/Kobo sync, per-user annotations hub, Hardcover/StoryGraph sync. The disk tree — not any app database — is the integration contract: every service reads or writes `Books/{Genre}/{Author}/{Series}/{NN - Title}/` and they compose only because they all respect that shape.
 
 **Working docs, scripts, decision history**: `G:\code\Projects\nerdz-reading` (see `docs/download-workflow-design.md`, `docs/abs-bindery-room-migration.md`). This file is the cluster-side gestalt; that repo holds the depth.
 
@@ -21,6 +21,8 @@ The family ebook + audiobook platform: four services around one NFS folder tree.
 | tqm | Torrent cleanup CronJob — flat 30-day-minimum seed rule for ALL trackers | downloads | [tqm](../../kubernetes/apps/downloads/tqm/) |
 | CWA (calibre-web-automated) | Calibre library of record + ingest watcher + metadata-baking tool. Sees ONLY `.calibre/ingest` + `.calibre/library`, never the genre tree | home | [calibre-web-automated](../../kubernetes/apps/home/calibre-web-automated/) |
 | Audiobookshelf | Reader/listener serving layer; one library per genre folder; kids' accounts restricted to fixed library lists | entertainment | [audiobookshelf](../../kubernetes/apps/entertainment/audiobookshelf/) |
+| BookOrbit (trial) | Reading hub: web reader, OPDS server, KOSync endpoints, KOReader/Kobo native sync, annotations hub, per-user Hardcover/StoryGraph sync. **Genre tree mounted READ-ONLY, no exceptions** (its per-book Write & Rename bypasses library toggles by design — bookorbit#852) | entertainment | [bookorbit](../../kubernetes/apps/entertainment/bookorbit/) + CNPG `postgres18-bookorbit` |
+| ebook-reconcile (embed-nightly + reconcile) | CronJobs on the CWA image: `embed-nightly` bakes DB metadata into Calibre's files (03:30, last-2-days window, mounts ONLY `.calibre/library`); `reconcile` (suspended pending validation) hardlinks `→abs`-tagged Calibre epubs into the genre tree | home | [ebook-reconcile](../../kubernetes/apps/home/ebook-reconcile/) |
 
 ```mermaid
 graph LR
@@ -29,7 +31,9 @@ graph LR
     Q -- "hardlink/copy, NEVER move" --> T["Genre tree Books/{Genre}/..."]
     B -- "ebook copy via cwa.ingest_path" --> C["CWA ingest -> Calibre bakes"]
     T --> A["ABS libraries (one per genre)"]
-    C -. "bake-sync: baked epub over tree copy" .-> T
+    T -- "read-only mount" --> O["BookOrbit (trial): reader + sync + annotations"]
+    E["embed-nightly CronJob"] -- "calibredb embed_metadata" --> C
+    C -. "bake-sync: baked epub over tree copy (manual) / reconcile hardlink (suspended)" .-> T
 
 %% MEANING: acquisition flows left-to-right into the disk tree; ABS only ever reads the tree.
 %% KEY INSIGHT: the seeding copy in /complete and the library copy are separate concerns joined by hardlinks.
@@ -51,6 +55,8 @@ Fixing a cover in ABS edits only the sidecar — opening the epub still shows th
 - Sidecar schema: `{title,subtitle,authors[],narrators[],series["Name #seq"],genres[],tags[],publishedYear,publisher,description,isbn,asin,language,explicit,abridged}`
 - `genres` = the curated 12-genre set (drives folders + ABS dropdown); `tags` = richer scraped arrays (Hardcover)
 - Workflow is FIX-FIRST: correct metadata in calibre-web (Calibre bakes it into the file), then bake-sync the corrected epub over the genre-tree copy + regen sidecar + ABS rescan
+- **CWA's UI enforcement only bakes UI edits** — `calibredb set_metadata` (bulk sessions) bypasses it. The `embed-nightly` CronJob closes that gap: every DB edit reaches the file layer within a day. Full process: `nerdz-reading/docs/metadata-bake-process.md`
+- BookOrbit reads the embedded layer only (cannot parse ABS sidecars) — its display of un-baked books is stale by design; Hardcover metadata provider is the display-side mitigation
 
 ### Capsule: HardlinkEconomy
 

--- a/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
@@ -27,6 +27,51 @@ spec:
       namespace: rook-ceph
   values:
     controllers:
+      # Nightly incremental bake: embed Calibre DB metadata into the library
+      # files (calibredb embed_metadata) for books modified in the last 2 days.
+      # Mounts ONLY the Calibre library (advancedMounts) — structurally cannot
+      # touch the genre tree. Pairs with ebook-reconcile: embed replaces the
+      # file inode, reconcile re-links the tree hardlink on its next run.
+      embed-nightly:
+        type: cronjob
+        cronjob:
+          suspend: false
+          schedule: "30 3 * * *"
+          timeZone: ${TIMEZONE}
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          backoffLimit: 1
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile: { type: RuntimeDefault }
+        containers:
+          app:
+            image:
+              repository: ghcr.io/crocodilestick/calibre-web-automated
+              tag: v4.0.6@sha256:c31a738b6d5ec6982c050063dd3f063b6943eb1051fc81144789f840d9093a8d
+            command: ["/bin/bash", "/scripts/embed_nightly.sh"]
+            env:
+              TZ: ${TIMEZONE}
+              HOME: /tmp
+              CALIBRE_CONFIG_DIRECTORY: /tmp/calibre
+              CALIBREDB: /app/calibre/calibredb
+              LIB: /calibre-library
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
       ebook-reconcile:
         type: cronjob
         cronjob:
@@ -81,18 +126,28 @@ spec:
         globalMounts:
           - path: /scripts
       # Single NFS mount so LIB (library) and DEST (Books) share one device → hardlinks work.
+      # advancedMounts: reconcile needs the whole export (library + tree);
+      # embed-nightly gets ONLY the Calibre library subpath — tree unreachable.
       media:
         type: nfs
         server: citadel.internal
         path: /mnt/storage0/media
-        globalMounts:
-          - path: /media
+        advancedMounts:
+          ebook-reconcile:
+            app:
+              - path: /media
+          embed-nightly:
+            app:
+              - path: /calibre-library
+                subPath: Library/Books/.calibre/library
       state:
         accessMode: ReadWriteOnce
         size: 128Mi
         storageClass: ceph-block
-        globalMounts:
-          - path: /state
+        advancedMounts:
+          ebook-reconcile:
+            app:
+              - path: /state
       tmp:
         type: emptyDir
         globalMounts:

--- a/kubernetes/apps/home/ebook-reconcile/app/kustomization.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/kustomization.yaml
@@ -8,5 +8,6 @@ configMapGenerator:
   - name: ebook-reconcile-scripts
     files:
       - reconcile.py=./resources/reconcile.py
+      - embed_nightly.sh=./resources/embed_nightly.sh
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/home/ebook-reconcile/app/resources/embed_nightly.sh
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/embed_nightly.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Nightly incremental metadata bake: embed Calibre DB metadata into the library
+# files themselves (calibredb embed_metadata). Covers every edit path — CWA UI,
+# calibredb CLI, bulk sessions — unlike CWA's UI-only enforcement hook.
+#
+# Scope: the Calibre library ONLY (this pod mounts nothing else). Propagation to
+# the genre tree is the reconcile job's business (hardlink re-link on inode
+# change) or a deliberate manual bake-sync — never this job's.
+#
+# Window: 2 days overlapping, idempotent (re-embedding an already-baked book is
+# a no-op byte-wise apart from a fresh rewrite).
+set -euo pipefail
+
+LIB="${LIB:?LIB (library path) must be set}"
+CALIBREDB="${CALIBREDB:-/app/calibre/calibredb}"
+CUTOFF=$(date -d '2 days ago' +%Y-%m-%d)
+
+ids=$("$CALIBREDB" search "last_modified:\">=${CUTOFF}\"" --library-path "$LIB" 2>/dev/null || true)
+if [ -z "$ids" ]; then
+  echo "embed-nightly: no books modified since ${CUTOFF} — nothing to do"
+  exit 0
+fi
+
+# calibredb search returns comma-separated ids; embed_metadata wants them as args
+read -r -a id_args <<< "${ids//,/ }"
+echo "embed-nightly: embedding ${#id_args[@]} book(s) modified since ${CUTOFF}: ${ids}"
+"$CALIBREDB" embed_metadata "${id_args[@]}" --library-path "$LIB"
+echo "embed-nightly: done"


### PR DESCRIPTION
## What

Adds the **nightly bake**: a CronJob that runs `calibredb embed_metadata` over every book whose Calibre metadata changed in the last 2 days (overlapping window, idempotent), at 03:30 .

## Why

CWA's metadata enforcement only fires for **web-UI edits**. All the bulk cleanup (Phase-1, Eastern Novels, etc.) went through `calibredb set_metadata`, which bypasses it — so the database says `Gu Man` while the epub still embeds `<unknown>`. BookOrbit's first library scan surfaced exactly this (2 books of 847). The nightly embed makes every edit path reach the file layer.

Worked example + full process (incl. the manual per-book bake-sync to the genre tree and its hardlink gate): `nerdz-reading/docs/metadata-bake-process.md`.

## Design

- **Second controller in the existing `ebook-reconcile` app** — same CWA image (pinned digest), same command-override conventions (`CALIBREDB=/app/calibre/calibredb`, `CALIBRE_CONFIG_DIRECTORY=/tmp/calibre`, rootless 568).
- **`advancedMounts` scoping**: `embed-nightly` mounts **only** `.calibre/library` — it structurally cannot touch the genre tree. The reconcile controller keeps `/media` and becomes the sole user of the RWO state PVC (removes a future multi-attach race between the two schedules).
- **Composes with the (still suspended) reconcile job**: embed replaces a file's inode → reconcile's documented behavior re-links the tree hardlink on its next pass. No change to reconcile itself; it stays suspended pending its controlled first run.
- Embed rewrites Calibre's library copies only — hardlink-safe (Calibre imports are copies; seeds live in `/complete`).

## Also in this PR

Stack gestalt (`docs/ai-context/nerdz-reading-stack.md`) updated per its evergreen rule: BookOrbit trial row (with the read-only-mount invariant + bookorbit#852 reference), the embed/bake pipeline rows, flow diagram, and the UI-vs-CLI enforcement gap.

## Validation

`kubectl kustomize` builds clean for the app and the `home` namespace. The embed command itself was validated live today on ids 545/549 in the CWA pod (before/after `ebook-meta` shown in the process doc).