### PR TITLE
chore(githooks): validate AI attribution trailers on commit

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Validates AI-attribution trailers. See AGENTS.md -> Commit Messages.
+#
+# This does NOT require attribution: a hook cannot know whether an agent was
+# involved, so demanding the trailers would block hand-written work. It only
+# checks that attribution, WHEN PRESENT, is complete and well formed — the
+# realistic failure mode now that agents add these routinely.
+set -euo pipefail
+
+MSG_FILE="$1"
+URL="https://nerdz.cloud/agentic-engineering"
+
+# Drop comment lines and the scissors section git adds for verbose commits.
+BODY="$(sed -e '/^# ------------------------ >8 /,$d' -e '/^#/d' "$MSG_FILE")"
+
+has_assisted=0
+has_engineered=0
+grep -qE '^Assisted-by:'            <<<"$BODY" && has_assisted=1
+grep -qE '^Agentically-Engineered:' <<<"$BODY" && has_engineered=1
+
+# No attribution at all: nothing to validate.
+if (( has_assisted == 0 && has_engineered == 0 )); then
+  exit 0
+fi
+
+fail() {
+  echo "commit-msg: $*" >&2
+  echo >&2
+  echo "Expected both trailers, e.g.:" >&2
+  echo "  Assisted-by: Claude Code (claude-opus-5)" >&2
+  echo "  Agentically-Engineered: $URL" >&2
+  exit 1
+}
+
+(( has_assisted    == 1 )) || fail "'Agentically-Engineered:' present without 'Assisted-by:'"
+(( has_engineered  == 1 )) || fail "'Assisted-by:' present without 'Agentically-Engineered:'"
+
+grep -qE '^Assisted-by: [A-Za-z0-9][A-Za-z0-9 ._-]* \([a-z0-9][a-z0-9._-]*\)[[:space:]]*$' <<<"$BODY" \
+  || fail "'Assisted-by:' must name the tool and the model actually used, as: Tool Name (model-id)"
+
+grep -qFx "Agentically-Engineered: $URL" <<<"$BODY" \
+  || fail "'Agentically-Engineered:' must be exactly: $URL"
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,13 @@ Name the model actually used — the trailer is a record of how the commit was
 built, so a stale or guessed model id makes that record wrong. Add a human
 `Co-Authored-By:` trailer as well when someone genuinely co-authored the change.
 
+A `commit-msg` hook in [`.githooks/`](.githooks/) checks this. It does **not**
+require attribution — a hook cannot tell whether an agent was involved, so
+demanding the trailers would block hand-written work. It validates attribution
+*when present*: both trailers together, a parenthesised model id, and the exact
+URL. The hook is version-controlled and wired via `core.hooksPath`, so a fresh
+clone needs `git config core.hooksPath .githooks` once.
+
 Earlier guidance told agents to strip every trace of AI involvement. That is
 **retired** — do not remove these trailers, and do not treat naming the
 assistant as something to avoid. The point is transparency about process, not


### PR DESCRIPTION
Follow-up to #2575, which set the attribution policy but left enforcement broken.

## What was actually wrong

`core.hooksPath` pointed at a path left over from the WSL2 setup:

```
$ git config --show-origin --get core.hooksPath
file:.git/config        /home/gavin/home-ops/.git/hooks

$ ls -d "$(git config core.hooksPath)"
No such file or directory
```

No hook file existed anywhere — not at that path, not in `.git/hooks`, not in any `~/.config/git/hooks`. So nothing had been enforced for some time. The old hook that rejected "claude"/"anthropic" was inert here, and would now **contradict** house policy wherever it is still live.

Scope-checked across all repos under `G:\code`: `home-ops` is the only one setting `core.hooksPath`, and there is no global setting. So this is contained.

## What this installs

A version-controlled `commit-msg` hook at [`.githooks/commit-msg`](.githooks/commit-msg).

It deliberately **does not require attribution.** A hook cannot know whether an agent was involved, so demanding the trailers would block hand-written commits. Instead it validates attribution *when present*:

- both trailers together, never one alone
- `Assisted-by:` names a tool and a parenthesised model id
- `Agentically-Engineered:` matches the URL exactly

Half-written trailers are the realistic failure mode now that agents add these routinely, and that is precisely what this catches.

## Testing

10 cases run directly against the hook:

| Case | Expect |
|---|---|
| plain human message, no trailers | pass |
| both trailers, correct | pass |
| `Assisted-by:` alone | reject |
| `Agentically-Engineered:` alone | reject |
| wrong URL | reject |
| model id missing parens | reject |
| empty model id | reject |
| alternate model id (`claude-haiku-4-5-20251001`) | pass |
| trailers only inside comment lines | pass |
| human `Co-Authored-By:` alongside | pass |

**10 passed, 0 failed.** Also confirmed end to end that a malformed message is refused through `core.hooksPath` rather than only when invoked directly — and this PR's own commit carries valid trailers, so it passed through the hook it adds.

## Note for a fresh clone

`core.hooksPath` is local config and does not clone. A new checkout needs it once:

```bash
git config core.hooksPath .githooks
```

Documented in `AGENTS.md` alongside the policy. Vendored in-repo rather than set globally so it stays reviewable and does not silently apply to repos with different conventions.

Assisted-by: Claude Code (claude-opus-5)
Agentically-Engineered: https://nerdz.cloud/agentic-engineering
