### PR TITLE
fix(ebook-reconcile): match existing folders instead of generating paths

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
@@ -32,6 +32,12 @@ GENRE_FIELD = os.environ.get("GENRE_FIELD", "*genre")
 # In the CWA image `/usr/bin/calibredb` is a symlink created by s6 at runtime; a
 # command-override container (no s6 init) won't have it, so point at the real binary.
 CALIBREDB = os.environ.get("CALIBREDB", "calibredb")
+# DRY_RUN=1 prints the plan and writes nothing. Always dry-run before a bulk
+# session: this job creates folders and can replace files in the live tree.
+DRY = os.environ.get("DRY_RUN", "") == "1"
+# Overwriting a curated tree file with Calibre's copy is a judgement about
+# which edition is better, so it is opt-in rather than a silent side effect.
+ALLOW_REPLACE = os.environ.get("ALLOW_REPLACE", "") == "1"
 FIELDS = f"id,title,authors,series,series_index,{GENRE_FIELD},formats"
 
 
@@ -64,18 +70,74 @@ def save_state(st):
     os.replace(tmp, STATE)
 
 
+def _norm(s):
+    """Compare titles ignoring case, punctuation and spacing.
+
+    The tree is hand-curated and inconsistent with Calibre's strings:
+    'Beyond The Veil' vs 'Beyond the Veil', 'as Told by the Boys' vs
+    'As Told By The Boys'. Exact comparison would call these different books.
+    """
+    return re.sub(r"[^a-z0-9]+", "", (s or "").lower())
+
+
+def _index_prefix(b):
+    """Folder index prefix -- FALLBACK ONLY, for a book that has no folder yet.
+
+    The old rule was int(float(idx)) zero-padded, which truncated every
+    fractional index: 1.5 -> '01', and 8.0/8.5/8.6 all collapsed to '08'. The
+    curated tree actually holds '1.5 - ', '5.5 - ', '8.5 - ', '8.6 - ' (yet
+    '0.5' as '00 - '), so NO generated rule can reproduce it. That is precisely
+    why an existing folder always wins over this.
+    """
+    try:
+        f = float(b.get("series_index") or 0)
+    except (TypeError, ValueError):
+        f = 0.0
+    return f"{int(f):02d}" if f == int(f) else f"{f:g}"
+
+
+def _match_child(parent_abs, title, want_dir=True):
+    """Return the existing child of parent_abs whose name means `title`, else None.
+
+    Book folders are '<index> - <Title>'; the index prefix is stripped before
+    comparing so a differing prefix never masks a book we already own.
+    """
+    want = _norm(title)
+    try:
+        entries = sorted(os.listdir(parent_abs))
+    except OSError:
+        return None
+    for e in entries:
+        full = os.path.join(parent_abs, e)
+        if want_dir and not os.path.isdir(full):
+            continue
+        if not want_dir and not e.lower().endswith(".epub"):
+            continue
+        name = e if want_dir else os.path.splitext(e)[0]
+        m = re.match(r"^\s*\d+(?:\.\d+)?\s*-\s*(.+)$", name)
+        if _norm(m.group(1) if m else name) == want:
+            return e
+    return None
+
+
 def rel_path(b):
+    """Prefer the folder/file this book ALREADY occupies; only invent a path
+    when it genuinely has none. Generating a path unconditionally is what
+    scattered 16 duplicate folders -- a book whose generated name disagreed with
+    its real one was silently treated as new rather than as an error."""
     genre = sanitize(b.get(GENRE_FIELD) or "")
     author = sanitize(b.get("authors") or "")
     title = sanitize(b.get("title") or "")
     series = (b.get("series") or "").strip()
     if not (genre and author and title):
         return None
-    if series:
-        s = sanitize(series)
-        nn = f'{int(float(b.get("series_index") or 0)):02d}'
-        return os.path.join(genre, author, s, f"{nn} - {title}", f"{title}.epub")
-    return os.path.join(genre, author, title, f"{title}.epub")
+    parts = [genre, author] + ([sanitize(series)] if series else [])
+    parent_abs = os.path.join(DEST, *parts)
+    folder = _match_child(parent_abs, title) or (
+        f"{_index_prefix(b)} - {title}" if series else title)
+    fname = _match_child(os.path.join(parent_abs, folder), title,
+                         want_dir=False) or f"{title}.epub"
+    return os.path.join(*parts, folder, fname)
 
 
 def epub_of(b):
@@ -89,7 +151,7 @@ def main():
     books = json.loads(calibredb(
         "list", "--search", f'tag:"{TAG}"', "--fields", FIELDS, "--for-machine") or "[]")
     state = load_state()
-    linked = relinked = moved = skipped = ok = 0
+    linked = relinked = moved = skipped = ok = conflicts = 0
 
     for b in books:
         bid, rp, src = str(b["id"]), rel_path(b), epub_of(b)
@@ -101,33 +163,57 @@ def main():
         prev = state.get(bid)
 
         if prev and prev != dst and os.path.lexists(prev):       # metadata moved the path
-            os.remove(prev)
-            try:
-                os.removedirs(os.path.dirname(prev))
-            except OSError:
-                pass
+            if not DRY:
+                os.remove(prev)
+                try:
+                    os.removedirs(os.path.dirname(prev))
+                except OSError:
+                    pass
             moved += 1
-            print(f"MOVED id={bid}: removed stale {prev}")
+            print(f"MOVED id={bid}: removed stale {prev}"
+                  f"{'  (DRY RUN - not removed)' if DRY else ''}")
 
         if not os.path.lexists(dst):
             colocated = os.path.isdir(os.path.dirname(dst))
-            os.makedirs(os.path.dirname(dst), exist_ok=True)
-            os.link(src, dst)
+            tag = 'colocated' if colocated else 'NEW FOLDER'
+            print(f"LINK   id={bid} -> {rp}  [{tag}]")
+            if not DRY:
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                os.link(src, dst)
             linked += 1
-            print(f"LINK   id={bid} -> {rp}  [{'colocated' if colocated else 'new folder'}]")
         elif os.stat(dst).st_ino != os.stat(src).st_ino:
-            os.remove(dst)
-            os.link(src, dst)
-            relinked += 1
-            print(f"RELINK id={bid} (file changed) -> {rp}")
+            dsz, ssz = os.stat(dst).st_size, os.stat(src).st_size
+            # Two very different situations, previously indistinguishable because
+            # generated paths never landed on a curated file:
+            #   prev == dst -> WE linked this before and Calibre's file changed
+            #                  (re-convert / embed). Re-linking is correct.
+            #   otherwise   -> a file WE NEVER PLACED already occupies this path.
+            #                  It is the curated tree copy, and which edition is
+            #                  better is a human judgement, not a cronjob's.
+            if prev == dst or ALLOW_REPLACE:
+                print(f"RELINK id={bid} (file changed) -> {rp}  "
+                      f"tree={dsz:,}B calibre={ssz:,}B"
+                      f"{'  (DRY RUN - not written)' if DRY else ''}")
+                if not DRY:
+                    os.remove(dst)
+                    os.link(src, dst)
+                relinked += 1
+            else:
+                print(f"CONFLICT id={bid} -> {rp}  tree={dsz:,}B calibre={ssz:,}B"
+                      f"  — pre-existing file not placed by us; left untouched "
+                      f"(set ALLOW_REPLACE=1 to overwrite)")
+                conflicts += 1
+                continue          # do NOT record state for a path we did not write
         else:
             ok += 1
             print(f"OK     id={bid} (current)")
         state[bid] = dst
 
-    save_state(state)
-    print(f"\ndone: {len(books)} {TAG} book(s) | "
-          f"linked={linked} relinked={relinked} moved={moved} ok={ok} skipped={skipped}")
+    if not DRY:
+        save_state(state)
+    print(f"\ndone{' (DRY RUN — nothing written)' if DRY else ''}: {len(books)} {TAG} book(s) | "
+          f"linked={linked} relinked={relinked} moved={moved} ok={ok} "
+          f"skipped={skipped} conflicts={conflicts}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`reconcile.py` computed its destination path unconditionally, so a book whose generated name disagreed with its real folder was treated as **new** — creating a duplicate folder rather than erroring.

Two causes compounded:

1. `#genre` disagreeing with where the book already lives on the NAS.
2. `int(float(series_index))` truncating fractional indexes — `1.5 -> 01`, and `8.0/8.5/8.6` all collapsing to `08`.

The curated tree is not internally consistent here (`0.5` is `00 - ` but `1.5` is `1.5 - `), so **no generated rule can reproduce it** — the path has to be matched, not computed.

This surfaced when a single new book was linked and the job produced 16 orphan duplicate folders for unrelated books sharing the `→abs` tag.

## Change

- Prefer the folder/file a book **already occupies**, comparing titles ignoring case and punctuation (`8.5 - Beyond The Veil` now matches Calibre's `Beyond the Veil`).
- Fractional prefix retained, but only for genuinely new folders.
- `DRY_RUN=1` plans without writing.
- `CONFLICT` guard: never overwrite a file we did not place. Distinguishes our own stale hardlink (state says we placed it → relink, correct) from a curated tree file (→ report; `ALLOW_REPLACE=1` overrides). Which edition is better is a human decision, not a cronjob's.

## Validation

Dry-run against the live tree over 17 tagged books:

| | before | after |
|---|---|---|
| new duplicate folders | 4 | **0** |
| silent overwrites | 13 | **0** (reported as conflicts) |

## Risk

The `ebook-reconcile` cronjob remains `suspend: true`, so this changes no behaviour on merge.