### PR TITLE
fix(ebook-reconcile): suspend embed-nightly — in-place epub writes pierce tree hardlinks

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
@@ -35,7 +35,15 @@ spec:
       embed-nightly:
         type: cronjob
         cronjob:
-          suspend: false
+          # SUSPENDED 2026-08-17: the "embed replaces the file inode" assumption
+          # above is FALSE for epub — calibredb embed_metadata writes IN PLACE,
+          # straight through the tree<->calibre hardlink (367 pairs), silently
+          # rewriting genre-tree files. bookorbit does not rehash on mtime change
+          # (upstream PR #932), so KOReader device matching breaks (Bride of Ash
+          # and Dust incident, nerdz-reading journal 2026-08-17). Unsuspend only
+          # after the hardlink-vs-identity design decision (break links, or add
+          # post-embed hash refresh) — see nerdz-reading session journal.
+          suspend: true
           schedule: "30 3 * * *"
           timeZone: ${TIMEZONE}
           concurrencyPolicy: Forbid


### PR DESCRIPTION
The embed-nightly design assumed calibredb embed_metadata replaces the file inode, leaving the tree's hardlink pointing at old bytes. Evidence (2026-08-17): it writes epubs IN PLACE — same inode, nlink=2, new bytes — so every nightly embed of a hardlinked book silently rewrites the genre-tree file behind bookorbit's back. bookorbit doesn't rehash on mtime change (upstream PR bookorbit#932), so KOReader device matching breaks silently (the Bride of Ash and Dust sync incident; 367 tree↔calibre hardlink pairs exist; 17 tree files rewritten in the last 48h).

Suspending until the design decision is made: break the tree↔calibre hardlinks (copies + nlink-gated bake-sync only), or keep hardlink+retain and add a post-embed bookorbit hash-refresh step. Full analysis in nerdz-reading session journal 2026-08-17.