### PR TITLE
feat(container): update image ghcr.io/bookorbit/bookorbit ( 2.8.1 ➔ 2.9.0 )

### DIFF
--- a/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
+++ b/kubernetes/apps/entertainment/bookorbit/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
             # scanner works, but nothing can bake metadata into the files yet.
             image:
               repository: ghcr.io/bookorbit/bookorbit
-              tag: 2.8.1@sha256:cc1ecc94135464888313e599467f5f3834325edfaf47c5cf2f96d5c7c92ceca8
+              tag: 2.9.0@sha256:3bf8d823d2c2179e519a96e08b928506c2a459e7854ab42ea584cdc78b50e6f4
             env:
               TZ: ${TIMEZONE}
               NODE_ENV: production


### PR DESCRIPTION
Bumps BookOrbit to **v2.9.0**, the first release containing the fixes for two bugs we have been carrying local workarounds for since 2026-08-31.

### Why this release specifically

Verified by commit containment, not by reading the release notes:

```bash
gh api repos/bookorbit/bookorbit/compare/f555f080...v2.9.0 --jq .behind_by  # 0
gh api repos/bookorbit/bookorbit/compare/2498e09...v2.9.0  --jq .behind_by  # 0
```

| Issue | What it was | Local workaround it retires |
|---|---|---|
| [bookorbit#1104](https://github.com/bookorbit/bookorbit/issues/1104) | ABS migration live run **deleted** the target user's pre-existing read statuses instead of merging. Cost us 30 statuses on a run that reported "completed, no errors". | mandatory `pg_dump` of `user_book_status` / `reading_progress` / `reading_attempts` before any live migration |
| [bookorbit#1099](https://github.com/bookorbit/bookorbit/issues/1099) | Deleting a book row left `library_dir_scan_state` stale, so the book was never re-created on scan. | clear the book's `library_dir_scan_state` rows (or bump folder mtime) after any delete, before rescanning |

### Digest

Fetched from ghcr rather than assumed. As a check on the method, the same lookup for `2.8.1` returns `cc1ecc94…`, which matches both the pin being replaced and the digest the running pod reports.

### ⚠ Do not unwind the workarounds on merge

A fix being released and a fix being true of this cluster are different facts — that distinction is exactly what these two rows exist to protect. Order is **deploy → probe → comment on the issues → then unwind**. Both probes are written up in `nerdz-reading/docs/upstream-tracker.md`; they deliberately isolate a single user and a single book rather than trusting a summary count.

This is a minor version bump, so check for schema migrations on rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcNWZGZcqxoUMcW1P8qaP6