### PR TITLE
feat(entertainment): nightly bookorbit library scan trigger

### DIFF
--- a/kubernetes/apps/entertainment/bookorbit/app/externalsecret.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/externalsecret.yaml
@@ -31,6 +31,10 @@ spec:
         # App secrets
         JWT_SECRET: "{{ .BOOKORBIT_JWT_SECRET }}"
         SETUP_BOOTSTRAP_TOKEN: "{{ .BOOKORBIT_SETUP_BOOTSTRAP_TOKEN }}"
+        # Local admin credentials for the scan-nightly CronJob (upstream
+        # bookorbit#985: autoScanCronExpression is stored but never scheduled)
+        BOOKORBIT_ADMIN_USER: nerdzadmin
+        BOOKORBIT_ADMIN_PASSWORD: "{{ .BOOKORBIT_ADMIN_PASSWORD }}"
   dataFrom:
     - extract:
         key: bookorbit

--- a/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
@@ -24,6 +24,61 @@ spec:
       retries: 3
   values:
     controllers:
+      # Nightly library scan trigger. Upstream bookorbit#985: the in-app
+      # autoScanCronExpression is stored/validated but never scheduled, and the
+      # file watcher cannot see NFS changes — so new acquisitions only appear
+      # via an API-triggered scan. Remove this controller once #985 lands
+      # (tracked in nerdz-reading docs/upstream-tracker.md).
+      # Script style: bare $VAR only, no dollar-brace tokens anywhere (Flux
+      # post-build envsubst processes this manifest; braces fail the build).
+      scan-nightly:
+        type: cronjob
+        cronjob:
+          suspend: false
+          schedule: "0 4 * * *"
+          timeZone: ${TIMEZONE}
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          backoffLimit: 1
+        containers:
+          app:
+            image:
+              repository: docker.io/curlimages/curl
+              tag: 8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                BO=http://bookorbit.entertainment.svc.cluster.local:3000
+                TOKEN=$(curl -sf -X POST "$BO/api/v1/auth/login" -H 'content-type: application/json' -d "{\"username\":\"$BOOKORBIT_ADMIN_USER\",\"password\":\"$BOOKORBIT_ADMIN_PASSWORD\"}" | sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p')
+                if [ -z "$TOKEN" ]; then echo "scan-nightly: login failed" >&2; exit 1; fi
+                CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BO/api/v1/scanner/libraries/1/scan" -H "Authorization: Bearer $TOKEN")
+                echo "scan-nightly: scan trigger returned HTTP $CODE"
+                case "$CODE" in 202) exit 0;; 409) echo "scan-nightly: scan already running - fine"; exit 0;; *) exit 1;; esac
+            env:
+              TZ: ${TIMEZONE}
+              BOOKORBIT_ADMIN_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: bookorbit-secret
+                    key: BOOKORBIT_ADMIN_USER
+              BOOKORBIT_ADMIN_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: bookorbit-secret
+                    key: BOOKORBIT_ADMIN_PASSWORD
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
       bookorbit:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -116,13 +171,18 @@ spec:
             namespace: network
             sectionName: https
     persistence:
+      # advancedMounts (not global): the scan-nightly CronJob pod must get NO
+      # mounts — the data PVC is RWO (multi-attach risk) and the tree is not
+      # its business; it only speaks HTTP to the service.
       data:
         type: persistentVolumeClaim
         accessMode: ReadWriteOnce
         size: 10Gi
         storageClass: ceph-block
-        globalMounts:
-          - path: /data
+        advancedMounts:
+          bookorbit:
+            app:
+              - path: /data
       # Same single NFS export as audiobookshelf/CWA, sub-pathed to the family
       # genre-tree library. READ-ONLY for the trial: BookOrbit's file-write
       # pipeline (metadata baking, renames) stays inert until the
@@ -131,11 +191,15 @@ spec:
         type: nfs
         server: citadel.internal
         path: /mnt/storage0/media
-        globalMounts:
-          - path: /books
-            subPath: Library/Books
-            readOnly: true
+        advancedMounts:
+          bookorbit:
+            app:
+              - path: /books
+                subPath: Library/Books
+                readOnly: true
       tmp:
         type: emptyDir
-        globalMounts:
-          - path: /tmp
+        advancedMounts:
+          bookorbit:
+            app:
+              - path: /tmp


### PR DESCRIPTION
Workaround for [bookorbit#985](https://github.com/bookorbit/bookorbit/issues/985) (`autoScanCronExpression` is a dead setting — stored, validated, never scheduled; and the file watcher can't see NFS changes). Without this, new acquisitions never appear in bookorbit until someone clicks scan.

- `scan-nightly` cronjob controller in the bookorbit app: 04:00 , `curlimages/curl` pinned by digest, logs in as the local admin and POSTs `/api/v1/scanner/libraries/1/scan`; treats 202 and 409 (scan already running) as success. **The exact login→scan flow was verified live against the running instance with the real credentials before this PR** (202 received).
- New ExternalSecret keys `BOOKORBIT_ADMIN_USER`/`BOOKORBIT_ADMIN_PASSWORD` from the 1Password `bookorbit` item (field added by Gavin today).
- Script is envsubst-safe — bare shell vars only, per the #2547 lesson.
- **Persistence moved to `advancedMounts`** scoped to the app controller: the cronjob pod attaches no volumes (the RWO data PVC would otherwise risk 4am multi-attach failures, and it has no business touching the tree).
- Sequenced after the 03:30 embed job so bake-synced files are picked up same-night. Remove when #985 lands — row exists in `nerdz-reading/docs/upstream-tracker.md` with this as the unwind item.

`kubectl kustomize` builds clean; no unexpected dollar-brace tokens.