### PR TITLE
fix(entertainment): raise audiobookshelf memory limit to 6Gi

### DIFF
--- a/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/audiobookshelf/app/helmrelease.yaml
@@ -68,9 +68,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 1Gi
               limits:
-                memory: 3Gi
+                memory: 6Gi
           abs-tract:
             image:
               repository: arranhs/abs-tract


### PR DESCRIPTION
## Problem

The `app` container was **OOMKilled (exit 137)** during a 124-book ingest, taking Audiobookshelf down until it restarted.

Audiobookshelf alone sits at **~2.0Gi of the old 3Gi limit while scanning a library**, leaving under 1Gi of headroom. That is not enough to run `ffmpeg` audio conversion concurrently — which is done in this pod, since it is the only one in the cluster shipping ffmpeg.

## Change

| | before | after |
|---|---|---|
| `limits.memory` | 3Gi | **6Gi** |
| `requests.memory` | 512Mi | **1Gi** |

The request is raised to match the observed idle working set so the scheduler places the pod sensibly rather than under-committing it.

## Validation

- `kubeconform` clean on the changed file (1 valid, 0 invalid)
- Repo-wide `task kubernetes:kubeconform` shows the **same single pre-existing failure** with and without this change (`envoy-external` Gateway, whose `${ENVOY_EXTERNAL_LBIP}` is a Flux envsubst placeholder kubeconform cannot resolve) — no new failures introduced
- Node has ~67Gi available, so the higher ceiling is comfortably schedulable

🤖 Generated with [Claude Code](https://claude.com/claude-code)