### PR TITLE
feat(jelu): Google Books provider with API key (429 on keyless lookups)

### DIFF
--- a/kubernetes/apps/entertainment/jelu/app/externalsecret.yaml
+++ b/kubernetes/apps/entertainment/jelu/app/externalsecret.yaml
@@ -13,14 +13,16 @@ spec:
     template:
       engineVersion: v2
       data:
-        # 1Password item "jelu" must hold these fields (from the pocket-id OAuth client):
-        #   JELU_OIDC_CLIENT_ID
-        #   JELU_OIDC_CLIENT_SECRET
+        # 1Password item "jelu" must hold these fields:
+        #   JELU_OIDC_CLIENT_ID / JELU_OIDC_CLIENT_SECRET  (pocket-id OAuth client)
+        #   JELU_GOOGLE_BOOKS_API_KEY                      (Google Cloud, Books API)
         # Jelu is Spring Boot; these are Spring Security's standard OAuth2 client
         # registration keys in env-var form (registration id "pocketid"). The
         # non-secret half of the registration lives in the HelmRelease env.
         SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_CLIENT_ID: "{{ .JELU_OIDC_CLIENT_ID }}"
         SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_CLIENT_SECRET: "{{ .JELU_OIDC_CLIENT_SECRET }}"
+        # Key for the "google" metadata provider (index 1 in the HelmRelease env).
+        JELU_METADATAPROVIDERS_1_APIKEY: "{{ .JELU_GOOGLE_BOOKS_API_KEY }}"
   dataFrom:
     - extract:
         key: jelu

--- a/kubernetes/apps/entertainment/jelu/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/jelu/app/helmrelease.yaml
@@ -61,6 +61,15 @@ spec:
               JELU_METADATAPROVIDERS_0_ISENABLED: "true"
               JELU_METADATAPROVIDERS_0_ORDER: "-10"
               JELU_METADATAPROVIDERS_0_CONFIG: en
+              # Google Books via Jelu's own plugin with an API key. Providers run
+              # highest order first, so this beats Calibre (order 1000). Added
+              # after the first import: Calibre's keyless Google lookups got
+              # HTTP 429 for the whole house IP ~150 books in, and every later
+              # book burned ~2 min failing. The key itself is
+              # JELU_METADATAPROVIDERS_1_APIKEY in jelu-secret.
+              JELU_METADATAPROVIDERS_1_NAME: google
+              JELU_METADATAPROVIDERS_1_ISENABLED: "true"
+              JELU_METADATAPROVIDERS_1_ORDER: "5000"
               # Lucene search index. Upstream default is "" = the working dir
               # /app, which is the read-only root here (first boot died on
               # /app/write.lock). Keep it on the data volume. The min-gram


### PR DESCRIPTION
## Why

The first Libib import stalled ~150 books in: Calibre's keyless Google Books lookups started returning **HTTP 429** for the house IP (confirmed from the pod and from a desktop), so every remaining row burned ~2 minutes failing through the plugins and landed without metadata or a cover. Import paused (pod recycled; 178 rows remain queued in `import_entity`, which Jelu resumes on the next upload).

## What

- `JELU_METADATAPROVIDERS_1_{NAME,ISENABLED,ORDER}` = `google` / `true` / `5000` in the HelmRelease. Jelu runs providers highest-order first, so the keyed Google plugin answers before Calibre (1000) and inventaire (-10).
- `JELU_METADATAPROVIDERS_1_APIKEY` templated from the 1Password `jelu` item field **`JELU_GOOGLE_BOOKS_API_KEY`** in the ExternalSecret.
- (The commit message mentions folding in a `.repoql` concept; `.repoql/` is gitignored here, so nothing of the sort is in the diff.)

## Before merge (Gavin)

Google Cloud console → enable **Books API** → Credentials → API key → add to 1Password `jelu` as `JELU_GOOGLE_BOOKS_API_KEY`.

## After merge

Pod restarts with the key; I re-trigger the queued import with a header-only CSV upload and reset the one `ERROR` row.

Verified: `task kubernetes:kubeconform` → `Kustomization jelu is valid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H9ecUkr6n2nqrd7bq7sX3