### PR TITLE
fix(jelu): Lucene index on the data volume (read-only root)

### DIFF
--- a/kubernetes/apps/entertainment/jelu/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/jelu/app/helmrelease.yaml
@@ -61,6 +61,14 @@ spec:
               JELU_METADATAPROVIDERS_0_ISENABLED: "true"
               JELU_METADATAPROVIDERS_0_ORDER: "-10"
               JELU_METADATAPROVIDERS_0_CONFIG: en
+              # Lucene search index. Upstream default is "" = the working dir
+              # /app, which is the read-only root here (first boot died on
+              # /app/write.lock). Keep it on the data volume. The min-gram
+              # line restates the default on purpose: jelu.lucene's
+              # indexAnalyzer has no constructor default, so binding
+              # data-directory alone would null it (same trap as jelu.auth).
+              JELU_LUCENE_DATA_DIRECTORY: /data/lucene
+              JELU_LUCENE_INDEX_ANALYZER_MIN_GRAM: "3"
               # --- SSO via pocket-id (OIDC) ---
               # Callback to register in pocket-id:
               #   https://jelu.${SECRET_DOMAIN}/login/oauth2/code/pocketid


### PR DESCRIPTION
Second first-boot failure (after #2627 fixed the auth binding):

```
Caused by: java.nio.file.NoSuchFileException: /app/write.lock
  Suppressed: java.nio.file.FileSystemException: /app/write.lock: Read-only file system
```

`jelu.lucene.dataDirectory` defaults to `""`, i.e. the working directory `/app`, which is the read-only root filesystem in this deployment (`LuceneConfiguration.diskDirectory` → `FSDirectory.open(Paths.get(dataDirectory))`). Now `/data/lucene` on the backed-up volume.

`JELU_LUCENE_INDEX_ANALYZER_MIN_GRAM=3` restates the upstream default deliberately: `Lucene(dataDirectory, indexAnalyzer)` has no default for `indexAnalyzer`, so binding `data-directory` alone would leave it null (the same constructor trap as `jelu.auth`).

Verified: `task kubernetes:kubeconform` → `Kustomization jelu is valid`. The auth fix is confirmed working in the same boot log (Tomcat started, no bind error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H9ecUkr6n2nqrd7bq7sX3
