### PR TITLE
fix(ebook-reconcile): select on #tosync instead of a Calibre tag

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
@@ -119,7 +119,10 @@ spec:
               LIB: /media/Library/Books/.calibre/library       # staging Calibre library (CWA workbench)
               DEST: /media/Library/Books/Books                 # AudiobookShelf books root
               STATE: /state/abs_paths.json
-              TAG: "→abs"
+              # Selector for "belongs in the tree". A custom column, not a tag: `tags`
+              # is embedded into the epub's dc:subject and BookOrbit reads that as a
+              # genre, so a tag marker leaks into the UI as a browsable genre.
+              SELECT: "#tosync:true"
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
@@ -2,7 +2,7 @@
 """Reconcile curated ebooks from a Calibre library into the AudiobookShelf
 folder structure by COPYING — idempotent.
 
-For every book tagged `→abs` (the review gate), compute its ABS path
+For every book flagged `#tosync` (the review gate), compute its ABS path
 (`<Genre>/<Author>/<Series>/<NN - Title>/<Title>.epub`) and place Calibre's epub
 there.
 
@@ -26,7 +26,8 @@ Reads metadata via `calibredb` (handles locking + custom columns + format
 paths). Keeps its own state file (book id -> last dst) so it never writes to
 Calibre's metadata.db.
 
-Env: LIB, DEST, STATE (default /state/abs_paths.json), TAG (default →abs).
+Env: LIB, DEST, STATE (default /state/abs_paths.json), SELECT (default
+`#tosync:true`).
 """
 import hashlib
 import json
@@ -38,7 +39,15 @@ import subprocess
 LIB = os.environ["LIB"]
 DEST = os.environ["DEST"]
 STATE = os.environ.get("STATE", "/state/abs_paths.json")
-TAG = os.environ.get("TAG", "→abs")
+# Which books belong in the tree. This was a Calibre TAG until 2026-09-03, and
+# that was quietly harmful: `tags` is what `calibredb embed_metadata` writes into
+# the epub's <dc:subject>, and BookOrbit reads <dc:subject> as a GENRE. So the
+# marker showed up as a browsable genre on ~2,800 books, and because it was the
+# ONLY subject we embedded, the real room never reached BookOrbit at all.
+# A custom column is not written into the file, so the marker stays internal and
+# `tags` is freed to carry the room and the discovery vocabulary.
+# Roll back with SELECT='tag:"→abs"'.
+SELECT = os.environ.get("SELECT", "#tosync:true")
 GENRE_FIELD = os.environ.get("GENRE_FIELD", "*genre")
 # In the CWA image `/usr/bin/calibredb` is a symlink created by s6 at runtime; a
 # command-override container (no s6 init) won't have it, so point at the real binary.
@@ -255,7 +264,7 @@ def _digest(p, chunk=1 << 20):
 
 def main():
     books = json.loads(calibredb(
-        "list", "--search", f'tag:"{TAG}"', "--fields", FIELDS, "--for-machine") or "[]")
+        "list", "--search", SELECT, "--fields", FIELDS, "--for-machine") or "[]")
     state = load_state()
     linked = relinked = moved = skipped = ok = conflicts = 0
 
@@ -316,7 +325,7 @@ def main():
 
     if not DRY:
         save_state(state)
-    print(f"\ndone{' (DRY RUN — nothing written)' if DRY else ''}: {len(books)} {TAG} book(s) | "
+    print(f"\ndone{' (DRY RUN — nothing written)' if DRY else ''}: {len(books)} selected book(s) | "
           f"linked={linked} relinked={relinked} moved={moved} ok={ok} "
           f"skipped={skipped} conflicts={conflicts}")
 


### PR DESCRIPTION
## What

`reconcile.py` selected books with `--search 'tag:"→abs"'`, so the marker had to live in Calibre's **`tags`** column. This swaps it to a custom column, `#tosync`.

## Why it matters more than it looks

`tags` is exactly what `calibredb embed_metadata` writes into the epub's `<dc:subject>` — and BookOrbit reads `<dc:subject>` as a **genre** (`server/src/modules/metadata/lib/pdf-xmp-reader.ts`: `genres: getList(merged['dc:subject'])`).

Two consequences, both measured on 2026-09-03:

1. `→abs` appears as a **browsable genre on ~2,800 books** in BookOrbit.
2. It is the **only** `dc:subject` we embed, so the real room never reaches BookOrbit at all. Books like *Released* have `→abs` as their sole genre.

BookOrbit can't fix this from its side: the genre blocklist is documented as provider-only ("stripped from provider results before metadata is written") and the scanner has no exclusion hook.

A custom column isn't written into the file, so the marker stays internal — and `tags` is freed to carry the room and, later, discovery tags.

## Verification

Both selectors return **exactly 2836** books through the `calibredb` CLI (the parser reconcile actually uses, which parses differently from the Python API):

```
CLI  #tosync:true -> 2836 books
CLI  tag:"→abs"   -> 2836 books
```

`SELECT` is overridable, so `SELECT='tag:"→abs"'` rolls this back with no image change.

## Sequencing

- ✅ Calibre migration applied — `#tosync` column created, set on all 2836 tagged books
- ⬜ **this PR** — deploy, then dry-run reconcile and confirm it still reports 2836
- ⬜ then strip the now-redundant `→abs` tag (preserving the other tags 12 of these books carry) and re-embed
- ⬜ then delete the `→abs` genre in BookOrbit

The genre deletion is deliberately **last**. Removing it before the cause is fixed just lets the next scan refill it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcNWZGZcqxoUMcW1P8qaP6