### PR TITLE
docs(reading): point the LLM context at where the pipeline depth lives

### DIFF
--- a/docs/domains/reading/context.md
+++ b/docs/domains/reading/context.md
@@ -7,6 +7,23 @@ categories: ["Reference[100%]", "DomainContext[95%]"]
 
 # Books, Audiobooks, Comics & Manga — Context
 
+> **Depth lives in the `nerdz-reading` repo.**
+> This file is the cluster-side map: apps, routes, storage, flows. The pipeline
+> semantics — how a book actually gets from acquisition to shelf, and the rules
+> that keep it from going wrong — are documented there:
+>
+> - `docs/README.md` — index; what is canonical vs superseded
+> - `docs/ebook-curation-pipeline.md` — **THE pipeline.** §10 field-proven
+>   corrections, §11 Bindery, §12 genre taxonomy. Required before any bulk import.
+> - `docs/download-workflow-design.md` — acquisition + seed safety
+> - `docs/metadata-bake-process.md` — the bake and per-book bake-sync
+> - `.repoql/concepts/` — the invariants, as auto-surfacing capsules
+>
+> Load-bearing facts that are easy to get wrong: the **genre tree on disk is the
+> integration contract** (`Books/{Genre}/{Author}/{Series}/{NN - Title}/`);
+> **ABS parses embedded ebook metadata only at first index**; and Bindery's
+> **autoGrab kill-switch does not stop an already-running sweep**.
+
 <!-- generated:start section=apps -->
 ## Apps
 


### PR DESCRIPTION
`docs/domains/reading/context.md` is the doc an agent loads first for this domain, and it contained **no reference to the `nerdz-reading` repo at all** — so the cluster map was reachable, but the pipeline semantics (how a book actually gets from acquisition to shelf) were not.

Adds a short pointer block naming the docs index, the pipeline doc, acquisition/seed safety, the bake process, and the concept capsules.

**Placed above the first generated section, outside the `generated:start`/`generated:end` markers**, so the domain-docs skill can regenerate without clobbering it. Markers verified still balanced (3/3).

It also states three facts inline, because each has already been re-derived wrongly at least once:

- the **genre tree on disk is the integration contract** (`Books/{Genre}/{Author}/{Series}/{NN - Title}/`)
- **ABS parses embedded ebook metadata only at first index** (a later rescan answers `UPTODATE` forever)
- Bindery's **autoGrab kill-switch does not stop an already-running sweep**

Docs-only; no manifest or runtime change.