### PR TITLE
docs(agents): require AI attribution trailers in commit messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,15 +267,25 @@ This ensures:
 - Clear version tracking (tag shows semantic version)
 - No surprise updates from mutable tags like `latest`
 
-### Commit Message Closing
+### Commit Messages
 
-When writing commits to git, use the following for the closing comments:
+Conventional commits: `type(scope): description`.
+
+**Attribute AI assistance.** Anything built with an agent closes with:
 
 ```
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>
+Assisted-by: Claude Code (claude-opus-5)
+Agentically-Engineered: https://nerdz.cloud/agentic-engineering
 ```
+
+Name the model actually used — the trailer is a record of how the commit was
+built, so a stale or guessed model id makes that record wrong. Add a human
+`Co-Authored-By:` trailer as well when someone genuinely co-authored the change.
+
+Earlier guidance told agents to strip every trace of AI involvement. That is
+**retired** — do not remove these trailers, and do not treat naming the
+assistant as something to avoid. The point is transparency about process, not
+decoration: see
+[nerdz.cloud/agentic-engineering](https://nerdz.cloud/agentic-engineering).
 
 For complete details, see the documentation in [`docs/ai-context/`](docs/ai-context/).

--- a/docs/Guides/CICD/Kustomize Components/README.md
+++ b/docs/Guides/CICD/Kustomize Components/README.md
@@ -228,10 +228,8 @@ cd ~/home-ops
 git add kubernetes/apps/myns/myapp/
 git commit -m "feat(myapp): add volsync backup component
 
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>"
+Assisted-by: Claude Code (claude-opus-5)
+Agentically-Engineered: https://nerdz.cloud/agentic-engineering"
 git push
 ```
 

--- a/docs/Guides/Storage/Ceph Upgrade - Reef to Squid/README.md
+++ b/docs/Guides/Storage/Ceph Upgrade - Reef to Squid/README.md
@@ -173,10 +173,8 @@ git commit -m "feat(rook-ceph): upgrade Ceph from Reef v18.2.7 to Squid v19.2.3
 
 Breaking changes reviewed - no impact on current configuration.
 
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>"
+Assisted-by: Claude Code (claude-opus-5)
+Agentically-Engineered: https://nerdz.cloud/agentic-engineering"
 
 git push
 ```

--- a/docs/Guides/Storage/Ceph Upgrade - Squid to Tentacle/README.md
+++ b/docs/Guides/Storage/Ceph Upgrade - Squid to Tentacle/README.md
@@ -163,10 +163,8 @@ git commit -m "feat(rook-ceph): upgrade Rook operator to v1.19.x
 
 Required for Ceph Tentacle support.
 
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>"
+Assisted-by: Claude Code (claude-opus-5)
+Agentically-Engineered: https://nerdz.cloud/agentic-engineering"
 
 git push
 ```
@@ -238,10 +236,8 @@ Breaking changes reviewed:
 - IAM tenant deprecation (not using tenant IAM)
 - EC default changed (existing pools unaffected)
 
-Pair-programmed with Claude Code - https://claude.com/claude-code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-Co-Authored-By: Gavin <gavin@nerdz.cloud>"
+Assisted-by: Claude Code (claude-opus-5)
+Agentically-Engineered: https://nerdz.cloud/agentic-engineering"
 
 git push
 ```

--- a/docs/ai-context/CONVENTIONS.md
+++ b/docs/ai-context/CONVENTIONS.md
@@ -160,6 +160,17 @@ chore(deps): update app-template to 4.4.0
 docs(readme): add troubleshooting section
 ```
 
+**Attribute AI assistance.** Commits produced with an agent carry:
+
+```
+Assisted-by: Claude Code (claude-opus-5)
+Agentically-Engineered: https://nerdz.cloud/agentic-engineering
+```
+
+Name the model actually used. Earlier guidance to strip AI attribution is
+retired — see [`AGENTS.md`](../../AGENTS.md) and
+[nerdz.cloud/agentic-engineering](https://nerdz.cloud/agentic-engineering).
+
 ### Branch Strategy
 
 - `main` is the deployment branch


### PR DESCRIPTION
Supersedes #2574, which resolved the same contradiction in the wrong direction.

## Problem

The repo pulled in two directions. `AGENTS.md` told agents to close every message with a trailer naming the assistant; a `commit-msg` hook rejected any message matching "claude" or "anthropic". An agent following the documented convention produced a message the hook refused, and the obvious escape hatch was `--no-verify`.

Found while working on #2573, where I had to deviate from `AGENTS.md` to land a commit at all.

## Resolution

In favour of attribution, not suppression. Per [nerdz.cloud/agentic-engineering](https://nerdz.cloud/agentic-engineering), commits built with an agent now carry:

```
Assisted-by: Claude Code (<model-id>)
Agentically-Engineered: https://nerdz.cloud/agentic-engineering
```

## Changes

- **`AGENTS.md`** — section rewritten to require the trailers, and to state explicitly that the earlier strip-all-traces guidance is retired. Retitled `Commit Message Closing` → `Commit Messages`.
- **`docs/ai-context/CONVENTIONS.md`** — rule mirrored here. `AGENTS.md` names this directory as the source of truth for conventions, and its Git Conventions section said nothing about attribution, so an agent reading only this file had no guidance either way.
- **4 guide examples** — Kustomize Components and both Ceph upgrade guides updated to the new format.

## On the guide examples

Each trailer sits *inside* a `-m "..."` string, so the closing quote has to move to the last trailer line. Verified by extracting every `bash` block containing a `-m "` string and parsing it: **4/4 clean** under `bash -n`.

Scope-checked first: `grep -n -- '-m "'` returns exactly 4 hits across the three guides, matching the 4 original trailer sites, so no unrelated example picked up a trailer by accident.

## The hook is deliberately not touched

`core.hooksPath` in this repo resolves to a path that does not exist on every machine:

```
$ git config core.hooksPath
/home/gavin/home-ops/.git/hooks
$ ls -d "$(git config core.hooksPath)"
No such file or directory
```

There are also no hooks in the local `.git/hooks`, so on this checkout it enforces nothing in either direction. Wherever the old blocking hook *is* still live it will now reject the documented convention, so it needs removing — but that is machine-level config rather than repo content, so it is left as a follow-up rather than done silently here.

## Follow-up not taken

`AGENTS.md` and `CONVENTIONS.md` disagree on branching: `AGENTS.md` says *"PRs: never push directly to `main`"*, `CONVENTIONS.md` Branch Strategy says *"Direct commits to `main` for simple changes"*. A genuine policy question, so not silently resolved.

## Validation

Docs-only; no manifests touched, so `kubeconform` is not meaningful. The real risk was shell quoting in the edited examples, covered by the `bash -n` check above.

Assisted-by: Claude Code (claude-opus-5)
Agentically-Engineered: https://nerdz.cloud/agentic-engineering
