### PR TITLE
fix(ebook-reconcile): select #tosync with :yes, not :true

### DIFF
--- a/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ebook-reconcile/app/helmrelease.yaml
@@ -122,7 +122,9 @@ spec:
               # Selector for "belongs in the tree". A custom column, not a tag: `tags`
               # is embedded into the epub's dc:subject and BookOrbit reads that as a
               # genre, so a tag marker leaks into the UI as a browsable genre.
-              SELECT: "#tosync:true"
+              # `:yes` not `:true` -- for a bool custom column Calibre reads
+              # `:true` as "has any value", so it also selects books set to False.
+              SELECT: "#tosync:yes"
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
+++ b/kubernetes/apps/home/ebook-reconcile/app/resources/reconcile.py
@@ -27,7 +27,7 @@ paths). Keeps its own state file (book id -> last dst) so it never writes to
 Calibre's metadata.db.
 
 Env: LIB, DEST, STATE (default /state/abs_paths.json), SELECT (default
-`#tosync:true`).
+`#tosync:yes`).
 """
 import hashlib
 import json
@@ -47,7 +47,12 @@ STATE = os.environ.get("STATE", "/state/abs_paths.json")
 # A custom column is not written into the file, so the marker stays internal and
 # `tags` is freed to carry the room and the discovery vocabulary.
 # Roll back with SELECT='tag:"→abs"'.
-SELECT = os.environ.get("SELECT", "#tosync:true")
+# `:yes`, NOT `:true`. For a Calibre BOOL custom column, `#tosync:true` matches
+# "has any value" -- it selects books explicitly set to False as well as True.
+# Measured 2026-09-04: with 97 books set False, `#tosync:true` returned 3608 and
+# `#tosync:yes` returned 3511, the difference being exactly those 97. Selecting
+# them would have created 97 duplicate folders for books already on the shelf.
+SELECT = os.environ.get("SELECT", "#tosync:yes")
 GENRE_FIELD = os.environ.get("GENRE_FIELD", "*genre")
 # In the CWA image `/usr/bin/calibredb` is a symlink created by s6 at runtime; a
 # command-override container (no s6 init) won't have it, so point at the real binary.


### PR DESCRIPTION
## The bug

`reconcile.py` selects books with the Calibre search `#tosync:true`. For a **bool** custom column, Calibre reads `:true` as *"has any value"* — it matches books explicitly set to **False** as well as True. The term that means True is `:yes`.

## How it surfaced

While bringing ~830 previously-unmanaged shelf books into the pipeline, a dry run showed 97 of them would get **new folders created for books already on the shelf** — duplicates. I excluded them by setting `#tosync = False`, and the count didn't move:

```
#tosync:true -> 3608 books   (still included all 97 set to False)
#tosync:yes  -> 3511 books   (correct)
```

So "explicitly excluded" was silently ignored, and the real run would have created the 97 duplicate folders anyway.

## Current state

Those 97 were cleared to **empty** instead, which the old selector *does* exclude — so nothing is broken right now, and both selectors currently return the same 3511. The bug is latent: the next book set to `False` walks into it.

## The change

One term in two places (the script default and the helmrelease env), plus a comment recording the measurement so nobody re-derives it. `SELECT` remains overridable, so the old behaviour is one env var away if this is ever wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcNWZGZcqxoUMcW1P8qaP6