### PR TITLE
feat(jelu): interim physical-book catalog

### DIFF
--- a/kubernetes/apps/entertainment/jelu/app/externalsecret.yaml
+++ b/kubernetes/apps/entertainment/jelu/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: jelu
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: jelu-secret
+    template:
+      engineVersion: v2
+      data:
+        # 1Password item "jelu" must hold these fields (from the pocket-id OAuth client):
+        #   JELU_OIDC_CLIENT_ID
+        #   JELU_OIDC_CLIENT_SECRET
+        # Jelu is Spring Boot; these are Spring Security's standard OAuth2 client
+        # registration keys in env-var form (registration id "pocketid"). The
+        # non-secret half of the registration lives in the HelmRelease env.
+        SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_CLIENT_ID: "{{ .JELU_OIDC_CLIENT_ID }}"
+        SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_CLIENT_SECRET: "{{ .JELU_OIDC_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: jelu

--- a/kubernetes/apps/entertainment/jelu/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/jelu/app/helmrelease.yaml
@@ -1,0 +1,145 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.4.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app jelu
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: storage
+  values:
+    controllers:
+      jelu:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            # INTERIM physical-book catalog (ISBN camera/USB scanning, Libib
+            # import, collector notes) until BookOrbit's physical-books slices
+            # land upstream. Design + the tag/note convention that is the
+            # migration contract: nerdz-reading
+            # docs/odad-physical-books/design/interim-jelu.md
+            image:
+              repository: docker.io/wabayang/jelu
+              tag: 0.84.6@sha256:6a119f79e7df33567b8a73f73a88d5ac41ad792b76591475c7566f9ed4202216
+            env:
+              TZ: ${TIMEZONE}
+              # All state under one backed-up volume (the image defaults are
+              # three separate paths: /database, /files/images, /files/imports).
+              JELU_DATABASE_PATH: /data/database/
+              JELU_FILES_IMAGES: /data/files/images/
+              JELU_FILES_IMPORTS: /data/files/imports/
+              # Metadata: the embedded Calibre fetcher (keyless Google Books /
+              # OpenLibrary / Amazon) plus inventaire.io. Calibre wants a
+              # writable config dir; upstream runs as root (Dockerfile has no
+              # USER) but we run 568 with a read-only root, so point it at /tmp.
+              JELU_METADATA_CALIBRE_PATH: /usr/bin/fetch-ebook-metadata
+              CALIBRE_CONFIG_DIRECTORY: /tmp/calibre-config
+              CALIBRE_TEMP_DIR: /tmp
+              HOME: /tmp
+              JELU_METADATAPROVIDERS_0_NAME: inventaireio
+              JELU_METADATAPROVIDERS_0_ISENABLED: "true"
+              JELU_METADATAPROVIDERS_0_ORDER: "-10"
+              JELU_METADATAPROVIDERS_0_CONFIG: en
+              # --- SSO via pocket-id (OIDC) ---
+              # Callback to register in pocket-id:
+              #   https://jelu.${SECRET_DOMAIN}/login/oauth2/code/pocketid
+              # Jelu matches OIDC logins to existing users BY EMAIL, so the
+              # admin is created once via the first-run wizard (with the
+              # pocket-id email), then signs in with pocket-id. Account
+              # auto-creation stays off: single-user tool.
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_PROVIDER: pocketid
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_CLIENT_NAME: pocket-id
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_SCOPE: openid,profile,email
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_AUTHORIZATION_GRANT_TYPE: authorization_code
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_REDIRECT_URI: "{baseUrl}/login/oauth2/code/{registrationId}"
+              SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_POCKETID_ISSUER_URI: https://id.${SECRET_DOMAIN}
+              SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_POCKETID_USER_NAME_ATTRIBUTE: preferred_username
+              JELU_AUTH_OAUTH2_ACCOUNT_CREATION: "false"
+            envFrom:
+              - secretRef:
+                  name: jelu-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    # The one unauthenticated JSON endpoint (permitAll in
+                    # SecurityConfig.kt); Jelu ships no actuator.
+                    path: /api/v1/setup/status
+                    port: &port 11111
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 1.5Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Entertainment
+          gethomepage.dev/name: Jelu
+          gethomepage.dev/app: *app
+          gethomepage.dev/icon: mdi-barcode-scan
+          gethomepage.dev/description: Physical book catalog
+          internal-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/entertainment/jelu/app/kustomization.yaml
+++ b/kubernetes/apps/entertainment/jelu/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/volsync-standard
+  - ../../../../components/priority/priority-06

--- a/kubernetes/apps/entertainment/jelu/ks.yaml
+++ b/kubernetes/apps/entertainment/jelu/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app jelu
+  namespace: &namespace entertainment
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: volsync
+      namespace: storage
+  path: ./kubernetes/apps/entertainment/jelu/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_MINUTE: "25"
+      VOLSYNC_B2_MINUTE: "55"
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-block
+      VOLSYNC_ACCESSMODES: ReadWriteOnce

--- a/kubernetes/apps/entertainment/kustomization.yaml
+++ b/kubernetes/apps/entertainment/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./audiobookshelf/ks.yaml
   - ./bookorbit/ks.yaml
   - ./immich/ks.yaml
+  - ./jelu/ks.yaml
   - ./kavita/ks.yaml
   - ./komf/ks.yaml
   - ./maloja/ks.yaml


### PR DESCRIPTION
## What

Adds **Jelu 0.84.6** (`kubernetes/apps/entertainment/jelu/`) as the interim self-hosted catalog for the physical bookshelf: phone-camera and USB ISBN scanning with metadata lookup, Goodreads-CSV import/export, pocket-id OIDC.

- Internal gateway only (`jelu.<domain>`); `GET /api/v1/books/**` is unauthenticated upstream, so this must never go external.
- One 2Gi ceph-block PVC under `/data` via `volsync-standard` (SQLite + covers + imports).
- UID 568, read-only root, drop ALL. The image has no `USER` (root upstream); Calibre's fetcher gets `CALIBRE_CONFIG_DIRECTORY=/tmp/...`.
- OIDC via Spring's standard registration env vars; `JELU_AUTH_OAUTH2_ACCOUNT_CREATION=false` (single-user). Jelu matches OIDC logins to the local user **by email**.
- Probe: `/api/v1/setup/status` (the one permitAll JSON endpoint; no actuator).

## Why interim

The BookOrbit physical-books arc (PR bookorbit#1034 awaiting the maintainer) is the destination; copies and collector fields are slices 3–4. Until then, binding / signed / "427 of 450" live in Jelu as tags + a `key: value` note grammar that maps 1:1 onto the future copy row. Spec: nerdz-reading `docs/odad-physical-books/design/interim-jelu.md`.

## Before merge (Gavin)

1. pocket-id → new OIDC client **Jelu**, callback `https://jelu.<domain>/login/oauth2/code/pocketid`.
2. 1Password vault Kubernetes → item `jelu` with `JELU_OIDC_CLIENT_ID`, `JELU_OIDC_CLIENT_SECRET`.

## Verification

- `task kubernetes:kubeconform`: `Kustomization jelu is valid`; the only failure is the pre-existing `${ENVOY_EXTERNAL_LBIP}` placeholder in envoy-gateway (unchanged by this PR).
- `kustomize build --load-restrictor LoadRestrictionsNone` renders HR + ExternalSecret + PVC + VolSync objects; HR/ES/PVC validate with kubeconform (VolSync objects carry unsubstituted `${...}` until Flux post-build, as in every other app).
- Post-merge: pod 1/1 as 568, `/data/database/jelu.db` created, first-run wizard, pocket-id login, import of 335 ISBN rows from the Libib export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H9ecUkr6n2nqrd7bq7sX3
