### PR TITLE
feat(cwa): persist Calibre config dir; fix reconcile author folder

### DIFF
--- a/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
@@ -83,6 +83,14 @@ spec:
               # Let s6-overlay work under a read-only-ish, non-privileged k8s sandbox
               S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES: "1"
               S6_READ_ONLY_ROOT: "1"
+              # Calibre otherwise resolves its config dir from HOME (=/root here),
+              # which is ephemeral — so tweaks.json is lost on every restart. The
+              # tweak that matters is author_sort_copy_method=copy: without it
+              # Calibre generates author_sort as "Lastname, Firstname" for every
+              # NEW author, which is not the sort order we want. Deliberately a
+              # separate dir from the calibre-server container's config, so the
+              # two containers do not race on the same global.py.json.
+              CALIBRE_CONFIG_DIRECTORY: /config/calibre-app
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
@@ -130,13 +130,33 @@ def _match_child(parent_abs, title, want_dir=True):
     return None
 
 
+def _author_dir(genre_abs, authors):
+    """The author folder to use -- an EXISTING one always wins over a generated one.
+
+    The tree files a collaboration under its PRIMARY author, not the joined
+    string: 'Fantasy/Raymond E. Feist/Riftwar Cycle/(2) The Empire Trilogy' for
+    Feist & Wurts, with no 'Janny Wurts' folder anywhere; likewise Eddings,
+    Nagoski, Armentrout. But exactly one joined folder exists ('Caroline Peckham
+    & Susanne Valenti'), so neither form can be assumed -- generating either one
+    unconditionally mints a duplicate for the books that use the other. Probe for
+    what is really there, and fall back to the dominant convention (primary) only
+    for a book that has no folder yet.
+    """
+    full = sanitize(authors or "")
+    primary = sanitize((authors or "").split(" & ")[0])
+    for cand in (full, primary):
+        if cand and os.path.isdir(os.path.join(genre_abs, cand)):
+            return cand
+    return primary
+
+
 def rel_path(b):
     """Prefer the folder/file this book ALREADY occupies; only invent a path
     when it genuinely has none. Generating a path unconditionally is what
     scattered 16 duplicate folders -- a book whose generated name disagreed with
     its real one was silently treated as new rather than as an error."""
     genre = sanitize(b.get(GENRE_FIELD) or "")
-    author = sanitize(b.get("authors") or "")
+    author = _author_dir(os.path.join(DEST, genre), b.get("authors"))
     title = sanitize(b.get("title") or "")
     series = (b.get("series") or "").strip()
     if not (genre and author and title):


### PR DESCRIPTION
Two fixes from cleaning up author metadata ahead of the ~2,700-book Kindle import.

## calibre-web-automated — `CALIBRE_CONFIG_DIRECTORY` on the app container

Calibre resolves its config dir from `HOME`, which is `/root` in this container — **ephemeral**, so `tweaks.json` does not survive a restart.

The tweak that matters is `author_sort_copy_method=copy`. With the previous value, Calibre generates `author_sort` as `Lastname, Firstname` for **every new author**. Having just corrected 976 books, the ~871 authors arriving with the import would have reintroduced the problem wholesale.

Points at `/config/calibre-app` (Ceph RBD, already seeded and verified) rather than the `calibre-server` container's `/config/calibre-server`, so the two containers don't race on the same `global.py.json`.

## ebook-reconcile — `_author_dir()`

`rel_path()` built the tree folder from the **full** author string, but the tree files a collaboration under its **primary** author:

```
Fantasy/Raymond E. Feist/Riftwar Cycle/(2) The Empire Trilogy   <- Feist & Wurts
```

There is no `Janny Wurts` folder anywhere; likewise no `Leigh Eddings`, `Amelia Nagoski`, or `Rayvn Salvador`. So every multi-author book would have had a duplicate folder minted for it — the same orphan-folder failure that scattered 16 folders previously.

Exactly **one** joined folder does exist (`Romantasy/Caroline Peckham & Susanne Valenti`), so neither form can be assumed. `_author_dir()` probes for the folder that is really there and falls back to the primary author only for a book with no folder yet — consistent with the existing match-don't-generate rule in `rel_path`/`_match_child`.

## Verification

- `helmrelease.yaml` parses; `reconcile.py` parses
- `/config/calibre-app/tweaks.json` seeded and read back by Calibre: `author_sort_copy_method = copy`, and `author_to_author_sort('Blake Pierce')` now returns `'Blake Pierce'`
- Calibre library swept after the data fix: **0 of 996 books** with `author_sort != authors`, 0 of 186 author records with `sort != name`
- No behaviour change for single-author books (the overwhelming majority)
- `ebook-reconcile` remains **suspended** pending review — this does not run on merge

Identical to `tools/reconcile.py` in nerdz-reading (`32722da`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)