### PR TITLE
feat(entertainment): bookorbit serves at read.nerdz.cloud

### DIFF
--- a/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
@@ -49,7 +49,9 @@ spec:
               TZ: ${TIMEZONE}
               NODE_ENV: production
               PORT: &port 3000
-              APP_URL: https://bookorbit.${SECRET_DOMAIN}
+              # Family-facing hostname (deliberately not the app name); APP_URL
+              # drives OIDC callback, Kobo endpoints, and email links.
+              APP_URL: https://read.${SECRET_DOMAIN}
               # Run as the cluster-standard app UID; ownership is managed by the
               # NFS exports and fsGroup, not by the container entrypoint.
               PUID: "568"
@@ -108,7 +110,7 @@ spec:
         annotations:
           internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
         hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - read.${SECRET_DOMAIN}
         parentRefs:
           - name: internal
             namespace: network


### PR DESCRIPTION
Renames the bookorbit route + `APP_URL` from `bookorbit.${SECRET_DOMAIN}` to `read.${SECRET_DOMAIN}` — family-facing name chosen by Gavin, done **before** OIDC/Kobo setup because `APP_URL` bakes into the OIDC callback (`/oauth2-callback`), Kobo pairing endpoints, and email links.

No data impact (admin account + library + scan state live in the DB, unaffected by hostname). After merge: old hostname stops resolving; the OIDC client in pocket-id will be registered against `https://read.nerdz.cloud/oauth2-callback`.

`kubectl kustomize` builds clean.