### PR TITLE
feat(cwa): add a read-only /import-staging mount for bulk imports

### DIFF
--- a/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
+++ b/kubernetes/apps/home/calibre-web-automated/app/helmrelease.yaml
@@ -210,6 +210,16 @@ spec:
             subPath: Library/Books/.calibre/ingest
           - path: /calibre-library
             subPath: Library/Books/.calibre/library
+          # Bulk-import staging, READ-ONLY and deliberately OUTSIDE the ingest
+          # tree. CWA's ingest watcher consumes anything under /cwa-book-ingest
+          # -- including dot-directories -- and DELETES the source after import.
+          # Staging there meant the watcher and a manual `calibredb add` both
+          # processed the same files: 50 source books produced 82 Calibre rows.
+          # A separate mount lets us add books deliberately, set #genre before
+          # anything is placed, and keep the source files intact.
+          - path: /import-staging
+            subPath: Library/Books/.import-staging
+            readOnly: true
       tmpfs:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
## Why

There is no path visible to both the NAS and the CWA container except `/cwa-book-ingest`. A bulk-import pilot staged files there under a dot-directory, assuming the ingest watcher would skip it.

**It doesn't.** The watcher consumes anything under `/cwa-book-ingest` — dot-directories included — and **deletes the source after import**. So the watcher and a deliberate `calibredb add` both processed the same files:

- 50 source books produced **82 Calibre rows**
- `.azw3` files became **separate books** rather than extra formats

## The fix

A dedicated `/import-staging` mount, **read-only**, deliberately outside the ingest tree:

```yaml
- path: /import-staging
  subPath: Library/Books/.import-staging
  readOnly: true
```

Books can then be added deliberately, `#genre` set *before* anything is placed into the genre tree, and the source files stay intact rather than being eaten mid-run. Read-only because the importer only ever reads from staging — writes belong in the Calibre library.

## Cleanup already done

The pilot's 82 rows were removed; the library is back to 996.

Worth recording: **the removal boundary was not the obvious one.** Selecting `id > 996` (the pre-pilot count) would have caught **73 of Gavin's own books** added over the preceding days, because Calibre ids are not contiguous after deletions. The safe selector was the add timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)