### PR TITLE
fix(ebook-reconcile): compare bytes when mtime differs but size matches

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
@@ -28,6 +28,7 @@ Calibre's metadata.db.
 
 Env: LIB, DEST, STATE (default /state/abs_paths.json), TAG (default →abs).
 """
+import hashlib
 import json
 import os
 import re
@@ -224,12 +225,32 @@ def _place(src, dst):
 
 def _same_content(src, dst):
     """Inode equality no longer means anything now that we copy, so compare the
-    bytes' fingerprint instead: size first (cheap), then mtime."""
+    bytes' fingerprint instead: size first (cheap), then mtime, and only if those
+    disagree, the bytes themselves.
+
+    The hash step exists because mtime is not a content signal. The nightly embed
+    CronJob rewrites every Calibre-side file; when the metadata it bakes is already
+    present the bytes come out identical but the mtime moves. Trusting mtime alone
+    re-copied 37 byte-identical files after one night, which at full library size
+    means copying the whole tree nightly and bumping every folder's mtime, which in
+    turn makes ABS re-index books that never changed."""
     try:
         a, b = os.stat(src), os.stat(dst)
     except OSError:
         return False
-    return a.st_size == b.st_size and int(a.st_mtime) == int(b.st_mtime)
+    if a.st_size != b.st_size:
+        return False
+    if int(a.st_mtime) == int(b.st_mtime):
+        return True
+    return _digest(src) == _digest(dst)
+
+
+def _digest(p, chunk=1 << 20):
+    h = hashlib.md5()
+    with open(p, 'rb') as f:
+        for blk in iter(lambda: f.read(chunk), b''):
+            h.update(blk)
+    return h.hexdigest()
 
 
 def main():


### PR DESCRIPTION
## Problem

`_same_content` treats **size + mtime** as the change signal. The nightly embed CronJob
rewrites every Calibre-side file; when the metadata it bakes is already present, the
bytes come out **identical** and only the mtime moves. reconcile reads that as
"file changed" and re-copies.

Measured after a single night: **37 byte-identical files** queued for re-copy.

```
calibre: cc0d87b166b1844d8a86b22b4356ff91  mtime=2026-08-22 03:30:02
tree:    cc0d87b166b1844d8a86b22b4356ff91  mtime=2026-08-21 10:15:47
```

At full library size that is the entire tree re-copied nightly, and every folder mtime
bumped — which makes ABS re-index books that never changed.

## Fix

Size stays the cheap first test, mtime the cheap second. Only when those disagree does
it hash the bytes.

## Verification

Unit-checked all three cases:

| case | result |
|---|---|
| identical bytes, different mtime | `True` (was `False`) |
| different bytes, same size | `False` — still detected |
| identical bytes, same mtime | `True` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)