### PR TITLE
feat(bookorbit): expose read.nerdz.cloud externally (dual-homed route)

### DIFF
--- a/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
@@ -161,6 +161,9 @@ spec:
           http:
             port: *port
     route:
+      # Dual-homed: LAN clients (Boox KOReader sync, family devices) stay on the
+      # internal gateway; the external route serves off-LAN readers — same
+      # internet-facing posture audiobookshelf has held on books.${SECRET_DOMAIN}.
       app:
         annotations:
           internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
@@ -168,6 +171,15 @@ spec:
           - read.${SECRET_DOMAIN}
         parentRefs:
           - name: internal
+            namespace: network
+            sectionName: https
+      external:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+        hostnames:
+          - read.${SECRET_DOMAIN}
+        parentRefs:
+          - name: external
             namespace: network
             sectionName: https
     persistence:


### PR DESCRIPTION
Adds an external gateway route for bookorbit alongside the existing internal one — same hostname, split-horizon DNS.

- LAN clients (Boox KOReader sync, family devices) keep resolving via the internal gateway, unchanged.
- Off-LAN readers reach read.nerdz.cloud through the external gateway — the same internet-facing posture audiobookshelf has held on books.nerdz.cloud.
- OIDC is unaffected: pocket-id (id.nerdz.cloud) is already dual-homed, so external logins complete the redirect flow.

Follows the dual-homed pattern (two route entries, one per gateway, same hostname) used by pocket-id.