### PR TITLE
docs(agents): forbid AI attribution trailers in commit messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,14 +267,21 @@ This ensures:
 - Clear version tracking (tag shows semantic version)
 - No surprise updates from mutable tags like `latest`
 
-### Commit Message Closing
+### Commit Messages
 
-When writing commits to git, use the following for the closing comments:
+Conventional commits: `type(scope): description`.
+
+**Never add AI attribution trailers.** A `commit-msg` hook rejects any message
+containing "claude" or "anthropic" (case-insensitive), so closings such as
+`Pair-programmed with Claude Code ...` or `Co-Authored-By: Claude ...` are
+blocked outright. Treat this as policy rather than something the hook enforces:
+it is bound to `core.hooksPath`, which does not resolve on every machine, so the
+rule still applies where the hook is silently inactive.
+
+Do not work around it with `--no-verify` — rewrite the message without the
+trailer. A human co-author trailer is fine:
 
 ```
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 Co-Authored-By: Gavin <gavin@nerdz.cloud>
 ```
 

--- a/docs/Guides/CICD/Kustomize Components/README.md
+++ b/docs/Guides/CICD/Kustomize Components/README.md
@@ -226,12 +226,7 @@ persistence:
 ```bash
 cd ~/home-ops
 git add kubernetes/apps/myns/myapp/
-git commit -m "feat(myapp): add volsync backup component
-
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>"
+git commit -m "feat(myapp): add volsync backup component"
 git push
 ```
 

--- a/docs/Guides/Storage/Ceph Upgrade - Reef to Squid/README.md
+++ b/docs/Guides/Storage/Ceph Upgrade - Reef to Squid/README.md
@@ -171,12 +171,7 @@ cd ~/home-ops
 git add kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
 git commit -m "feat(rook-ceph): upgrade Ceph from Reef v18.2.7 to Squid v19.2.3
 
-Breaking changes reviewed - no impact on current configuration.
-
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>"
+Breaking changes reviewed - no impact on current configuration."
 
 git push
 ```

--- a/docs/Guides/Storage/Ceph Upgrade - Squid to Tentacle/README.md
+++ b/docs/Guides/Storage/Ceph Upgrade - Squid to Tentacle/README.md
@@ -161,12 +161,7 @@ spec:
 git add kubernetes/apps/rook-ceph/
 git commit -m "feat(rook-ceph): upgrade Rook operator to v1.19.x
 
-Required for Ceph Tentacle support.
-
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>"
+Required for Ceph Tentacle support."
 
 git push
 ```
@@ -236,12 +231,7 @@ git commit -m "feat(rook-ceph): upgrade Ceph from Squid v19.2.3 to Tentacle v20.
 Breaking changes reviewed:
 - restful/zabbix modules removed (not used)
 - IAM tenant deprecation (not using tenant IAM)
-- EC default changed (existing pools unaffected)
-
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>"
+- EC default changed (existing pools unaffected)"
 
 git push
 ```

--- a/docs/ai-context/CONVENTIONS.md
+++ b/docs/ai-context/CONVENTIONS.md
@@ -160,6 +160,13 @@ chore(deps): update app-template to 4.4.0
 docs(readme): add troubleshooting section
 ```
 
+**No AI attribution.** A `commit-msg` hook rejects any message containing
+"claude" or "anthropic" (case-insensitive), so `Co-Authored-By: Claude ...`
+and `Pair-programmed with ...` closings are blocked. The hook is bound to
+`core.hooksPath` and does not resolve on every machine — treat this as policy,
+not something enforcement will reliably catch. Never bypass with `--no-verify`;
+rewrite the message instead.
+
 ### Branch Strategy
 
 - `main` is the deployment branch


### PR DESCRIPTION
## Problem

`AGENTS.md` told agents to close every message with:

```
Pair-programmed with <assistant> - <url>

Co-Authored-By: <assistant> <noreply@...>
Co-Authored-By: Gavin <gavin@nerdz.cloud>
```

The `commit-msg` hook rejects any message matching "claude" or "anthropic". So an agent that followed the documented convention produced a message the repo refuses — and the obvious escape hatch is `--no-verify`, which is worse.

Four guide READMEs repeated the same closing inside their worked examples, so the bad pattern was reachable from several directions.

Found while working on #2573, where I had to deviate from `AGENTS.md` to land a commit at all.

## Changes

- **`AGENTS.md`** — section rewritten from "here is the closing to use" to the actual policy. Retitled `Commit Message Closing` → `Commit Messages`, since it no longer describes a closing.
- **`docs/ai-context/CONVENTIONS.md`** — rule mirrored here. `AGENTS.md` names this directory as the source of truth for conventions, and its Git Conventions section previously said nothing about attribution, so an agent reading only this file would have had no idea.
- **4 guide examples** — trailers stripped from `Kustomize Components` and both Ceph upgrade guides.

## On the guide examples

Each trailer sat *inside* a `-m "..."` string, so the closing quote had to be reattached to the preceding content line. My first pass got this wrong on the Ceph guides — the block-consuming loop swallowed the trailing blank line and dropped the quote, which would have left three guides with unterminated strings. Caught it in review, reverted, and reworked the transform.

Verified by extracting every `bash` block containing a `-m "` string and parsing it: **4/4 parse cleanly** under `bash -n`.

## Framing

Written as policy rather than as hook behaviour, deliberately. `core.hooksPath` in this repo resolves to a path that does not exist on every machine:

```
$ git config core.hooksPath
/home/gavin/home-ops/.git/hooks
$ ls -d "$(git config core.hooksPath)"
No such file or directory
```

There are also no hooks in the local `.git/hooks`. So on at least this checkout the hook is silently inactive and enforces nothing — an agent could land an attributed message today without resistance. Docs that say "the hook will stop you" would be wrong there; docs that say "this is the rule" hold either way.

## Follow-ups not taken here

- **Hook enforcement is currently absent.** Fixing `core.hooksPath` touches machine-level git config rather than repo content, so I have left it alone — worth a decision on whether to restore it or vendor a hook into the repo.
- **`AGENTS.md` and `CONVENTIONS.md` disagree on branching.** `AGENTS.md` says *"PRs: never push directly to `main`"*; `CONVENTIONS.md` Branch Strategy says *"Direct commits to `main` for simple changes"*. Genuine policy question, so not silently resolved.

## Validation

Docs-only; no manifests touched, so `kubeconform` is not meaningful here. The relevant risk was shell quoting in the edited examples, covered by the `bash -n` check above.
