### PR TITLE
fix(ebook-reconcile): file standing author partnerships under the joined name

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
@@ -130,6 +130,20 @@ def _match_child(parent_abs, title, want_dir=True):
     return None
 
 
+def _partnership_dir_exists(name):
+    """Has this exact author pairing been given its own folder in any genre room?
+
+    Distinguishes a standing writing duo (their own series, their own folder)
+    from a one-off collaboration filed under the lead author. Rooms are the
+    top level of DEST, so this is a couple of dozen cheap isdir() checks.
+    """
+    try:
+        rooms = os.listdir(DEST)
+    except OSError:
+        return False
+    return any(os.path.isdir(os.path.join(DEST, r, name)) for r in rooms)
+
+
 def _author_dir(genre_abs, authors):
     """The author folder to use -- an EXISTING one always wins over a generated one.
 
@@ -147,6 +161,18 @@ def _author_dir(genre_abs, authors):
     for cand in (full, primary):
         if cand and os.path.isdir(os.path.join(genre_abs, cand)):
             return cand
+    # No folder yet, so the form has to be chosen. The two cases are genuinely
+    # different and the tree already encodes which is which:
+    #   incidental collaboration -- Janny Wurts co-wrote three books inside
+    #     Feist's Riftwar Cycle. Those belong under the primary author, beside
+    #     the rest of the series.
+    #   standing partnership -- Caroline Peckham & Susanne Valenti write their
+    #     series together AND publish solo. The pair is its own author identity
+    #     and has earned its own folder.
+    # If this exact pairing already holds a folder in ANY room, it is a
+    # partnership; otherwise fall back to the primary author.
+    if full and full != primary and _partnership_dir_exists(full):
+        return full
     return primary
 
 


### PR DESCRIPTION
Follow-up to #2579. That PR made `_author_dir()` prefer whichever author folder actually exists, falling back to the **primary** author otherwise. The fallback is right for an incidental collaboration but wrong for a writing partnership.

## The rule

**Primary author** when the collaboration is incidental to one author's series — Janny Wurts co-wrote three books inside Feist's Riftwar Cycle, and they belong beside the rest of that series:

```
Fantasy/Raymond E. Feist/Riftwar Cycle/(2) The Empire Trilogy
```

**Joined name** when the pair is a standing partnership with its own series — Caroline Peckham & Susanne Valenti write theirs together *and* publish solo, so the pair is its own author identity:

```
Romantasy/Caroline Peckham & Susanne Valenti/...
Romantasy/Caroline Peckham/...              <- solo work, still separate
```

`_partnership_dir_exists()` lets the tree answer which is which: if that exact pairing already holds a folder in **any** genre room, it's a partnership. An existing folder still wins outright — this only decides the form for a book that has none yet.

## Verification

7/7 against the live tree, including the cases that separate the two rules:

| Room | Authors | Result |
|---|---|---|
| Fantasy | `Raymond E. Feist & Janny Wurts` | `Raymond E. Feist` |
| Romantasy | `Caroline Peckham & Susanne Valenti` | joined (existing folder) |
| Fantasy | `Caroline Peckham & Susanne Valenti` | joined — no folder in that room, partnership recognised from Romantasy |
| Erotica | `Raymond E. Feist & Janny Wurts` | `Raymond E. Feist` |
| Fantasy | `Caroline Peckham` | `Caroline Peckham` (solo) |

Cost is a couple of dozen `isdir()` checks against the top level of DEST, and only for a multi-author book with no folder.

Identical to `tools/reconcile.py` in nerdz-reading (`8c0c97c`). `ebook-reconcile` remains **suspended** — this does not run on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)