### PR TITLE
feat(mangarr): bump to sha-bc178f9 — volume-aware filing + conflict detection

### DIFF
--- a/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/mangarr/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gavinmcfall/mangarr
-              tag: sha-79dc68b@sha256:ead7fc49064bb35b8f5b9ca4bf5413cf4847f79efad40586ac5c263a7192a5d5
+              tag: sha-bc178f9@sha256:989021ecdd4f861e09b5bb6ad43efbf734a09d780ef9fb45bc2c5d1478ea7a17
             env:
               TZ: ${TIMEZONE}
               MANGARR_DOWNLOAD_ROOTS: >-


### PR DESCRIPTION
Image bump `ghcr.io/gavinmcfall/mangarr` `sha-79dc68b` → `sha-bc178f9` (digest verified against the GHCR package API).

Brings gavinmcfall/mangarr#71:
- volume rename scheme (`{series}/{series} - Vol.{volume}.cbz` default) so retail/volume `.cbz` file as volumes, not `Ch.NNN`
- conflict detection: two sources rendering to one destination, or an existing library file that isn't a hardlink of the source, are reported (`conflict` activity + series status + `mangarr_file_conflicts_total`) instead of silently skipped/overwritten
- filer re-reads mode/schemes from settings per call

Follow-up on the cluster (no manifest change): add `/media/Downloads/manual` as a third download root via settings, move `--SORT--/Dragon Ball Z (Color Edition)` into it, verify 26 volumes land in Kavita. Expect the first tick after rollout to flag the existing Weeb Central "Dragon Ball" as `conflict` — that's the detector reporting the pre-existing corruption, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtsvoLH8UZLuH2xuoo1gkv