### PR TITLE
fix(bookorbit): scan-nightly iterates all libraries — library 1 no longer exists

### DIFF
--- a/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
@@ -54,9 +54,16 @@ spec:
                 BO=http://bookorbit.entertainment.svc.cluster.local:3000
                 TOKEN=$(curl -sf -X POST "$BO/api/v1/auth/login" -H 'content-type: application/json' -d "{\"username\":\"$BOOKORBIT_ADMIN_USER\",\"password\":\"$BOOKORBIT_ADMIN_PASSWORD\"}" | sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p')
                 if [ -z "$TOKEN" ]; then echo "scan-nightly: login failed" >&2; exit 1; fi
-                CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BO/api/v1/scanner/libraries/1/scan" -H "Authorization: Bearer $TOKEN")
-                echo "scan-nightly: scan trigger returned HTTP $CODE"
-                case "$CODE" in 202) exit 0;; 409) echo "scan-nightly: scan already running - fine"; exit 0;; *) exit 1;; esac
+                LIBS=$(curl -sf "$BO/api/v1/libraries" -H "Authorization: Bearer $TOKEN" | grep -oE '"id":[0-9]+,"name"' | grep -oE '[0-9]+')
+                if [ -z "$LIBS" ]; then echo "scan-nightly: no libraries found" >&2; exit 1; fi
+                RC=0
+                for LIB in $LIBS; do
+                  CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BO/api/v1/scanner/libraries/$LIB/scan" -H "Authorization: Bearer $TOKEN")
+                  echo "scan-nightly: library $LIB scan HTTP $CODE"
+                  case "$CODE" in 202|409) ;; *) RC=1;; esac
+                  sleep 3
+                done
+                exit $RC
             env:
               TZ: ${TIMEZONE}
               BOOKORBIT_ADMIN_USER:


### PR DESCRIPTION
The Aug 18 library rebuild replaced the single library with 22 per-genre libraries (ids 2–23); the CronJob's hardcoded `libraries/1/scan` has 404'd ever since, so nothing has scanned nightly since then (surfaced by the Heir of Fire replacement never getting indexed).

Now enumerates `GET /api/v1/libraries` and scans each (parse pattern verified against the live response), tolerating 409 already-running. Brace-free per the envsubst constraint.