### PR TITLE
feat(pelican): update panel v1.0.0-beta33 -> v1.0.0-beta37

### DIFF
--- a/kubernetes/apps/games/pelican-dev/app/helmrelease.yaml
+++ b/kubernetes/apps/games/pelican-dev/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           install-plugin-deps:
             image:
               repository: ghcr.io/pelican-dev/panel
-              tag: v1.0.0-beta33@sha256:871032c289b7e00a23e1eb701772603750a14b8c7cfa72b072058ce645c41032
+              tag: v1.0.0-beta37@sha256:3844fad517fcb865fb8a9cafa06304feefffbfa79f26a8986bc8e05aa247a1b5
             env:
               COMPOSER_VENDOR_DIR: /mnt/vendor
             command:
@@ -81,7 +81,7 @@ spec:
           app:
             image:
               repository: ghcr.io/pelican-dev/panel
-              tag: v1.0.0-beta33@sha256:871032c289b7e00a23e1eb701772603750a14b8c7cfa72b072058ce645c41032
+              tag: v1.0.0-beta37@sha256:3844fad517fcb865fb8a9cafa06304feefffbfa79f26a8986bc8e05aa247a1b5
             env:
               XDG_DATA_HOME: /pelican-data
               FILAMENT_UPLOADABLE_AVATARS: "true"

--- a/kubernetes/apps/games/pelican/app/helmrelease.yaml
+++ b/kubernetes/apps/games/pelican/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           install-plugin-deps:
             image:
               repository: ghcr.io/pelican-dev/panel
-              tag: v1.0.0-beta33@sha256:871032c289b7e00a23e1eb701772603750a14b8c7cfa72b072058ce645c41032
+              tag: v1.0.0-beta37@sha256:3844fad517fcb865fb8a9cafa06304feefffbfa79f26a8986bc8e05aa247a1b5
             env:
               COMPOSER_VENDOR_DIR: /mnt/vendor
             command:
@@ -75,7 +75,7 @@ spec:
           app:
             image:
               repository: ghcr.io/pelican-dev/panel
-              tag: v1.0.0-beta33@sha256:871032c289b7e00a23e1eb701772603750a14b8c7cfa72b072058ce645c41032
+              tag: v1.0.0-beta37@sha256:3844fad517fcb865fb8a9cafa06304feefffbfa79f26a8986bc8e05aa247a1b5
             env:
               XDG_DATA_HOME: /pelican-data
               FILAMENT_UPLOADABLE_AVATARS: "true"


### PR DESCRIPTION
Bumps `ghcr.io/pelican-dev/panel` to v1.0.0-beta37 (digest-pinned) for both pelican and pelican-dev — app container and the plugin-deps init container in each.

- No breaking changes flagged in beta34–37 release notes; migrations run on boot
- Pairs with wings v1.0.0-beta28 being updated on the truenas wings node
- Depends on #2563 (redis netpol fix) already merged — panel was throwing 500s on cache access