### PR TITLE
fix(home): embed-nightly script must be envsubst-safe

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/resources/embed_nightly.sh
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/embed_nightly.sh
@@ -7,22 +7,28 @@
 # the genre tree is the reconcile job's business (hardlink re-link on inode
 # change) or a deliberate manual bake-sync — never this job's.
 #
-# Window: 2 days overlapping, idempotent (re-embedding an already-baked book is
-# a no-op byte-wise apart from a fresh rewrite).
-set -euo pipefail
+# Window: 2 days overlapping, idempotent.
+#
+# STYLE CONSTRAINT: no dollar-brace expansions anywhere in this file, comments
+# included — Flux's post-build envsubst runs over the ConfigMap and treats
+# every dollar-brace token as a substitution variable ("bad substitution"
+# broke the whole Kustomization). Bare $VAR is safe; brace expansion is not.
+set -e
 
-LIB="${LIB:?LIB (library path) must be set}"
-CALIBREDB="${CALIBREDB:-/app/calibre/calibredb}"
+if [ -z "$LIB" ]; then echo "embed-nightly: LIB not set" >&2; exit 1; fi
+if [ -z "$CALIBREDB" ]; then CALIBREDB=/app/calibre/calibredb; fi
 CUTOFF=$(date -d '2 days ago' +%Y-%m-%d)
 
-ids=$("$CALIBREDB" search "last_modified:\">=${CUTOFF}\"" --library-path "$LIB" 2>/dev/null || true)
+ids=$("$CALIBREDB" search "last_modified:\">=$CUTOFF\"" --library-path "$LIB" 2>/dev/null || true)
 if [ -z "$ids" ]; then
-  echo "embed-nightly: no books modified since ${CUTOFF} — nothing to do"
+  echo "embed-nightly: no books modified since $CUTOFF - nothing to do"
   exit 0
 fi
 
-# calibredb search returns comma-separated ids; embed_metadata wants them as args
-read -r -a id_args <<< "${ids//,/ }"
-echo "embed-nightly: embedding ${#id_args[@]} book(s) modified since ${CUTOFF}: ${ids}"
-"$CALIBREDB" embed_metadata "${id_args[@]}" --library-path "$LIB"
+# calibredb search returns comma-separated ids; embed_metadata wants args
+ids_spaced=$(printf '%s' "$ids" | tr ',' ' ')
+count=$(echo "$ids_spaced" | wc -w)
+echo "embed-nightly: embedding $count book(s) modified since $CUTOFF: $ids"
+# shellcheck disable=SC2086 — word-splitting is intended
+"$CALIBREDB" embed_metadata $ids_spaced --library-path "$LIB"
 echo "embed-nightly: done"


### PR DESCRIPTION
Follow-up to #2546 — the CronJob script's bash parameter expansions (and even a comment mentioning the syntax) are treated as substitution variables by Flux's post-build envsubst, failing the whole `ebook-reconcile` Kustomization with `bad substitution` at reconcile time (flux-local diffs don't run post-build substitution, so CI was green).

Rewritten brace-free (`tr`/`wc` instead of parameter expansion), constraint documented in the script header. `kubectl kustomize` builds clean; grep confirms zero dollar-brace tokens remain.

Merge to restore the `ebook-reconcile` Kustomization to Ready and let the embed-nightly CronJob actually deploy.