### PR TITLE
fix(thelounge): mount a writable /tmp so sqlite migrations can run; grow PVC to 5Gi

### DIFF
--- a/kubernetes/apps/home/thelounge/app/helmrelease.yaml
+++ b/kubernetes/apps/home/thelounge/app/helmrelease.yaml
@@ -85,3 +85,11 @@ spec:
     persistence:
       config:
         existingClaim: *app
+      # node:sqlite needs a writable temp dir to build indexes and VACUUM.
+      # With readOnlyRootFilesystem and no /tmp, the 4.5.2 schema migration
+      # failed with SQLITE_IOERR_GETTEMPPATH and message storage silently
+      # switched itself off.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/home/thelounge/ks.yaml
+++ b/kubernetes/apps/home/thelounge/ks.yaml
@@ -26,6 +26,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_MINUTE: "44"
       VOLSYNC_B2_MINUTE: "21"


### PR DESCRIPTION
## Why

`KubePersistentVolumeFillingUp` fired for `home/thelounge` (1Gi PVC at 97%). Triage found a second, older fault: since the 4.5.2 upgrade on 2026-07-24 the sqlite message store has been **disabled** because its schema migration fails on every start.

## Root cause

The container runs with `readOnlyRootFilesystem: true` and had no `/tmp` mount. `node:sqlite` needs a temp directory to build the `network_channel_time` index over 1.8M rows (and to `VACUUM`). SQLite fails with `SQLITE_IOERR_GETTEMPPATH` (errcode 6410), auto-rolls back, and thelounge's explicit `ROLLBACK` then throws the misleading "cannot rollback - no transaction is active".

Proven by replaying the migration on a copy of the DB inside the pod: fails in 94ms by default, succeeds with a writable temp dir (18s migration + 38s VACUUM).

## Changes

- `helmrelease.yaml`: `emptyDir` mounted at `/tmp`.
- `ks.yaml`: `VOLSYNC_CAPACITY` 1Gi → 5Gi (live PVC already patched to 5Gi; this keeps restores consistent).

Done live on the volume, not in git: `messageStorage` set to `["sqlite"]` in `config.js` (backup kept) and the 371MB of duplicate text logs deleted, per Gavin.

## Verification

`kubeconform`: 2 resources valid. Post-merge: watch the pod log for the migration completing without "Migration failed", and `df /config` on the new pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQTE9VBWb1aUUmc8Y2kjHX
