### PR TITLE
fix(dragonfly): allow cross-namespace redis ingress (port 6379)

### DIFF
--- a/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
@@ -24,3 +24,26 @@ spec:
       ports:
         - port: 9999
           protocol: TCP
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/networking.k8s.io/networkpolicy_v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dragonfly-allow-redis
+  namespace: database
+spec:
+  # The operator-owned NetworkPolicy only allows port 6379 from pods in the
+  # database namespace (`from: podSelector: {}` is namespace-scoped), which
+  # blocks every cross-namespace Redis consumer (pelican, immich, paperless,
+  # oauth2-proxy, ...). Same additive-policy approach as the metrics fix above.
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 6379
+          protocol: TCP


### PR DESCRIPTION
## Problem

The dragonfly-operator (v1.6, default-on) creates a NetworkPolicy that only allows port 6379 from pods **inside the database namespace** (`from: podSelector: {}` is namespace-scoped). Every cross-namespace Redis consumer is silently blocked: pelican, pelican-dev, immich, paperless, searxng, oauth2-proxy, romm, plane, outline, manyfold, affine.

Observed fallout:
- Pelican panel throws 500 ConnectionException on every API call that touches cache/session → wings on truenas has been crash-looping (**43,653 container restarts**)
- immich logging Redis client errors
- Verified live: TCP to dragonfly:6379 times out from games, home, and entertainment namespaces; succeeds only in-namespace

## Fix

Supplementary additive NetworkPolicy allowing 6379 from all namespaces — the exact pattern already used in this file for the metrics-scrape port (the operator-owned policy reverts direct edits).

## Validation

- `kubectl kustomize` build OK
- `kubectl apply --dry-run=server` OK