### PR TITLE
fix(smtp-relay): persist queue + alert on backlog; encrypt BookOrbit SMTP passwords

### DIFF
--- a/kubernetes/apps/entertainment/bookorbit/app/externalsecret.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/externalsecret.yaml
@@ -31,6 +31,14 @@ spec:
         # App secrets
         JWT_SECRET: "{{ .BOOKORBIT_JWT_SECRET }}"
         SETUP_BOOTSTRAP_TOKEN: "{{ .BOOKORBIT_SETUP_BOOTSTRAP_TOKEN }}"
+        # AES-256-GCM key (64 hex chars) for SMTP provider passwords stored in
+        # the email_providers table. Must be set BEFORE any provider with a
+        # password is saved: without it BookOrbit writes the password as
+        # plaintext, and adding the key afterwards makes decrypt() fail on
+        # those rows. Rotating or losing this key breaks every stored password.
+        # The house smtp-relay itself needs no password (auth off), but this
+        # covers any provider added later (e.g. a direct Send-to-Kindle relay).
+        EMAIL_ENCRYPTION_KEY: "{{ .BOOKORBIT_EMAIL_ENCRYPTION_KEY }}"
         # Local admin credentials for the scan-nightly CronJob (upstream
         # bookorbit#985: autoScanCronExpression is stored but never scheduled)
         BOOKORBIT_ADMIN_USER: nerdzadmin

--- a/kubernetes/apps/home/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/home/smtp-relay/app/helmrelease.yaml
@@ -25,7 +25,11 @@ spec:
   values:
     controllers:
       smtp-relay:
-        strategy: RollingUpdate
+        # Recreate, not RollingUpdate: the queue PVC is RWO, so a rolling
+        # update would deadlock with the new pod waiting on a volume the
+        # outgoing pod still holds. SMTP senders retry, so the brief gap
+        # during a roll is harmless.
+        strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -59,6 +63,11 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
         runAsGroup: 65534
+        # fsGroup is required now that the queue lives on a ceph-block (ext4)
+        # PVC: the volume comes up root-owned and maddy runs as nobody, so
+        # without this the queue directory is unwritable at startup.
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile: { type: RuntimeDefault }
       topologySpreadConstraints:
         - maxSkew: 1
@@ -98,6 +107,18 @@ spec:
           - path: /data/maddy.conf
             subPath: maddy.conf
             readOnly: true
+      # Outbound queue. Persistent on purpose: maddy's state_dir holds
+      # undelivered mail, and on the previous emptyDir every pod restart or
+      # reschedule silently discarded it (~188 queued messages lost on
+      # 2026-08-18 when reloader restarted the pod after a credential fix).
+      queue:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /queue
+      # runtime_dir only — sockets and pidfiles, deliberately ephemeral.
       cache:
         type: emptyDir
         globalMounts:

--- a/kubernetes/apps/home/smtp-relay/app/kustomization.yaml
+++ b/kubernetes/apps/home/smtp-relay/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./prometheusrule.yaml
 components:
   - ../../../../components/priority/priority-10
 configMapGenerator:

--- a/kubernetes/apps/home/smtp-relay/app/prometheusrule.yaml
+++ b/kubernetes/apps/home/smtp-relay/app/prometheusrule.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: smtp-relay-rules
+spec:
+  groups:
+    - name: smtp-relay.rules
+      rules:
+        - alert: SmtpRelayAbsent
+          annotations:
+            summary: smtp-relay has disappeared from Prometheus target discovery.
+          expr: |
+            absent(up{job="smtp-relay"})
+          for: 15m
+          labels:
+            severity: critical
+
+        # maddy 0.9.5 publishes only three metrics and none of them count
+        # delivery failures, so queue depth is the only delivery signal
+        # available. It is also the better one: it fires regardless of cause
+        # (bad credentials, rejected sender, upstream unreachable).
+        #
+        # This is the gap that let a TOTAL 23-day outage pass unnoticed —
+        # 0 of 94 messages delivered while every dashboard looked healthy,
+        # because the relay accepted mail happily and only failed on the
+        # upstream hop to Migadu.
+        #
+        # A healthy relay drains in seconds. 30m tolerates one failed
+        # delivery sitting through maddy's ~15m first retry backoff without
+        # paging; anything past that is a real fault.
+        - alert: SmtpRelayQueueBacklog
+          annotations:
+            summary: >-
+              smtp-relay has {{ $value }} message(s) stuck in the
+              {{ $labels.module }} queue — upstream delivery is failing.
+          expr: |
+            maddy_queue_length > 0
+          for: 30m
+          labels:
+            severity: warning
+
+        - alert: SmtpRelayQueueStuck
+          annotations:
+            summary: >-
+              smtp-relay queue has been backed up for over two hours
+              ({{ $value }} message(s) in {{ $labels.module }}).
+          expr: |
+            maddy_queue_length > 0
+          for: 2h
+          labels:
+            severity: critical

--- a/kubernetes/apps/home/smtp-relay/app/resources/maddy.conf
+++ b/kubernetes/apps/home/smtp-relay/app/resources/maddy.conf
@@ -1,4 +1,8 @@
-state_dir /cache/state
+# state_dir holds the outbound queue, so it MUST be persistent: a pod restart
+# on ephemeral storage silently destroys undelivered mail (this ate ~188 queued
+# messages on 2026-08-18). runtime_dir is sockets/pidfiles only and is
+# deliberately left on the emptyDir so nothing stale survives a restart.
+state_dir /queue
 runtime_dir /cache/run
 
 openmetrics tcp://0.0.0.0:{env:SMTP_RELAY_METRICS_PORT} { }


### PR DESCRIPTION
## Why

While wiring BookOrbit's email, the house SMTP relay turned out to have delivered **0 of 94 messages in 23+ days**. Two faults were stacked:

1. **Invalid Migadu password** — `535 authentication failed` from the start of the log window, flipping to `454 invalid credentials`. Ruled out ESO drift first: the ExternalSecret was `Ready/SecretSynced` and the live secret's sha256 matched 1Password exactly, so the stored credential was simply wrong upstream.
2. **Wildcard sending off** on `infrastructure@nerdz.cloud`, so it could only send as itself — meaning *every* consumer (`outline@`, `paperless@`, `affine@`, pelican, immich) had a From address Migadu rejected. This was completely masked by fault 1.

Both fixed outside this repo (credential rotated, wildcard sending enabled, `read@nerdz.cloud` alias created). Delivery verified end-to-end in both directions.

This PR addresses the two things that let it go unnoticed and made recovery lossy.

## Queue durability

maddy's `state_dir` holds undelivered mail but lived on an `emptyDir`, so every restart or reschedule discarded the queue — the very restart that applied the credential fix destroyed ~188 queued messages.

`state_dir` moves to a 1Gi `ceph-block` PVC at `/queue`. `runtime_dir` stays on the emptyDir, since sockets and pidfiles should not survive a restart.

Two forced consequences:
- `fsGroup: 65534` — the ext4 volume comes up root-owned and maddy runs as nobody
- `strategy: Recreate` — an RWO volume would deadlock a rolling update

## Alerting

maddy 0.9.5 publishes only three metrics, and none of them counts delivery failures:

```
maddy_queue_length{location=...,module=...}
maddy_smtp_started_transactions{module="smtp"}
```

So queue depth is the only delivery signal available — and it is arguably the better one, since it fires regardless of cause (bad credentials, rejected sender, upstream unreachable). Thresholds tolerate one failed delivery sitting through maddy's ~15m first retry backoff: **30m warning, 2h critical**, plus a target-absent rule.

Expressions were verified against live Prometheus, including confirming `maddy_queue_length` actually returns a series — otherwise the rules would silently match nothing forever, which is the same class of failure this PR exists to fix.

## BookOrbit `EMAIL_ENCRYPTION_KEY`

BookOrbit stores SMTP provider credentials in the `email_providers` table, not in env. Without this key set it writes provider passwords as **plaintext**, and adding the key later makes `decrypt()` fail on the existing rows. Applied while the table was still empty, so there is nothing to migrate.

## Validation

- `task kubernetes:kubeconform` — `Kustomization smtp-relay is valid`, `Kustomization bookorbit is valid`
- `kubectl kustomize` renders both cleanly
- `flux diff` on both kustomizations (below) — no unexpected drift

<details>
<summary><code>flux diff kustomization smtp-relay -n home</code></summary>

```
► HelmRelease/home/smtp-relay drifted

spec.values.controllers.smtp-relay.strategy
- RollingUpdate
+ Recreate

spec.values.defaultPodOptions.securityContext
+ two map entries added:
  fsGroup: 65534
  fsGroupChangePolicy: OnRootMismatch

spec.values.persistence
+ one map entry added:
  queue:
    type: persistentVolumeClaim
    accessMode: ReadWriteOnce
    size: 1Gi
    storageClass: ceph-block
    globalMounts:
    - path: /queue

► PrometheusRule/home/smtp-relay-rules created
► ConfigMap/home/smtp-relay-configmap drifted

data.maddy.conf
- state_dir /cache/state
+ state_dir /queue
```
</details>

<details>
<summary><code>flux diff kustomization bookorbit -n entertainment</code></summary>

```
► ExternalSecret/entertainment/bookorbit drifted

spec.target.template.data
+ one map entry added:
  EMAIL_ENCRYPTION_KEY: "{{ .BOOKORBIT_EMAIL_ENCRYPTION_KEY }}"
```
</details>

## ⚠️ Merge in a watched window

This forces a **Recreate** roll onto a brand-new RWO PVC. If the `fsGroup` is wrong, maddy will not start and the relay goes down again — immediately after it was restored. After merge, confirm:

- pod `1/1 Running` in `home`
- `maddy_queue_length` still scraping (proves `/queue` is writable and the metrics endpoint is up)
- a probe send actually reaches `delivered` in the relay logs

If the HelmRelease wedges, check for stale `Succeeded` pods owned by the ReplicaSet before debugging the manifest.
